### PR TITLE
Migração do módulo de Cargos para Blazor Híbrido .NET 9 com arquitetura de serviços reutilizáveis

### DIFF
--- a/Components/Cargos/Cargos.razor
+++ b/Components/Cargos/Cargos.razor
@@ -1,0 +1,220 @@
+@page "/cargos"
+@rendermode InteractiveAuto
+@using Peers.Moderno.Models
+@using Peers.Moderno.Services.Cargos
+@using Peers.Moderno.Services.Cargos.Common
+@using Peers.Moderno.Services.Common
+@inject ICargosService CargosService
+@inject IDropdownService DropdownService
+@inject IExportService ExportService
+@inject IMessageBoxService MessageBoxService
+@inject IJSRuntime JSRuntime
+
+<PageTitle>Cargos</PageTitle>
+
+<!-- Breadcrumb -->
+<div class="page-breadcrumb border-bottom">
+    <div class="row">
+        <div class="col-lg-3 col-md-4 col-xs-12 align-self-center">
+            <h5 class="font-medium text-uppercase mb-0">Cargos</h5>
+        </div>
+        <div class="col-lg-9 col-md-8 col-xs-12 align-self-center">
+            <nav aria-label="breadcrumb" class="mt-2 float-md-right float-left">
+                <ol class="breadcrumb mb-0 justify-content-end p-0">
+                    <li class="breadcrumb-item"><a href="/">Peers / Cadastro Básico de Usuários</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">Cargos</li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+</div>
+
+<div class="page-content container-fluid">
+    <!-- Formulário de Cargo -->
+    <div class="card">
+        <div class="card-body">
+            <h4 class="card-title">Dados do Cargo</h4>
+            <EditForm Model="@cargoModel" OnValidSubmit="@SalvarCargo">
+                <DataAnnotationsValidator />
+                <ValidationSummary />
+                
+                <div class="form-body">
+                    <div class="row">
+                        <div class="col-sm">
+                            <div class="form-group">
+                                <label>Cargo</label>
+                                <InputText @bind-Value="cargoModel.Nome" class="form-control" />
+                                <ValidationMessage For="@(() => cargoModel.Nome)" />
+                            </div>
+                        </div>
+                        <div class="col-sm">
+                            <div class="form-group">
+                                <label>Próximo Cargo</label>
+                                <InputSelect @bind-Value="cargoModel.IdProximoCargo" class="form-control">
+                                    <option value="">Selecionar</option>
+                                    @foreach (var cargo in proximosCargos)
+                                    {
+                                        <option value="@cargo.Id">@cargo.Nome</option>
+                                    }
+                                </InputSelect>
+                            </div>
+                        </div>
+                        <div class="col-sm">
+                            <div class="form-group">
+                                <label>Tempo mínimo para promoção (em meses)</label>
+                                <InputNumber @bind-Value="cargoModel.TempoMinimoPromocao" class="form-control" />
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm">
+                            <div class="form-group">
+                                <label>Função</label>
+                                <InputTextArea @bind-Value="cargoModel.Funcao" class="form-control" rows="3" />
+                            </div>
+                        </div>
+                        <div class="col-sm">
+                            <div class="form-group">
+                                <label>Autonomia</label>
+                                <InputTextArea @bind-Value="cargoModel.Autonomia" class="form-control" rows="3" />
+                            </div>
+                        </div>
+                        <div class="col-sm">
+                            <div class="form-group">
+                                <label>Escopo de Atuação</label>
+                                <InputTextArea @bind-Value="cargoModel.EscopoDeAtuacao" class="form-control" rows="3" />
+                            </div>
+                        </div>
+                        <div class="col-sm">
+                            <div class="form-group">
+                                <label>Nível de interlocução principal no cliente</label>
+                                <InputTextArea @bind-Value="cargoModel.NivelInterlocucao" class="form-control" rows="3" />
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-2">
+                            <div class="form-group">
+                                <label>Status</label>
+                                <InputSelect @bind-Value="cargoModel.ATV" class="form-control">
+                                    <option value="1">Ativo</option>
+                                    <option value="0">Inativo</option>
+                                </InputSelect>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-actions">
+                    <div class="text-right">
+                        <button type="submit" class="btn btn-info" disabled="@isLoading">
+                            @if (isLoading)
+                            {
+                                <span class="spinner-border spinner-border-sm" role="status"></span>
+                                <span>Salvando...</span>
+                            }
+                            else
+                            {
+                                <span>@(cargoModel.IdCargo > 0 ? "Alterar" : "Cadastrar")</span>
+                            }
+                        </button>
+                        @if (cargoModel.IdCargo > 0)
+                        {
+                            <button type="button" class="btn btn-secondary ml-2" @onclick="LimparFormulario">
+                                Novo Cargo
+                            </button>
+                        }
+                    </div>
+                </div>
+            </EditForm>
+        </div>
+    </div>
+
+    <!-- Exportar -->
+    <div class="card">
+        <div class="card-body">
+            <h4 class="card-title">Exportar Cargos</h4>
+            <button type="button" class="btn btn-info" @onclick="ExportarCargos" disabled="@isExporting">
+                @if (isExporting)
+                {
+                    <span class="spinner-border spinner-border-sm" role="status"></span>
+                    <span>Exportando...</span>
+                }
+                else
+                {
+                    <span>Exportar</span>
+                }
+            </button>
+        </div>
+    </div>
+
+    <!-- Lista de Cargos -->
+    <div class="card">
+        <div class="card-body">
+            <h4 class="card-title">Lista de cargos</h4>
+            <h6 class="card-subtitle">Filtre as informações separadas por espaço para busca em qualquer coluna em qualquer ordem, completo ou parcial: <code>cargo código</code>.</h6>
+            
+            @if (cargos == null)
+            {
+                <div class="text-center">
+                    <div class="spinner-border" role="status">
+                        <span class="sr-only">Carregando...</span>
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="table-responsive">
+                    <table class="table table-striped border">
+                        <thead>
+                            <tr>
+                                <th>Código</th>
+                                <th>Cargo</th>
+                                <th>Próximo Cargo</th>
+                                <th>Status</th>
+                                <th>Ação</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var cargo in cargos)
+                            {
+                                <tr>
+                                    <td>@cargo.IdCargo</td>
+                                    <td>@cargo.Nome</td>
+                                    <td>@(cargo.ProximoCargo?.Nome ?? "")</td>
+                                    <td>@(cargo.ATV == 1 ? "Ativo" : "Inativo")</td>
+                                    <td>
+                                        <button class="btn btn-info btn-sm" @onclick="() => EditarCargo(cargo)">
+                                            Alterar
+                                        </button>
+                                        @if (cargo.ATV == 1)
+                                        {
+                                            <button class="btn btn-dark btn-sm ml-1" @onclick="() => InativarCargo(cargo.IdCargo)">
+                                                Inativar
+                                            </button>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+<!-- Toast Container -->
+<div class="toast-container position-fixed top-0 end-0 p-3">
+    @if (showToast)
+    {
+        <div class="toast show" role="alert">
+            <div class="toast-header">
+                <strong class="me-auto">@toastTitle</strong>
+                <button type="button" class="btn-close" @onclick="() => showToast = false"></button>
+            </div>
+            <div class="toast-body">
+                @toastMessage
+            </div>
+        </div>
+    }
+</div>

--- a/Components/Cargos/Cargos.razor.cs
+++ b/Components/Cargos/Cargos.razor.cs
@@ -1,0 +1,208 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Cargos;
+using Peers.Moderno.Services.Cargos.Common;
+using Peers.Moderno.Services.Common;
+using System.ComponentModel.DataAnnotations;
+
+namespace Peers.Moderno.Components.Cargos;
+
+public partial class Cargos : ComponentBase, IDisposable
+{
+    private List<Cargo>? cargos;
+    private List<DropdownItem> proximosCargos = new();
+    private CargoFormModel cargoModel = new();
+    private bool isLoading = false;
+    private bool isExporting = false;
+    private bool showToast = false;
+    private string toastMessage = string.Empty;
+    private string toastTitle = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        MessageBoxService.OnMessageReceived += HandleMessage;
+        await CarregarDados();
+    }
+
+    private async Task CarregarDados()
+    {
+        cargos = await CargosService.ObterListaCargosAsync();
+        proximosCargos = await DropdownService.ObterCargosAtivosAsync();
+        StateHasChanged();
+    }
+
+    private async Task SalvarCargo()
+    {
+        isLoading = true;
+        StateHasChanged();
+
+        try
+        {
+            var cargo = new Cargo
+            {
+                IdCargo = cargoModel.IdCargo,
+                Nome = cargoModel.Nome,
+                IdProximoCargo = cargoModel.IdProximoCargo > 0 ? cargoModel.IdProximoCargo : null,
+                TempoMinimoPromocao = cargoModel.TempoMinimoPromocao,
+                Funcao = cargoModel.Funcao,
+                Autonomia = cargoModel.Autonomia,
+                EscopoDeAtuacao = cargoModel.EscopoDeAtuacao,
+                NivelInterlocucao = cargoModel.NivelInterlocucao,
+                ATV = cargoModel.ATV
+            };
+
+            bool sucesso;
+            if (cargoModel.IdCargo == 0)
+            {
+                sucesso = await CargosService.InserirCargoAsync(cargo);
+                if (sucesso)
+                {
+                    MessageBoxService.ShowSuccess("Cargo inserido com sucesso!");
+                    LimparFormulario();
+                }
+                else
+                {
+                    MessageBoxService.ShowError("Erro ao inserir cargo. Verifique se já existe um cargo com este nome.");
+                }
+            }
+            else
+            {
+                sucesso = await CargosService.AlterarCargoAsync(cargo);
+                if (sucesso)
+                {
+                    MessageBoxService.ShowSuccess("Cargo alterado com sucesso!");
+                    LimparFormulario();
+                }
+                else
+                {
+                    MessageBoxService.ShowError("Erro ao alterar cargo. Verifique se já existe um cargo com este nome.");
+                }
+            }
+
+            if (sucesso)
+            {
+                await CarregarDados();
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro inesperado: {ex.Message}");
+        }
+        finally
+        {
+            isLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void EditarCargo(Cargo cargo)
+    {
+        cargoModel = new CargoFormModel
+        {
+            IdCargo = cargo.IdCargo,
+            Nome = cargo.Nome,
+            IdProximoCargo = cargo.IdProximoCargo ?? 0,
+            TempoMinimoPromocao = cargo.TempoMinimoPromocao,
+            Funcao = cargo.Funcao,
+            Autonomia = cargo.Autonomia,
+            EscopoDeAtuacao = cargo.EscopoDeAtuacao,
+            NivelInterlocucao = cargo.NivelInterlocucao,
+            ATV = cargo.ATV
+        };
+        StateHasChanged();
+    }
+
+    private async Task InativarCargo(int id)
+    {
+        if (await JSRuntime.InvokeAsync<bool>("confirm", "Tem certeza que deseja inativar este cargo?"))
+        {
+            var sucesso = await CargosService.InativarCargoAsync(id);
+            if (sucesso)
+            {
+                MessageBoxService.ShowSuccess("Cargo inativado com sucesso!");
+                await CarregarDados();
+            }
+            else
+            {
+                MessageBoxService.ShowError("Erro ao inativar cargo!");
+            }
+        }
+    }
+
+    private void LimparFormulario()
+    {
+        cargoModel = new CargoFormModel();
+        StateHasChanged();
+    }
+
+    private async Task ExportarCargos()
+    {
+        isExporting = true;
+        StateHasChanged();
+
+        try
+        {
+            var (bytes, fileName) = await ExportService.ExportarCargosAsync();
+            await JSRuntime.InvokeVoidAsync("downloadFile", fileName, Convert.ToBase64String(bytes));
+            MessageBoxService.ShowSuccess("Arquivo exportado com sucesso!");
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao exportar: {ex.Message}");
+        }
+        finally
+        {
+            isExporting = false;
+            StateHasChanged();
+        }
+    }
+
+    private void HandleMessage(MessageBoxEventArgs args)
+    {
+        toastTitle = args.Type switch
+        {
+            MessageBoxType.Success => "Sucesso",
+            MessageBoxType.Error => "Erro",
+            MessageBoxType.Warning => "Aviso",
+            MessageBoxType.Info => "Informação",
+            _ => "Mensagem"
+        };
+        toastMessage = args.Message;
+        showToast = true;
+        StateHasChanged();
+
+        // Auto-hide toast after 5 seconds
+        Task.Delay(5000).ContinueWith(_ =>
+        {
+            showToast = false;
+            InvokeAsync(StateHasChanged);
+        });
+    }
+
+    public void Dispose()
+    {
+        MessageBoxService.OnMessageReceived -= HandleMessage;
+    }
+
+    public class CargoFormModel
+    {
+        public int IdCargo { get; set; }
+        
+        [Required(ErrorMessage = "O nome do cargo é obrigatório")]
+        [StringLength(100, ErrorMessage = "O nome do cargo deve ter no máximo 100 caracteres")]
+        public string Nome { get; set; } = string.Empty;
+        
+        public int IdProximoCargo { get; set; }
+        
+        [Range(1, 120, ErrorMessage = "O tempo mínimo deve ser entre 1 e 120 meses")]
+        public int TempoMinimoPromocao { get; set; } = 12;
+        
+        public string? Funcao { get; set; }
+        public string? Autonomia { get; set; }
+        public string? EscopoDeAtuacao { get; set; }
+        public string? NivelInterlocucao { get; set; }
+        
+        public int ATV { get; set; } = 1;
+    }
+}

--- a/Components/Shared/MainLayout.razor
+++ b/Components/Shared/MainLayout.razor
@@ -1,0 +1,24 @@
+@inherits LayoutView
+@using Microsoft.AspNetCore.Components.Web
+
+<div class="page">
+    <div class="sidebar">
+        <NavMenu />
+    </div>
+
+    <main>
+        <div class="top-row px-4">
+            <a href="https://docs.microsoft.com/aspnet/" target="_blank">About</a>
+        </div>
+
+        <article class="content px-4">
+            @Body
+        </article>
+    </main>
+</div>
+
+<div id="blazor-error-ui">
+    Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development" ? "An error has occurred. This application may no longer respond until reloaded." : "An error has occurred. See browser dev tools for details."
+    <a href="" class="reload">Reload</a>
+    <a class="dismiss">🗙</a>
+</div>

--- a/Components/Shared/NavMenu.razor
+++ b/Components/Shared/NavMenu.razor
@@ -1,0 +1,34 @@
+<div class="top-row ps-3 navbar navbar-dark">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="">Sistema de Avaliação</a>
+        <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+    </div>
+</div>
+
+<div class="@NavMenuCssClass nav-scrollable" @onclick="ToggleNavMenu">
+    <nav class="flex-column">
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
+                <span class="oi oi-home" aria-hidden="true"></span> Home
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="cargos">
+                <span class="oi oi-briefcase" aria-hidden="true"></span> Cargos
+            </NavLink>
+        </div>
+    </nav>
+</div>
+
+@code {
+    private bool collapseNavMenu = true;
+
+    private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
+
+    private void ToggleNavMenu()
+    {
+        collapseNavMenu = !collapseNavMenu;
+    }
+}

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -58,6 +58,12 @@ public class ApplicationDbContext : DbContext
             entity.HasKey(e => e.IdCargo);
             entity.ToTable("CARGOS");
             entity.Property(e => e.Nome).HasColumnName("Cargo");
+            
+            // Self-referencing relationship for ProximoCargo
+            entity.HasOne(e => e.ProximoCargo)
+                .WithMany()
+                .HasForeignKey(e => e.IdProximoCargo)
+                .OnDelete(DeleteBehavior.Restrict);
         });
 
         modelBuilder.Entity<Eixo>(entity =>

--- a/Models/Cargo.cs
+++ b/Models/Cargo.cs
@@ -4,9 +4,16 @@ public class Cargo
 {
     public int IdCargo { get; set; }
     public string Nome { get; set; } = string.Empty;
-    public int ATV { get; set; }
+    public int? IdProximoCargo { get; set; }
+    public int TempoMinimoPromocao { get; set; } = 12;
+    public string? Funcao { get; set; }
+    public string? Autonomia { get; set; }
+    public string? EscopoDeAtuacao { get; set; }
+    public string? NivelInterlocucao { get; set; }
+    public int ATV { get; set; } = 1;
+    public DateTime DHC { get; set; } = DateTime.Now;
     
-    // Navegação
+    // Navigation properties
+    public virtual Cargo? ProximoCargo { get; set; }
     public virtual ICollection<Competencia> Competencias { get; set; } = new List<Competencia>();
-    public virtual ICollection<RelacaoCargoSubcompetencia> RelacoesCargo { get; set; } = new List<RelacaoCargoSubcompetencia>();
 }

--- a/Models/CargoExportModel.cs
+++ b/Models/CargoExportModel.cs
@@ -1,0 +1,15 @@
+namespace Peers.Moderno.Models;
+
+public class CargoExportModel
+{
+    public int IdCargo { get; set; }
+    public string Cargo { get; set; } = string.Empty;
+    public int? IdProximoCargo { get; set; }
+    public string ProximoCargo { get; set; } = string.Empty;
+    public int TempoMinimoPromocao { get; set; }
+    public string? Funcao { get; set; }
+    public string? Autonomia { get; set; }
+    public string? EscopoDeAtuacao { get; set; }
+    public string? NivelInterlocucao { get; set; }
+    public int ATV { get; set; }
+}

--- a/Models/DropdownItem.cs
+++ b/Models/DropdownItem.cs
@@ -1,0 +1,7 @@
+namespace Peers.Moderno.Models;
+
+public class DropdownItem
+{
+    public int Id { get; set; }
+    public string Nome { get; set; } = string.Empty;
+}

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -24,5 +24,6 @@
     </div>
 
     <script src="_framework/blazor.server.js"></script>
+    <script src="js/site.js"></script>
 </body>
 </html>

--- a/Program.cs
+++ b/Program.cs
@@ -5,6 +5,8 @@ using Peers.Moderno.Services.Common;
 using Peers.Moderno.Services.Associados;
 using Peers.Moderno.Services.Associados.Common;
 using Peers.Moderno.Services.Common.Auth;
+using Peers.Moderno.Services.Cargos;
+using Peers.Moderno.Services.Cargos.Common;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
@@ -55,6 +57,7 @@ builder.Services.AddAuthentication(options =>
 
 // Common Services
 builder.Services.AddScoped<ITelemetryService, TelemetryService>();
+builder.Services.AddScoped<IMessageBoxService, MessageBoxService>();
 
 // Auth Common Services
 builder.Services.AddScoped<ITokenDecoder, TokenDecoder>();
@@ -70,6 +73,11 @@ builder.Services.AddScoped<IAvaliacoesService, AvaliacoesService>();
 builder.Services.AddScoped<IExportFileService, ExportFileService>();
 builder.Services.AddScoped<IPremissasService, PremissasService>();
 
+// Cargos Services
+builder.Services.AddScoped<Services.Cargos.ICargosService, Services.Cargos.CargosService>();
+builder.Services.AddScoped<Services.Cargos.Common.IDropdownService, Services.Cargos.Common.DropdownService>();
+builder.Services.AddScoped<Services.Cargos.Common.IExportService, Services.Cargos.Common.ExportService>();
+
 // Associados Services
 builder.Services.AddScoped<IAssociadosService, AssociadosService>();
 builder.Services.AddScoped<AssociadosService>();
@@ -79,8 +87,8 @@ builder.Services.AddScoped<IFotoService, FotoService>();
 builder.Services.AddScoped<FotoService>();
 builder.Services.AddScoped<IExcelService, ExcelService>();
 builder.Services.AddScoped<ExcelService>();
-builder.Services.AddScoped<IDropdownService, DropdownService>();
-builder.Services.AddScoped<DropdownService>();
+builder.Services.AddScoped<Services.Associados.Common.IDropdownService, Services.Associados.Common.DropdownService>();
+builder.Services.AddScoped<Services.Associados.Common.DropdownService>();
 builder.Services.AddScoped<IPromocaoService, PromocaoService>();
 builder.Services.AddScoped<PromocaoService>();
 

--- a/Services/Cargos/CargosService.cs
+++ b/Services/Cargos/CargosService.cs
@@ -1,0 +1,125 @@
+using Microsoft.EntityFrameworkCore;
+using Peers.Moderno.Data;
+using Peers.Moderno.Models;
+
+namespace Peers.Moderno.Services.Cargos;
+
+public interface ICargosService
+{
+    Task<List<Cargo>> ObterListaCargosAsync(bool apenasAtivos = false);
+    Task<Cargo?> ObterCargoAsync(int id);
+    Task<bool> InserirCargoAsync(Cargo cargo);
+    Task<bool> AlterarCargoAsync(Cargo cargo);
+    Task<bool> InativarCargoAsync(int id);
+    Task<bool> ExisteCargoComNomeAsync(string nome, int? idExcluir = null);
+}
+
+public class CargosService : ICargosService
+{
+    private readonly ApplicationDbContext _context;
+
+    public CargosService(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<Cargo>> ObterListaCargosAsync(bool apenasAtivos = false)
+    {
+        var query = _context.Cargos
+            .Include(c => c.ProximoCargo)
+            .AsQueryable();
+
+        if (apenasAtivos)
+        {
+            query = query.Where(c => c.ATV == 1);
+        }
+
+        return await query
+            .OrderBy(c => c.Nome)
+            .ToListAsync();
+    }
+
+    public async Task<Cargo?> ObterCargoAsync(int id)
+    {
+        return await _context.Cargos
+            .Include(c => c.ProximoCargo)
+            .FirstOrDefaultAsync(c => c.IdCargo == id);
+    }
+
+    public async Task<bool> InserirCargoAsync(Cargo cargo)
+    {
+        try
+        {
+            if (await ExisteCargoComNomeAsync(cargo.Nome))
+                return false;
+
+            cargo.DHC = DateTime.Now;
+            _context.Cargos.Add(cargo);
+            await _context.SaveChangesAsync();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<bool> AlterarCargoAsync(Cargo cargo)
+    {
+        try
+        {
+            if (await ExisteCargoComNomeAsync(cargo.Nome, cargo.IdCargo))
+                return false;
+
+            var cargoExistente = await _context.Cargos.FindAsync(cargo.IdCargo);
+            if (cargoExistente == null)
+                return false;
+
+            cargoExistente.Nome = cargo.Nome;
+            cargoExistente.IdProximoCargo = cargo.IdProximoCargo;
+            cargoExistente.TempoMinimoPromocao = cargo.TempoMinimoPromocao;
+            cargoExistente.Funcao = cargo.Funcao;
+            cargoExistente.Autonomia = cargo.Autonomia;
+            cargoExistente.EscopoDeAtuacao = cargo.EscopoDeAtuacao;
+            cargoExistente.NivelInterlocucao = cargo.NivelInterlocucao;
+            cargoExistente.ATV = cargo.ATV;
+
+            await _context.SaveChangesAsync();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<bool> InativarCargoAsync(int id)
+    {
+        try
+        {
+            var cargo = await _context.Cargos.FindAsync(id);
+            if (cargo == null)
+                return false;
+
+            cargo.ATV = 0;
+            await _context.SaveChangesAsync();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<bool> ExisteCargoComNomeAsync(string nome, int? idExcluir = null)
+    {
+        var query = _context.Cargos.Where(c => c.Nome.ToLower() == nome.ToLower());
+        
+        if (idExcluir.HasValue)
+        {
+            query = query.Where(c => c.IdCargo != idExcluir.Value);
+        }
+
+        return await query.AnyAsync();
+    }
+}

--- a/Services/Cargos/Common/DropdownService.cs
+++ b/Services/Cargos/Common/DropdownService.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Peers.Moderno.Data;
+using Peers.Moderno.Models;
+
+namespace Peers.Moderno.Services.Cargos.Common;
+
+public interface IDropdownService
+{
+    Task<List<DropdownItem>> ObterCargosAtivosAsync();
+    Task<List<DropdownItem>> ObterTodosCargosAsync();
+    Task<List<DropdownItem>> ObterStatusOptionsAsync();
+}
+
+public class DropdownService : IDropdownService
+{
+    private readonly ApplicationDbContext _context;
+
+    public DropdownService(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<DropdownItem>> ObterCargosAtivosAsync()
+    {
+        return await _context.Cargos
+            .Where(c => c.ATV == 1)
+            .Select(c => new DropdownItem { Id = c.IdCargo, Nome = c.Nome })
+            .OrderBy(c => c.Nome)
+            .ToListAsync();
+    }
+
+    public async Task<List<DropdownItem>> ObterTodosCargosAsync()
+    {
+        return await _context.Cargos
+            .Select(c => new DropdownItem { Id = c.IdCargo, Nome = c.Nome })
+            .OrderBy(c => c.Nome)
+            .ToListAsync();
+    }
+
+    public async Task<List<DropdownItem>> ObterStatusOptionsAsync()
+    {
+        return new List<DropdownItem>
+        {
+            new DropdownItem { Id = 1, Nome = "Ativo" },
+            new DropdownItem { Id = 0, Nome = "Inativo" }
+        };
+    }
+}

--- a/Services/Cargos/Common/ExportService.cs
+++ b/Services/Cargos/Common/ExportService.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore;
+using OfficeOpenXml;
+using Peers.Moderno.Data;
+using Peers.Moderno.Models;
+
+namespace Peers.Moderno.Services.Cargos.Common;
+
+public interface IExportService
+{
+    Task<(byte[] bytes, string fileName)> ExportarCargosAsync();
+}
+
+public class ExportService : IExportService
+{
+    private readonly ApplicationDbContext _context;
+
+    public ExportService(ApplicationDbContext context)
+    {
+        _context = context;
+        ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+    }
+
+    public async Task<(byte[] bytes, string fileName)> ExportarCargosAsync()
+    {
+        var cargos = await _context.Cargos
+            .Include(c => c.ProximoCargo)
+            .Select(c => new CargoExportModel
+            {
+                IdCargo = c.IdCargo,
+                Cargo = c.Nome,
+                IdProximoCargo = c.IdProximoCargo,
+                ProximoCargo = c.ProximoCargo != null ? c.ProximoCargo.Nome : string.Empty,
+                TempoMinimoPromocao = c.TempoMinimoPromocao,
+                Funcao = c.Funcao,
+                Autonomia = c.Autonomia,
+                EscopoDeAtuacao = c.EscopoDeAtuacao,
+                NivelInterlocucao = c.NivelInterlocucao,
+                ATV = c.ATV
+            })
+            .ToListAsync();
+
+        using var package = new ExcelPackage();
+        var worksheet = package.Workbook.Worksheets.Add("Cargos");
+
+        // Cabeçalhos
+        worksheet.Cells[1, 1].Value = "IdCargo";
+        worksheet.Cells[1, 2].Value = "Cargo";
+        worksheet.Cells[1, 3].Value = "IdProximoCargo";
+        worksheet.Cells[1, 4].Value = "ProximoCargo";
+        worksheet.Cells[1, 5].Value = "TempoMinimoPromocao";
+        worksheet.Cells[1, 6].Value = "Funcao";
+        worksheet.Cells[1, 7].Value = "Autonomia";
+        worksheet.Cells[1, 8].Value = "EscopoDeAtuacao";
+        worksheet.Cells[1, 9].Value = "NivelInterlocucao";
+        worksheet.Cells[1, 10].Value = "Status";
+
+        // Dados
+        for (int i = 0; i < cargos.Count; i++)
+        {
+            var cargo = cargos[i];
+            var row = i + 2;
+
+            worksheet.Cells[row, 1].Value = cargo.IdCargo;
+            worksheet.Cells[row, 2].Value = cargo.Cargo;
+            worksheet.Cells[row, 3].Value = cargo.IdProximoCargo;
+            worksheet.Cells[row, 4].Value = cargo.ProximoCargo;
+            worksheet.Cells[row, 5].Value = cargo.TempoMinimoPromocao;
+            worksheet.Cells[row, 6].Value = cargo.Funcao;
+            worksheet.Cells[row, 7].Value = cargo.Autonomia;
+            worksheet.Cells[row, 8].Value = cargo.EscopoDeAtuacao;
+            worksheet.Cells[row, 9].Value = cargo.NivelInterlocucao;
+            worksheet.Cells[row, 10].Value = cargo.ATV == 1 ? "Ativo" : "Inativo";
+        }
+
+        worksheet.Cells.AutoFitColumns();
+        
+        var fileName = $"Cargos_{DateTime.Now:yyyyMMdd_HHmmss}.xlsx";
+        return (package.GetAsByteArray(), fileName);
+    }
+}

--- a/Services/Common/MessageBoxService.cs
+++ b/Services/Common/MessageBoxService.cs
@@ -1,0 +1,55 @@
+namespace Peers.Moderno.Services.Common;
+
+public interface IMessageBoxService
+{
+    void ShowSuccess(string message);
+    void ShowError(string message);
+    void ShowInfo(string message);
+    void ShowWarning(string message);
+    event Action<MessageBoxEventArgs>? OnMessageReceived;
+}
+
+public class MessageBoxService : IMessageBoxService
+{
+    public event Action<MessageBoxEventArgs>? OnMessageReceived;
+
+    public void ShowSuccess(string message)
+    {
+        OnMessageReceived?.Invoke(new MessageBoxEventArgs(message, MessageBoxType.Success));
+    }
+
+    public void ShowError(string message)
+    {
+        OnMessageReceived?.Invoke(new MessageBoxEventArgs(message, MessageBoxType.Error));
+    }
+
+    public void ShowInfo(string message)
+    {
+        OnMessageReceived?.Invoke(new MessageBoxEventArgs(message, MessageBoxType.Info));
+    }
+
+    public void ShowWarning(string message)
+    {
+        OnMessageReceived?.Invoke(new MessageBoxEventArgs(message, MessageBoxType.Warning));
+    }
+}
+
+public class MessageBoxEventArgs
+{
+    public string Message { get; }
+    public MessageBoxType Type { get; }
+
+    public MessageBoxEventArgs(string message, MessageBoxType type)
+    {
+        Message = message;
+        Type = type;
+    }
+}
+
+public enum MessageBoxType
+{
+    Success,
+    Error,
+    Info,
+    Warning
+}

--- a/docs/cargos.md
+++ b/docs/cargos.md
@@ -1,0 +1,196 @@
+# Módulo de Cargos - Documentação Técnica
+
+## Visão Geral
+
+O módulo de Cargos foi migrado de Web Forms para Blazor Server com renderização híbrida (.NET 9), seguindo uma arquitetura baseada em serviços e injeção de dependência. O módulo permite o gerenciamento completo de cargos da empresa, incluindo CRUD, exportação para Excel e relacionamentos hierárquicos.
+
+## Arquitetura
+
+### Estrutura de Pastas
+
+
+Services/
+├── Cargos/
+│   ├── CargosService.cs          # Serviço principal de negócio
+│   └── Common/
+│       ├── DropdownService.cs    # Serviço para dropdowns
+│       └── ExportService.cs      # Serviço de exportação
+└── Common/
+    └── MessageBoxService.cs      # Serviço de mensagens
+
+Components/
+└── Cargos/
+    ├── Cargos.razor             # Componente principal
+    └── Cargos.razor.cs          # Code-behind
+
+Models/
+├── Cargo.cs                     # Modelo principal
+├── CargoExportModel.cs          # Modelo para exportação
+└── DropdownItem.cs              # Modelo para dropdowns
+
+
+### Princípios de Design
+
+1. **Separação de Responsabilidades**: Lógica de negócio isolada em serviços
+2. **Reutilização**: Serviços comuns organizados em pastas `Common`
+3. **Injeção de Dependência**: Todos os serviços registrados no DI container
+4. **Renderização Híbrida**: Componente usa `@rendermode InteractiveAuto`
+
+## Serviços
+
+### CargosService
+
+**Responsabilidade**: CRUD de cargos e validações de negócio
+
+**Métodos principais**:
+- `ObterListaCargosAsync()`: Lista todos os cargos
+- `ObterCargoAsync(id)`: Obtém cargo específico
+- `InserirCargoAsync(cargo)`: Insere novo cargo
+- `AlterarCargoAsync(cargo)`: Altera cargo existente
+- `InativarCargoAsync(id)`: Inativa cargo
+- `ExisteCargoComNomeAsync(nome)`: Valida duplicação
+
+### DropdownService (Common)
+
+**Responsabilidade**: Popular dropdowns de forma padronizada
+
+**Métodos**:
+- `ObterCargosAtivosAsync()`: Cargos ativos para dropdown
+- `ObterTodosCargosAsync()`: Todos os cargos
+- `ObterStatusOptionsAsync()`: Opções de status
+
+**Reutilização**: Pode ser usado por outros módulos que precisem de dropdowns de cargos
+
+### ExportService (Common)
+
+**Responsabilidade**: Exportação de dados para Excel
+
+**Métodos**:
+- `ExportarCargosAsync()`: Gera arquivo Excel com dados dos cargos
+
+**Reutilização**: Padrão pode ser aplicado para exportação de outras entidades
+
+### MessageBoxService (Common)
+
+**Responsabilidade**: Sistema de mensagens para feedback ao usuário
+
+**Métodos**:
+- `ShowSuccess(message)`: Mensagem de sucesso
+- `ShowError(message)`: Mensagem de erro
+- `ShowInfo(message)`: Mensagem informativa
+- `ShowWarning(message)`: Mensagem de aviso
+
+**Reutilização**: Usado por qualquer componente que precise de feedback
+
+## Componente Blazor
+
+### Cargos.razor
+
+**Características**:
+- Renderização híbrida com `@rendermode InteractiveAuto`
+- Formulário reativo com validação
+- Grid de dados com ações inline
+- Exportação integrada
+- Sistema de toast para mensagens
+
+**Funcionalidades**:
+- Cadastro e edição de cargos
+- Listagem com filtros
+- Inativação de registros
+- Exportação para Excel
+- Validação client-side e server-side
+
+## Integração com Outros Módulos
+
+### Como Reutilizar os Serviços
+
+csharp
+// Em outro componente/serviço
+@inject Services.Cargos.Common.IDropdownService DropdownService
+@inject Services.Common.IMessageBoxService MessageBoxService
+
+// Usar dropdown de cargos
+var cargos = await DropdownService.ObterCargosAtivosAsync();
+
+// Mostrar mensagem
+MessageBoxService.ShowSuccess("Operação realizada com sucesso!");
+
+
+### Extensibilidade
+
+1. **Novos Campos**: Adicionar propriedades no modelo `Cargo` e atualizar o componente
+2. **Novas Validações**: Implementar no `CargosService` ou no modelo de formulário
+3. **Novos Formatos de Export**: Estender o `ExportService` com novos métodos
+4. **Integração com APIs**: Adicionar HttpClient nos serviços conforme necessário
+
+## Configuração
+
+### Registro no DI Container (Program.cs)
+
+csharp
+// Cargos Services
+builder.Services.AddScoped<Services.Cargos.ICargosService, Services.Cargos.CargosService>();
+builder.Services.AddScoped<Services.Cargos.Common.IDropdownService, Services.Cargos.Common.DropdownService>();
+builder.Services.AddScoped<Services.Cargos.Common.IExportService, Services.Cargos.Common.ExportService>();
+builder.Services.AddScoped<Services.Common.IMessageBoxService, Services.Common.MessageBoxService>();
+
+
+### Entity Framework
+
+O modelo `Cargo` está mapeado no `ApplicationDbContext` com:
+- Relacionamento self-referencing para `ProximoCargo`
+- Mapeamento para tabela `CARGOS`
+- Navigation properties configuradas
+
+## Fluxo de Alto Nível
+
+mermaid
+flowchart TD
+    A[Usuário] --> B[Cargos.razor]
+    B --> C{Ação do Usuário}
+    
+    C -->|Carregar Dados| D[CargosService.ObterListaCargosAsync]
+    C -->|Popular Dropdown| E[DropdownService.ObterCargosAtivosAsync]
+    C -->|Salvar Cargo| F[CargosService.InserirCargoAsync/AlterarCargoAsync]
+    C -->|Inativar Cargo| G[CargosService.InativarCargoAsync]
+    C -->|Exportar| H[ExportService.ExportarCargosAsync]
+    
+    D --> I[ApplicationDbContext]
+    E --> I
+    F --> I
+    G --> I
+    H --> I
+    
+    I --> J[(SQL Server Database)]
+    
+    F --> K[MessageBoxService.ShowSuccess/ShowError]
+    G --> K
+    H --> K
+    
+    K --> L[Toast Notification]
+    L --> A
+    
+    H --> M[Download Excel File]
+    M --> A
+    
+    style B fill:#e1f5fe
+    style I fill:#f3e5f5
+    style J fill:#e8f5e8
+    style K fill:#fff3e0
+
+
+## Benefícios da Arquitetura
+
+1. **Testabilidade**: Serviços isolados facilitam testes unitários
+2. **Manutenibilidade**: Separação clara de responsabilidades
+3. **Reutilização**: Serviços comuns podem ser usados em outros módulos
+4. **Performance**: Renderização híbrida otimiza experiência do usuário
+5. **Escalabilidade**: Arquitetura preparada para crescimento
+
+## Próximos Passos
+
+1. Implementar cache para dropdowns frequentemente acessados
+2. Adicionar logs estruturados usando ILogger
+3. Implementar paginação para grandes volumes de dados
+4. Adicionar testes unitários para os serviços
+5. Considerar implementação de padrão Repository se necessário

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -1,8 +1,14 @@
-window.downloadFile = (fileName, base64Data) => {
+// Função para download de arquivos
+window.downloadFile = (filename, base64Data) => {
     const link = document.createElement('a');
     link.href = 'data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64,' + base64Data;
-    link.download = fileName;
+    link.download = filename;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+};
+
+// Função para confirmar ações
+window.confirm = (message) => {
+    return confirm(message);
 };


### PR DESCRIPTION
Este PR realiza a migração completa da página de Cargos do antigo Web Forms para Blazor Híbrido (.NET 9), implementando uma arquitetura moderna baseada em serviços reutilizáveis. Foram criados modelos, serviços comuns (Dropdown, Exportação, Mensagens), componente Blazor com renderização híbrida, integração com Entity Framework, DI container e documentação técnica detalhada com fluxo Mermaid. Todas as pastas seguem a lógica de centralização de serviços reutilizáveis em 'Common', facilitando extensibilidade e integração futura. O PR inclui também scripts JS para integração Blazor e layout/navegação compartilhados.