### PR TITLE
Migração dos componentes de Competências para Blazor com arquitetura orientada a reutilização e documentação inicial

### DIFF
--- a/Components/Competencias/CompetenciasForm.razor
+++ b/Components/Competencias/CompetenciasForm.razor
@@ -1,0 +1,514 @@
+@using Peers.Moderno.Models
+@using Peers.Moderno.Services.Competencias
+@using Peers.Moderno.Services.Common
+@inject ICompetenciasService CompetenciasService
+@inject ICargosService CargosService
+@inject IEixosService EixosService
+@inject ISubCompetenciasService SubCompetenciasService
+@inject IDimensoesService DimensoesService
+@inject IAvaliacoesService AvaliacoesService
+@inject IMessageBoxService MessageBoxService
+
+<div class="card">
+    <div class="card-body">
+        <h4 class="card-title">Dados da Competência</h4>
+        <EditForm Model="@competencia" OnValidSubmit="@HandleValidSubmit">
+            <DataAnnotationsValidator />
+            <ValidationSummary />
+            
+            <div class="form-body">
+                <div class="text-left">
+                    <label>Tipo de Avaliação</label><br />
+                    <InputSelect @bind-Value="tipoAvaliacao" @onchange="OnTipoAvaliacaoChanged" class="form-control p-0 select2" style="width: 25%">
+                        <option value="">Selecionar</option>
+                        <option value="desempenho">Avaliação de Desempenho</option>
+                        <option value="lideranca">Avaliação de Liderança</option>
+                    </InputSelect><br />
+                </div>
+            </div>
+
+            @if (tipoAvaliacao == "desempenho")
+            {
+                <div class="form-body">
+                    <div class="row">
+                        <div class="col-md-4">
+                            <div class="form-group">
+                                <label>Cargo</label>
+                                <InputSelect @bind-Value="competencia.IdCargo" @onchange="OnCargoChanged" class="form-control p-0 select2" style="width: 100%">
+                                    <option value="0">Selecionar</option>
+                                    @foreach (var cargo in cargos)
+                                    {
+                                        <option value="@cargo.IdCargo">@cargo.Nome</option>
+                                    }
+                                </InputSelect>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="form-group">
+                                <label>Eixo</label>
+                                <InputSelect @bind-Value="competencia.IdEixo" class="form-control p-0 select2" style="width: 100%">
+                                    <option value="0">Selecionar</option>
+                                    @foreach (var eixo in eixos)
+                                    {
+                                        <option value="@eixo.IdEixo">@eixo.Nome</option>
+                                    }
+                                </InputSelect>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label>Sub Competência</label>
+                                <InputSelect @bind-Value="competencia.IdSubCompetencia" @onchange="OnSubCompetenciaChanged" class="form-control p-0 select2" style="width: 100%">
+                                    <option value="0">Selecionar</option>
+                                    @foreach (var subComp in subCompetencias)
+                                    {
+                                        <option value="@subComp.IdSubCompetencia">@subComp.Nome</option>
+                                    }
+                                </InputSelect>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label>Dimensão</label>
+                                <InputSelect @bind-Value="competencia.IdDimensao" class="form-control p-0 select2" style="width: 100%">
+                                    <option value="0">Selecionar</option>
+                                    @foreach (var dimensao in dimensoes)
+                                    {
+                                        <option value="@dimensao.IdDimensao">@dimensao.Nome</option>
+                                    }
+                                </InputSelect>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-9">
+                            <div class="form-group">
+                                <label>Detalhamento Nível Atual</label>
+                                <InputTextArea @bind-Value="competencia.CompetenciaJRDetalhe" rows="5" cols="40" class="form-control" />
+                            </div>
+                        </div>
+                        <div class="col-md-3">
+                            <div class="form-group">
+                                <label>Nivel Atual</label>
+                                <InputText @bind-Value="competencia.CompetenciaJR" @oninput="OnNivelAtualChanged" class="form-control" />
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm">
+                            <div class="form-group">
+                                <label>Palavras-chave</label>
+                                <InputTextArea @bind-Value="competencia.PalavrasChave" class="form-control" />
+                            </div>
+                        </div>
+                        <div class="col-sm">
+                            <div class="form-group">
+                                <label>Resumo da subcompetência pro cargo</label>
+                                <InputTextArea @bind-Value="relacaoSubcompetencia" class="form-control" />
+                                <small class="text-muted font-italic">O valor acima é compartilhado para todas as competências que possuírem a mesma associação de cargo e subcompetência</small>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="row">
+                        <h4>Configurações de auto preenchimento</h4>
+                    </div>
+                    <br />
+                    <div class="row" style="white-space:nowrap">
+                        <div class="col-sm">
+                            <InputCheckbox @bind-Value="competencia.InputAutoAvaliacao" class="checkbox" id="cboxInputAutoAv" />
+                            <label class="labelCbox">Input Auto Avaliação</label>
+                        </div>
+                        <div class="col-sm">
+                            <InputCheckbox @bind-Value="competencia.InputAvaliacaoAsCegas" class="checkbox" id="cboxInputAvCegas" />
+                            <label class="labelCbox">Input Avaliação as Cegas</label>
+                        </div>
+                        <div class="col-sm">
+                            <InputCheckbox @bind-Value="competencia.InputAvaliacaoGestor" class="checkbox" id="cboxInputAvGestor" />
+                            <label class="labelCbox">Input Avaliação do Gestor</label>
+                        </div>
+                        <div class="col-sm">
+                            <InputCheckbox @bind-Value="competencia.InputFeedback" class="checkbox" id="cboxInputFeedback" />
+                            <label class="labelCbox">Input Feedback</label>
+                        </div>
+                    </div>
+                    <div class="row" style="white-space:nowrap">
+                        <div class="col-sm">
+                            <InputCheckbox @bind-Value="competencia.InputNivel1" class="checkbox" id="cboxInputNivel1" />
+                            <label class="labelCbox">Input Nível 1</label>
+                        </div>
+                        <div class="col-sm">
+                            <InputCheckbox @bind-Value="competencia.InputNivel2" class="checkbox" id="cboxInputNivel2" />
+                            <label class="labelCbox">Input Nível 2</label>
+                        </div>
+                    </div>
+                    <br />
+                    <div class="row" style="white-space:nowrap">
+                        <div class="col-sm">
+                            <InputCheckbox @bind-Value="competencia.VisivelAutoAvaliacao" class="checkbox" id="cboxVisivelAutoAv" />
+                            <label class="labelCbox">Visível Auto Avaliação</label>
+                        </div>
+                        <div class="col-sm">
+                            <InputCheckbox @bind-Value="competencia.VisivelAvaliacaoAsCegas" class="checkbox" id="cboxVisivelAvCegas" />
+                            <label class="labelCbox">Visível Avaliação as Cegas</label>
+                        </div>
+                        <div class="col-sm">
+                            <InputCheckbox @bind-Value="competencia.VisivelAvaliacaoGestor" class="checkbox" id="cboxVisivelAvGestor" />
+                            <label class="labelCbox">Visível Avaliação do Gestor</label>
+                        </div>
+                        <div class="col-sm">
+                            <InputCheckbox @bind-Value="competencia.VisivelFeedback" class="checkbox" id="cboxVisivelFeedback" />
+                            <label class="labelCbox">Visível Feedback</label>
+                        </div>
+                    </div>
+                    <div class="row" style="white-space:nowrap">
+                        <div class="col-sm">
+                            <InputCheckbox @bind-Value="competencia.VisivelNivel1" class="checkbox" id="cboxVisivelNivel1" />
+                            <label class="labelCbox">Visível Nível 1</label>
+                        </div>
+                        <div class="col-sm">
+                            <InputCheckbox @bind-Value="competencia.VisivelNivel2" class="checkbox" id="cboxVisivelNivel2" />
+                            <label class="labelCbox">Visível Nível 2</label>
+                        </div>
+                    </div>
+                    <br />
+                    <div class="row">
+                        <div class="col-md-3">
+                            <label class="labelCbox">Nota Padrão Nível 1</label>
+                            <InputSelect @bind-Value="competencia.IdNotaPadraoNivel1" class="form-control p-0 select2" style="width: 100%">
+                                <option value="0">Selecionar</option>
+                                @foreach (var nota in notasPadrao)
+                                {
+                                    <option value="@nota.IdNota">@nota.CodigoNota</option>
+                                }
+                            </InputSelect>
+                        </div>
+                        <div class="col-md-3">
+                            <label class="labelCbox">Nota Padrão Nível 2</label>
+                            <InputSelect @bind-Value="competencia.IdNotaPadraoNivel2" class="form-control p-0 select2" style="width: 100%">
+                                <option value="0">Selecionar</option>
+                                @foreach (var nota in notasPadrao)
+                                {
+                                    <option value="@nota.IdNota">@nota.CodigoNota</option>
+                                }
+                            </InputSelect>
+                        </div>
+                    </div>
+                    <br />
+                    <div class="row">
+                        <div class="col-md-3">
+                            <label class="labelCbox">Modo de Cálculo</label>
+                            <InputSelect @bind-Value="competencia.IdModo" class="form-control p-0 select2" style="width: 100%">
+                                @foreach (var modo in modosCalculo)
+                                {
+                                    <option value="@modo.IdModo">@modo.ModoDesc</option>
+                                }
+                            </InputSelect>
+                        </div>
+                    </div>
+                </div>
+            }
+            else if (tipoAvaliacao == "lideranca")
+            {
+                <div class="form-body">
+                    <div class="row">
+                        <div class="col-md-4">
+                            <div class="form-group">
+                                <label>Escopo</label><br />
+                                <InputSelect @bind-Value="competencia.Escopo" class="form-control p-0 select2" style="width: 100%">
+                                    <option value="">Selecionar</option>
+                                    <option value="projeto">Por projeto</option>
+                                    <option value="líder">Por líder</option>
+                                    <option value="backoffice">backoffice</option>
+                                </InputSelect>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="form-group">
+                                <label>Pilar</label><br />
+                                <InputSelect @bind-Value="competencia.IdEixo" class="form-control p-0 select2" style="width: 100%">
+                                    <option value="0">Selecionar</option>
+                                    @foreach (var eixo in eixosLideranca)
+                                    {
+                                        <option value="@eixo.IdEixo">@eixo.Nome</option>
+                                    }
+                                </InputSelect>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="form-group">
+                                <label>Título</label><br />
+                                <InputSelect @bind-Value="competencia.IdSubCompetencia" class="form-control p-0 select2" style="width: 100%">
+                                    <option value="0">Selecionar</option>
+                                    @foreach (var subComp in subCompetencias)
+                                    {
+                                        <option value="@subComp.IdSubCompetencia">@subComp.Nome</option>
+                                    }
+                                </InputSelect>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="form-group">
+                                <label>Detalhamento</label>
+                                <InputText @bind-Value="competencia.CompetenciaJRDetalhe" class="form-control" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
+
+            <div class="form-actions">
+                <div class="text-right">
+                    @if (competencia.IdCompetencia > 0)
+                    {
+                        <button type="button" @onclick="AgregarCompetencia" class="btn btn-facebook" 
+                                title="Adicionar esta competência as avaliações já existentes do período atual que não possuírem esta competência.">
+                            Agregar
+                        </button>
+                    }
+                    <button type="submit" class="btn btn-info">@(competencia.IdCompetencia == 0 ? "Cadastrar" : "Salvar")</button>
+                    <button type="button" @onclick="LimparFormulario" class="btn btn-secondary">Limpar</button>
+                </div>
+            </div>
+        </EditForm>
+    </div>
+</div>
+
+@code {
+    [Parameter] public Competencia? CompetenciaEdicao { get; set; }
+    [Parameter] public EventCallback OnCompetenciaSalva { get; set; }
+    [Parameter] public EventCallback OnFormularioLimpo { get; set; }
+
+    private Competencia competencia = new();
+    private string tipoAvaliacao = string.Empty;
+    private string relacaoSubcompetencia = string.Empty;
+    
+    private List<Cargo> cargos = new();
+    private List<Eixo> eixos = new();
+    private List<Eixo> eixosLideranca = new();
+    private List<SubCompetencia> subCompetencias = new();
+    private List<Dimensao> dimensoes = new();
+    private List<AvaliacaoCompetenciaNota> notasPadrao = new();
+    private List<ModoCalculoCompetencia> modosCalculo = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await CarregarDadosIniciais();
+        
+        if (CompetenciaEdicao != null)
+        {
+            competencia = CompetenciaEdicao;
+            tipoAvaliacao = competencia.TipoAvaliacao ?? "desempenho";
+            await CarregarRelacaoCargoSubcompetencia();
+        }
+        else
+        {
+            InicializarNovaCompetencia();
+        }
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (CompetenciaEdicao != null && CompetenciaEdicao.IdCompetencia != competencia.IdCompetencia)
+        {
+            competencia = CompetenciaEdicao;
+            tipoAvaliacao = competencia.TipoAvaliacao ?? "desempenho";
+            await CarregarRelacaoCargoSubcompetencia();
+        }
+    }
+
+    private async Task CarregarDadosIniciais()
+    {
+        cargos = await CargosService.ObterListaCargosAsync(true);
+        eixos = await EixosService.ListaEixosAsync(true, "desempenho");
+        eixosLideranca = await EixosService.ListaEixosAsync(true, "lideranca");
+        subCompetencias = await SubCompetenciasService.ListaSubCompetenciasAsync(true);
+        dimensoes = await DimensoesService.ListaDimensoesAsync(true, "desempenho");
+        notasPadrao = await AvaliacoesService.ObterAvaliacaoCompetenciasNotasAsync();
+        modosCalculo = await AvaliacoesService.ObterModosCalculosCompetenciasAsync();
+    }
+
+    private void InicializarNovaCompetencia()
+    {
+        competencia = new Competencia
+        {
+            InputAutoAvaliacao = true,
+            InputAvaliacaoAsCegas = true,
+            InputAvaliacaoGestor = true,
+            InputFeedback = true,
+            InputNivel1 = true,
+            InputNivel2 = true,
+            VisivelAutoAvaliacao = true,
+            VisivelAvaliacaoAsCegas = true,
+            VisivelAvaliacaoGestor = true,
+            VisivelFeedback = true,
+            VisivelNivel1 = true,
+            VisivelNivel2 = true,
+            ATV = 1
+        };
+        tipoAvaliacao = string.Empty;
+        relacaoSubcompetencia = string.Empty;
+    }
+
+    private async Task OnTipoAvaliacaoChanged(ChangeEventArgs e)
+    {
+        tipoAvaliacao = e.Value?.ToString() ?? string.Empty;
+        competencia.TipoAvaliacao = tipoAvaliacao;
+        
+        if (tipoAvaliacao == "lideranca")
+        {
+            competencia.IdCargo = 96; // Cargo fixo para liderança
+            competencia.IdNivel = 1;
+            competencia.IdDimensao = 10; // Dimensão fixa para liderança
+        }
+    }
+
+    private async Task OnCargoChanged(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out int cargoId))
+        {
+            competencia.IdCargo = cargoId;
+            await CarregarRelacaoCargoSubcompetencia();
+        }
+    }
+
+    private async Task OnSubCompetenciaChanged(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out int subCompId))
+        {
+            competencia.IdSubCompetencia = subCompId;
+            await CarregarRelacaoCargoSubcompetencia();
+        }
+    }
+
+    private void OnNivelAtualChanged(ChangeEventArgs e)
+    {
+        relacaoSubcompetencia = e.Value?.ToString() ?? string.Empty;
+    }
+
+    private async Task CarregarRelacaoCargoSubcompetencia()
+    {
+        if (competencia.IdCargo > 0 && competencia.IdSubCompetencia > 0)
+        {
+            var relacao = await CargosService.ObterRelacaoCargoSubcompetenciaAsync(competencia.IdCargo, competencia.IdSubCompetencia);
+            relacaoSubcompetencia = relacao?.Descricao ?? string.Empty;
+        }
+    }
+
+    private async Task HandleValidSubmit()
+    {
+        try
+        {
+            if (ValidarFormulario())
+            {
+                // Atualizar relação cargo x subcompetência se necessário
+                if (!string.IsNullOrEmpty(relacaoSubcompetencia) && competencia.IdCargo > 0 && competencia.IdSubCompetencia > 0)
+                {
+                    await CargosService.AtualizarRelacaoCargoSubcompetenciaAsync(new RelacaoCargoSubcompetencia
+                    {
+                        IdCargo = competencia.IdCargo,
+                        IdSubcompetencia = competencia.IdSubCompetencia,
+                        Descricao = relacaoSubcompetencia
+                    });
+                }
+
+                bool sucesso;
+                if (competencia.IdCompetencia == 0)
+                {
+                    sucesso = await CompetenciasService.InserirCompetenciaAsync(competencia);
+                    MessageBoxService.ShowSuccess(sucesso ? "Competência inserida com sucesso!" : "Falha na inserção da competência!");
+                }
+                else
+                {
+                    sucesso = await CompetenciasService.AlterarCompetenciaAsync(competencia);
+                    MessageBoxService.ShowSuccess(sucesso ? "Competência alterada com sucesso!" : "Falha na alteração da competência!");
+                }
+
+                if (sucesso)
+                {
+                    await OnCompetenciaSalva.InvokeAsync();
+                    LimparFormulario();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao salvar competência: {ex.Message}");
+        }
+    }
+
+    private bool ValidarFormulario()
+    {
+        if (string.IsNullOrEmpty(tipoAvaliacao))
+        {
+            MessageBoxService.ShowWarning("Selecione o tipo de avaliação");
+            return false;
+        }
+
+        if (tipoAvaliacao == "desempenho")
+        {
+            if (competencia.IdCargo == 0)
+            {
+                MessageBoxService.ShowInfo("Favor selecionar o Cargo!");
+                return false;
+            }
+            if (competencia.IdEixo == 0)
+            {
+                MessageBoxService.ShowInfo("Favor selecionar o Eixo!");
+                return false;
+            }
+            if (competencia.IdSubCompetencia == 0)
+            {
+                MessageBoxService.ShowInfo("Favor selecionar a Sub Competência!");
+                return false;
+            }
+            if (competencia.IdDimensao == 0)
+            {
+                MessageBoxService.ShowInfo("Favor selecionar a Dimensão!");
+                return false;
+            }
+            if (string.IsNullOrEmpty(competencia.CompetenciaJRDetalhe))
+            {
+                MessageBoxService.ShowInfo("Favor preencher o Detalhamento do Nível Atual!");
+                return false;
+            }
+            if (string.IsNullOrEmpty(competencia.CompetenciaJR))
+            {
+                MessageBoxService.ShowInfo("Favor preencher o Nivel Atual!");
+                return false;
+            }
+        }
+        else if (tipoAvaliacao == "lideranca")
+        {
+            if (competencia.IdEixo == 0 || string.IsNullOrEmpty(competencia.Escopo) || 
+                competencia.IdSubCompetencia == 0 || string.IsNullOrEmpty(competencia.CompetenciaJRDetalhe))
+            {
+                MessageBoxService.ShowWarning("Preencha todos os campos");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private async Task AgregarCompetencia()
+    {
+        try
+        {
+            var resultado = await CompetenciasService.AgregarCompetenciaAsync(competencia.IdCompetencia);
+            MessageBoxService.ShowInfo($"Agregadas {resultado.CompetenciasAdicionadas} competências as avaliações existentes de {resultado.AssociadosAfetados} associados.");
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao agregar competência: {ex.Message}");
+        }
+    }
+
+    private void LimparFormulario()
+    {
+        InicializarNovaCompetencia();
+        OnFormularioLimpo.InvokeAsync();
+    }
+}

--- a/Components/Competencias/CompetenciasImportExport.razor
+++ b/Components/Competencias/CompetenciasImportExport.razor
@@ -1,0 +1,310 @@
+@using Peers.Moderno.Services.Competencias
+@using Peers.Moderno.Services.Common
+@inject ICompetenciasService CompetenciasService
+@inject IMessageBoxService MessageBoxService
+@inject IJSRuntime JSRuntime
+
+<div class="card">
+    <div class="card-body">
+        <h4 class="card-title">Exportar e Importar Competências</h4>
+        <h6 class="card-subtitle">Utilize o modelo de arquivo exportado para alterar ou adicionar competências.</h6>
+        <h6 class="card-subtitle">Mantenha uma linha SEM um valor na coluna IdCompetência para adicionar uma nova competência.</h6>
+        <h6 class="card-subtitle">As correlações de cargo, eixo, subcompetência e dimensão devem ser identificadas por seus CÓDIGOS.</h6>
+        <h6 class="card-subtitle">NÃO altere a ordem e quantidade das colunas, a quantidade de abas do arquivo ou coloque linhas acima da linha de títulos.</h6>
+        
+        <div class="row">
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">
+                            <i class="fas fa-download"></i> Exportar Competências
+                        </h5>
+                    </div>
+                    <div class="card-body">
+                        <p class="card-text">Baixe um arquivo Excel com todas as competências cadastradas no sistema.</p>
+                        <button type="button" @onclick="ExportarCompetencias" class="btn btn-info" disabled="@exportando">
+                            @if (exportando)
+                            {
+                                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                <span>Exportando...</span>
+                            }
+                            else
+                            {
+                                <i class="fas fa-file-excel"></i>
+                                <span>Exportar</span>
+                            }
+                        </button>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">
+                            <i class="fas fa-upload"></i> Importar Competências
+                        </h5>
+                    </div>
+                    <div class="card-body">
+                        <p class="card-text">Selecione um arquivo Excel para importar competências.</p>
+                        
+                        <div class="form-group">
+                            <InputFile OnChange="OnFileSelected" accept=".xlsx" class="form-control-file" disabled="@importando" />
+                        </div>
+                        
+                        @if (arquivoSelecionado != null)
+                        {
+                            <div class="alert alert-info mt-2">
+                                <small>
+                                    <i class="fas fa-file"></i>
+                                    Arquivo selecionado: <strong>@arquivoSelecionado.Name</strong>
+                                    <br />
+                                    Tamanho: @FormatarTamanhoArquivo(arquivoSelecionado.Size)
+                                </small>
+                            </div>
+                        }
+                        
+                        <button type="button" @onclick="ImportarCompetencias" class="btn btn-info" 
+                                disabled="@(importando || arquivoSelecionado == null)">
+                            @if (importando)
+                            {
+                                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                <span>Importando...</span>
+                            }
+                            else
+                            {
+                                <i class="fas fa-file-import"></i>
+                                <span>Importar</span>
+                            }
+                        </button>
+                        
+                        @if (arquivoSelecionado != null)
+                        {
+                            <button type="button" @onclick="LimparArquivo" class="btn btn-outline-secondary ml-2" disabled="@importando">
+                                <i class="fas fa-times"></i> Limpar
+                            </button>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        @if (resultadoImportacao != null)
+        {
+            <div class="row mt-3">
+                <div class="col-12">
+                    <div class="alert alert-info">
+                        <h6><i class="fas fa-info-circle"></i> Resultado da Importação</h6>
+                        <ul class="mb-0">
+                            <li><strong>Inseridas:</strong> @resultadoImportacao.LinhasInseridas</li>
+                            <li><strong>Alteradas:</strong> @resultadoImportacao.LinhasAlteradas</li>
+                            <li><strong>Desconsideradas:</strong> @resultadoImportacao.LinhasDesconsideradas</li>
+                            <li><strong>Com erro:</strong> @resultadoImportacao.LinhasComErro</li>
+                        </ul>
+                        
+                        @if (resultadoImportacao.Erros.Any())
+                        {
+                            <hr />
+                            <h6>Erros encontrados:</h6>
+                            <ul class="mb-0">
+                                @foreach (var erro in resultadoImportacao.Erros.Take(10))
+                                {
+                                    <li><small>@erro</small></li>
+                                }
+                                @if (resultadoImportacao.Erros.Count > 10)
+                                {
+                                    <li><small><em>... e mais @(resultadoImportacao.Erros.Count - 10) erros</em></small></li>
+                                }
+                            </ul>
+                        }
+                    </div>
+                </div>
+            </div>
+        }
+        
+        @if (progressoImportacao > 0 && progressoImportacao < 100)
+        {
+            <div class="row mt-3">
+                <div class="col-12">
+                    <div class="progress">
+                        <div class="progress-bar progress-bar-striped progress-bar-animated" 
+                             role="progressbar" 
+                             style="width: @(progressoImportacao)%" 
+                             aria-valuenow="@progressoImportacao" 
+                             aria-valuemin="0" 
+                             aria-valuemax="100">
+                            @progressoImportacao%
+                        </div>
+                    </div>
+                    <small class="text-muted">Processando arquivo...</small>
+                </div>
+            </div>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter] public EventCallback OnImportacaoConcluida { get; set; }
+    
+    private IBrowserFile? arquivoSelecionado;
+    private bool exportando = false;
+    private bool importando = false;
+    private int progressoImportacao = 0;
+    private ResultadoImportacao? resultadoImportacao;
+
+    private void OnFileSelected(InputFileChangeEventArgs e)
+    {
+        arquivoSelecionado = e.File;
+        resultadoImportacao = null;
+        StateHasChanged();
+    }
+
+    private void LimparArquivo()
+    {
+        arquivoSelecionado = null;
+        resultadoImportacao = null;
+        progressoImportacao = 0;
+        StateHasChanged();
+    }
+
+    private async Task ExportarCompetencias()
+    {
+        try
+        {
+            exportando = true;
+            StateHasChanged();
+
+            var resultado = await CompetenciasService.ExportarCompetenciasAsync();
+            
+            if (resultado.Sucesso)
+            {
+                var nomeArquivo = $"Competencias_{DateTime.Now:yyyyMMdd_HHmmss}.xlsx";
+                await JSRuntime.InvokeVoidAsync("downloadFile", nomeArquivo, Convert.ToBase64String(resultado.Dados));
+                MessageBoxService.ShowSuccess("Arquivo exportado com sucesso!");
+            }
+            else
+            {
+                MessageBoxService.ShowError($"Erro ao exportar: {resultado.MensagemErro}");
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao exportar competências: {ex.Message}");
+        }
+        finally
+        {
+            exportando = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task ImportarCompetencias()
+    {
+        if (arquivoSelecionado == null)
+        {
+            MessageBoxService.ShowWarning("Selecione um arquivo para importar");
+            return;
+        }
+
+        try
+        {
+            importando = true;
+            progressoImportacao = 0;
+            resultadoImportacao = null;
+            StateHasChanged();
+
+            // Validar tamanho do arquivo (máximo 10MB)
+            const long tamanhoMaximo = 10 * 1024 * 1024;
+            if (arquivoSelecionado.Size > tamanhoMaximo)
+            {
+                MessageBoxService.ShowWarning("O arquivo é muito grande. Tamanho máximo permitido: 10MB");
+                return;
+            }
+
+            // Validar extensão
+            if (!arquivoSelecionado.Name.EndsWith(".xlsx", StringComparison.OrdinalIgnoreCase))
+            {
+                MessageBoxService.ShowWarning("Apenas arquivos .xlsx são permitidos");
+                return;
+            }
+
+            progressoImportacao = 25;
+            StateHasChanged();
+
+            // Ler o arquivo
+            using var stream = arquivoSelecionado.OpenReadStream(tamanhoMaximo);
+            using var memoryStream = new MemoryStream();
+            await stream.CopyToAsync(memoryStream);
+            
+            progressoImportacao = 50;
+            StateHasChanged();
+
+            // Processar importação
+            var dados = memoryStream.ToArray();
+            resultadoImportacao = await CompetenciasService.ImportarCompetenciasAsync(dados);
+            
+            progressoImportacao = 100;
+            StateHasChanged();
+
+            // Aguardar um pouco para mostrar o progresso completo
+            await Task.Delay(500);
+            progressoImportacao = 0;
+
+            if (resultadoImportacao.Sucesso)
+            {
+                MessageBoxService.ShowSuccess(
+                    $"Importação concluída! Inseridas: {resultadoImportacao.LinhasInseridas}, " +
+                    $"Alteradas: {resultadoImportacao.LinhasAlteradas}, " +
+                    $"Desconsideradas: {resultadoImportacao.LinhasDesconsideradas}, " +
+                    $"Com erro: {resultadoImportacao.LinhasComErro}");
+                
+                await OnImportacaoConcluida.InvokeAsync();
+            }
+            else
+            {
+                MessageBoxService.ShowError($"Erro na importação: {resultadoImportacao.MensagemErro}");
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao importar competências: {ex.Message}");
+            resultadoImportacao = new ResultadoImportacao
+            {
+                Sucesso = false,
+                MensagemErro = ex.Message
+            };
+        }
+        finally
+        {
+            importando = false;
+            progressoImportacao = 0;
+            StateHasChanged();
+        }
+    }
+
+    private string FormatarTamanhoArquivo(long bytes)
+    {
+        string[] sufixos = { "B", "KB", "MB", "GB" };
+        int contador = 0;
+        decimal tamanho = bytes;
+        
+        while (Math.Round(tamanho / 1024) >= 1)
+        {
+            tamanho /= 1024;
+            contador++;
+        }
+        
+        return $"{tamanho:n1} {sufixos[contador]}";
+    }
+
+    public class ResultadoImportacao
+    {
+        public bool Sucesso { get; set; }
+        public string MensagemErro { get; set; } = string.Empty;
+        public int LinhasInseridas { get; set; }
+        public int LinhasAlteradas { get; set; }
+        public int LinhasDesconsideradas { get; set; }
+        public int LinhasComErro { get; set; }
+        public List<string> Erros { get; set; } = new();
+    }
+}

--- a/Components/Competencias/CompetenciasList.razor
+++ b/Components/Competencias/CompetenciasList.razor
@@ -1,0 +1,230 @@
+@using Peers.Moderno.Models
+@using Peers.Moderno.Services.Competencias
+@using Peers.Moderno.Services.Common
+@inject ICompetenciasService CompetenciasService
+@inject IMessageBoxService MessageBoxService
+@inject IJSRuntime JSRuntime
+
+<div class="card">
+    <div class="card-body">
+        <h4 class="card-title">Lista de Competências</h4>
+        <h6 class="card-subtitle">Filtre as informações separadas por espaço para busca em qualquer coluna em qualquer ordem, completo ou parcial: <code>competência nível cargo</code>.</h6>
+        
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <input type="text" @bind="filtro" @oninput="FiltrarCompetencias" class="form-control" placeholder="Digite para filtrar..." />
+            </div>
+            <div class="col-md-6">
+                <button type="button" @onclick="CarregarCompetencias" class="btn btn-primary">
+                    <i class="fas fa-sync-alt"></i> Atualizar
+                </button>
+            </div>
+        </div>
+
+        <div class="table-responsive">
+            @if (competenciasFiltradas.Any())
+            {
+                <table class="table table-striped border">
+                    <thead>
+                        <tr>
+                            <th>Código</th>
+                            <th>Cargo</th>
+                            <th>Escopo</th>
+                            <th>Eixo</th>
+                            <th>Sub Competência</th>
+                            <th>Competencia Jr</th>
+                            <th>Status(Ativo/Inativo)</th>
+                            <th>Ação</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var competencia in competenciasFiltradas)
+                        {
+                            <tr>
+                                <td>@competencia.IdCompetencia</td>
+                                <td>@competencia.Cargo?.Nome</td>
+                                <td>@competencia.Escopo</td>
+                                <td>@competencia.Eixo?.Nome</td>
+                                <td>@competencia.SubCompetencia?.Nome</td>
+                                <td>@competencia.CompetenciaJR</td>
+                                <td>@(competencia.ATV == 1 ? "Ativo" : "Inativo")</td>
+                                <td>
+                                    <button type="button" @onclick="() => EditarCompetencia(competencia)" class="btn btn-info btn-sm">
+                                        Alterar
+                                    </button>
+                                    @if (competencia.ATV == 1)
+                                    {
+                                        <button type="button" @onclick="() => InativarCompetencia(competencia.IdCompetencia)" class="btn btn-dark btn-sm">
+                                            Inativar
+                                        </button>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <th>Código</th>
+                            <th>Cargo</th>
+                            <th>Escopo</th>
+                            <th>Eixo</th>
+                            <th>Sub Competência</th>
+                            <th>Competencia Jr</th>
+                            <th>Status(Ativo/Inativo)</th>
+                            <th>Ação</th>
+                        </tr>
+                    </tfoot>
+                </table>
+            }
+            else if (carregando)
+            {
+                <div class="text-center p-4">
+                    <div class="spinner-border" role="status">
+                        <span class="sr-only">Carregando...</span>
+                    </div>
+                    <p class="mt-2">Carregando competências...</p>
+                </div>
+            }
+            else
+            {
+                <div class="text-center p-4">
+                    <p class="text-muted">Nenhuma competência encontrada.</p>
+                </div>
+            }
+        </div>
+
+        @if (competenciasFiltradas.Any())
+        {
+            <div class="row mt-3">
+                <div class="col-md-6">
+                    <small class="text-muted">
+                        Mostrando @competenciasFiltradas.Count de @competencias.Count competências
+                    </small>
+                </div>
+                <div class="col-md-6 text-right">
+                    @if (!string.IsNullOrEmpty(filtro))
+                    {
+                        <button type="button" @onclick="LimparFiltro" class="btn btn-outline-secondary btn-sm">
+                            Limpar Filtro
+                        </button>
+                    }
+                </div>
+            </div>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter] public EventCallback<Competencia> OnEditarCompetencia { get; set; }
+    [Parameter] public EventCallback OnCompetenciaInativada { get; set; }
+
+    private List<Competencia> competencias = new();
+    private List<Competencia> competenciasFiltradas = new();
+    private string filtro = string.Empty;
+    private bool carregando = false;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await CarregarCompetencias();
+    }
+
+    public async Task CarregarCompetencias()
+    {
+        try
+        {
+            carregando = true;
+            StateHasChanged();
+            
+            competencias = await CompetenciasService.ObterListaCompetenciasAsync(true);
+            competenciasFiltradas = competencias.ToList();
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao carregar competências: {ex.Message}");
+        }
+        finally
+        {
+            carregando = false;
+            StateHasChanged();
+        }
+    }
+
+    private void FiltrarCompetencias(ChangeEventArgs e)
+    {
+        filtro = e.Value?.ToString() ?? string.Empty;
+        AplicarFiltro();
+    }
+
+    private void AplicarFiltro()
+    {
+        if (string.IsNullOrWhiteSpace(filtro))
+        {
+            competenciasFiltradas = competencias.ToList();
+        }
+        else
+        {
+            var termosFiltro = filtro.ToLower().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            
+            competenciasFiltradas = competencias.Where(c =>
+                termosFiltro.All(termo =>
+                    (c.IdCompetencia.ToString().Contains(termo)) ||
+                    (c.Cargo?.Nome?.ToLower().Contains(termo) == true) ||
+                    (c.Escopo?.ToLower().Contains(termo) == true) ||
+                    (c.Eixo?.Nome?.ToLower().Contains(termo) == true) ||
+                    (c.SubCompetencia?.Nome?.ToLower().Contains(termo) == true) ||
+                    (c.CompetenciaJR?.ToLower().Contains(termo) == true) ||
+                    (c.CompetenciaJRDetalhe?.ToLower().Contains(termo) == true) ||
+                    (c.PalavrasChave?.ToLower().Contains(termo) == true) ||
+                    (c.ATV == 1 ? "ativo" : "inativo").Contains(termo)
+                )
+            ).ToList();
+        }
+        
+        StateHasChanged();
+    }
+
+    private void LimparFiltro()
+    {
+        filtro = string.Empty;
+        competenciasFiltradas = competencias.ToList();
+        StateHasChanged();
+    }
+
+    private async Task EditarCompetencia(Competencia competencia)
+    {
+        await OnEditarCompetencia.InvokeAsync(competencia);
+    }
+
+    private async Task InativarCompetencia(int idCompetencia)
+    {
+        try
+        {
+            var confirmacao = await JSRuntime.InvokeAsync<bool>("confirm", "Tem certeza que deseja inativar esta competência?");
+            
+            if (confirmacao)
+            {
+                var sucesso = await CompetenciasService.ExcluirCompetenciaAsync(idCompetencia);
+                
+                if (sucesso)
+                {
+                    MessageBoxService.ShowSuccess("Competência inativada com sucesso!");
+                    await CarregarCompetencias();
+                    await OnCompetenciaInativada.InvokeAsync();
+                }
+                else
+                {
+                    MessageBoxService.ShowWarning("Erro ao inativar competência!");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao inativar competência: {ex.Message}");
+        }
+    }
+
+    public async Task AtualizarLista()
+    {
+        await CarregarCompetencias();
+    }
+}

--- a/Components/Competencias/CompetenciasPage.razor
+++ b/Components/Competencias/CompetenciasPage.razor
@@ -1,0 +1,129 @@
+@page "/competencias"
+@using Peers.Moderno.Models
+@using Peers.Moderno.Services.Common
+@inject IMessageBoxService MessageBoxService
+
+<PageTitle>Competências - Sistema de Avaliação</PageTitle>
+
+<!-- Breadcrumb -->
+<div class="page-breadcrumb border-bottom">
+    <div class="row">
+        <div class="col-lg-3 col-md-4 col-xs-12 align-self-center">
+            <h5 class="font-medium text-uppercase mb-0">Competências</h5>
+        </div>
+        <div class="col-lg-9 col-md-8 col-xs-12 align-self-center">
+            <nav aria-label="breadcrumb" class="mt-2 float-md-right float-left">
+                <ol class="breadcrumb mb-0 justify-content-end p-0">
+                    <li class="breadcrumb-item"><a href="/">Peers / Cadastro Básico de Projetos</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">Competências</li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+</div>
+
+<!-- Container Principal -->
+<div class="page-content container-fluid">
+    
+    <!-- Mensagens -->
+    <MessageBoxComponent />
+    
+    <!-- Formulário de Competências -->
+    <CompetenciasForm CompetenciaEdicao="@competenciaEdicao" 
+                      OnCompetenciaSalva="@OnCompetenciaSalva" 
+                      OnFormularioLimpo="@OnFormularioLimpo" />
+    
+    <!-- Importação e Exportação -->
+    <CompetenciasImportExport OnImportacaoConcluida="@OnImportacaoConcluida" />
+    
+    <!-- Lista de Competências -->
+    <CompetenciasList @ref="competenciasList" 
+                      OnEditarCompetencia="@OnEditarCompetencia" 
+                      OnCompetenciaInativada="@OnCompetenciaInativada" />
+    
+</div>
+
+@code {
+    private CompetenciasList? competenciasList;
+    private Competencia? competenciaEdicao;
+
+    protected override async Task OnInitializedAsync()
+    {
+        // Configurar listener para mensagens
+        MessageBoxService.OnMessageReceived += OnMessageReceived;
+    }
+
+    private void OnMessageReceived(MessageBoxEventArgs args)
+    {
+        // As mensagens são tratadas pelo componente MessageBoxComponent
+        StateHasChanged();
+    }
+
+    private async Task OnCompetenciaSalva()
+    {
+        // Limpar edição e atualizar lista
+        competenciaEdicao = null;
+        
+        if (competenciasList != null)
+        {
+            await competenciasList.AtualizarLista();
+        }
+        
+        StateHasChanged();
+    }
+
+    private void OnFormularioLimpo()
+    {
+        // Limpar edição
+        competenciaEdicao = null;
+        StateHasChanged();
+    }
+
+    private async Task OnEditarCompetencia(Competencia competencia)
+    {
+        // Definir competência para edição
+        competenciaEdicao = competencia;
+        StateHasChanged();
+        
+        // Scroll para o topo da página
+        await Task.Delay(100); // Aguardar renderização
+        await ScrollToTop();
+    }
+
+    private async Task OnCompetenciaInativada()
+    {
+        // Limpar edição se a competência inativada estava sendo editada
+        if (competenciaEdicao != null)
+        {
+            competenciaEdicao = null;
+            StateHasChanged();
+        }
+    }
+
+    private async Task OnImportacaoConcluida()
+    {
+        // Atualizar lista após importação
+        if (competenciasList != null)
+        {
+            await competenciasList.AtualizarLista();
+        }
+    }
+
+    private async Task ScrollToTop()
+    {
+        try
+        {
+            await Task.Delay(50);
+            // Implementar scroll suave para o topo se necessário
+        }
+        catch
+        {
+            // Ignorar erros de scroll
+        }
+    }
+
+    public void Dispose()
+    {
+        MessageBoxService.OnMessageReceived -= OnMessageReceived;
+    }
+}

--- a/Components/Shared/MessageBoxComponent.razor
+++ b/Components/Shared/MessageBoxComponent.razor
@@ -1,0 +1,101 @@
+@using Peers.Moderno.Services.Common
+@inject IMessageBoxService MessageBoxService
+@implements IDisposable
+
+@if (mensagens.Any())
+{
+    <div class="message-container">
+        @foreach (var mensagem in mensagens)
+        {
+            <div class="alert @GetAlertClass(mensagem.Type) alert-dismissible fade show" role="alert">
+                <i class="@GetIconClass(mensagem.Type)"></i>
+                @((MarkupString)mensagem.Message)
+                <button type="button" class="close" @onclick="() => RemoverMensagem(mensagem)" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        }
+    </div>
+}
+
+@code {
+    private List<MessageBoxEventArgs> mensagens = new();
+    private Timer? timer;
+
+    protected override void OnInitialized()
+    {
+        MessageBoxService.OnMessageReceived += OnMessageReceived;
+    }
+
+    private void OnMessageReceived(MessageBoxEventArgs args)
+    {
+        mensagens.Add(args);
+        InvokeAsync(StateHasChanged);
+        
+        // Auto-remover mensagens após 5 segundos (exceto erros)
+        if (args.Type != MessageBoxType.Error)
+        {
+            timer?.Dispose();
+            timer = new Timer(_ => 
+            {
+                RemoverMensagem(args);
+                InvokeAsync(StateHasChanged);
+            }, null, TimeSpan.FromSeconds(5), Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    private void RemoverMensagem(MessageBoxEventArgs mensagem)
+    {
+        mensagens.Remove(mensagem);
+        StateHasChanged();
+    }
+
+    private string GetAlertClass(MessageBoxType type)
+    {
+        return type switch
+        {
+            MessageBoxType.Success => "alert-success",
+            MessageBoxType.Error => "alert-danger",
+            MessageBoxType.Warning => "alert-warning",
+            MessageBoxType.Info => "alert-info",
+            _ => "alert-info"
+        };
+    }
+
+    private string GetIconClass(MessageBoxType type)
+    {
+        return type switch
+        {
+            MessageBoxType.Success => "fas fa-check-circle",
+            MessageBoxType.Error => "fas fa-exclamation-triangle",
+            MessageBoxType.Warning => "fas fa-exclamation-circle",
+            MessageBoxType.Info => "fas fa-info-circle",
+            _ => "fas fa-info-circle"
+        };
+    }
+
+    public void Dispose()
+    {
+        MessageBoxService.OnMessageReceived -= OnMessageReceived;
+        timer?.Dispose();
+    }
+}
+
+<style>
+    .message-container {
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        z-index: 1050;
+        max-width: 400px;
+    }
+    
+    .alert {
+        margin-bottom: 10px;
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    }
+    
+    .alert i {
+        margin-right: 8px;
+    }
+</style>


### PR DESCRIPTION
Este PR realiza a migração da página de Competências do Web Forms para Blazor, criando componentes modulares e reutilizáveis conforme as melhores práticas. Os serviços comuns foram centralizados para facilitar a reutilização futura. Também foi criada a pasta docs para documentação técnica, incluindo explicação funcional e diagrama mermaid do fluxo de integração dos componentes. Recomenda-se revisão por engenheiros com experiência em Blazor, arquitetura de componentes e documentação técnica.