### PR TITLE
Criação da estrutura base de Frentes Internas (modelos, serviços, helpers e configuração)

### DIFF
--- a/Models/AlocacaoExportModel.cs
+++ b/Models/AlocacaoExportModel.cs
@@ -1,0 +1,20 @@
+namespace Peers.Moderno.Models;
+
+public class AlocacaoExportModel
+{
+    public int IdAvaliacaoAlocacao { get; set; }
+    public int IdAlocacaoInterna { get; set; }
+    public string AlocacaoInterna { get; set; } = string.Empty;
+    public int IdPeriodo { get; set; }
+    public string Periodo { get; set; } = string.Empty;
+    public int IdLiderAlocacao { get; set; }
+    public string LiderAlocacao { get; set; } = string.Empty;
+    public int IdAvaliado { get; set; }
+    public string Avaliado { get; set; } = string.Empty;
+    public int IdNota { get; set; }
+    public string Nota { get; set; } = string.Empty;
+    public string Comentarios { get; set; } = string.Empty;
+    public string DHCNota { get; set; } = string.Empty;
+    public string ValidadoMD { get; set; } = string.Empty;
+    public string DHCValidadoMD { get; set; } = string.Empty;
+}

--- a/Models/FrenteInternaModel.cs
+++ b/Models/FrenteInternaModel.cs
@@ -1,0 +1,16 @@
+namespace Peers.Moderno.Models;
+
+public class FrenteInternaModel
+{
+    public int IdFrenteInterna { get; set; }
+    public string FrenteInterna { get; set; } = string.Empty;
+    public int TotalLideres { get; set; }
+    public string Lideres { get; set; } = string.Empty;
+    public int ATV { get; set; }
+    public bool Ativo => ATV == 1;
+    public DateTime DHC { get; set; }
+    public int USR { get; set; }
+    
+    public List<LiderFrenteInternaModel> LideresLista { get; set; } = new();
+    public List<ParticipanteFrenteInternaModel> ParticipantesLista { get; set; } = new();
+}

--- a/Models/LiderFrenteInternaModel.cs
+++ b/Models/LiderFrenteInternaModel.cs
@@ -1,0 +1,16 @@
+namespace Peers.Moderno.Models;
+
+public class LiderFrenteInternaModel
+{
+    public int IdLiderFrenteInterna { get; set; }
+    public int IdFrenteInterna { get; set; }
+    public int IdAssociado { get; set; }
+    public string NomeAssociado { get; set; } = string.Empty;
+    public bool ATV { get; set; }
+    public string StatusTexto => ATV ? "Ativo" : "Inativo";
+    public DateTime DHC { get; set; }
+    public int USR { get; set; }
+    
+    public FrenteInternaModel? FrenteInterna { get; set; }
+    public Associado? Associado { get; set; }
+}

--- a/Models/ParticipanteFrenteInternaModel.cs
+++ b/Models/ParticipanteFrenteInternaModel.cs
@@ -1,0 +1,16 @@
+namespace Peers.Moderno.Models;
+
+public class ParticipanteFrenteInternaModel
+{
+    public int IdParticipanteFrenteInterna { get; set; }
+    public int IdFrenteInterna { get; set; }
+    public int IdAssociado { get; set; }
+    public string NomeAssociado { get; set; } = string.Empty;
+    public bool ATV { get; set; }
+    public string StatusTexto => ATV ? "Ativo" : "Inativo";
+    public DateTime DHC { get; set; }
+    public int USR { get; set; }
+    
+    public FrenteInternaModel? FrenteInterna { get; set; }
+    public Associado? Associado { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -25,6 +25,8 @@ using Peers.Moderno.Services.Eixos;
 using Peers.Moderno.Services.Eixos.Common;
 using Peers.Moderno.Services.Avaliacoes;
 using Peers.Moderno.Services.Avaliacoes.Common;
+using Peers.Moderno.Services.FrentesInternas;
+using Peers.Moderno.Services.FrentesInternas.Common;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
@@ -165,6 +167,13 @@ builder.Services.AddScoped<IEvolucaoAssociadoService, EvolucaoAssociadoService>(
 // Avaliacoes Common Services - Novos serviços adicionados
 builder.Services.AddScoped<IEmailUtils, EmailUtils>();
 builder.Services.AddScoped<IWorkflowUtils, WorkflowUtils>();
+
+// FrentesInternas Services - Novos serviços adicionados
+builder.Services.AddScoped<IFrentesInternasService, FrentesInternasService>();
+
+// FrentesInternas Common Services - Novos serviços adicionados
+builder.Services.AddScoped<IStatusHelper, StatusHelper>();
+builder.Services.AddScoped<IExportHelper, ExportHelper>();
 
 var app = builder.Build();
 

--- a/Services/FrentesInternas/Common/ExportHelper.cs
+++ b/Services/FrentesInternas/Common/ExportHelper.cs
@@ -1,0 +1,170 @@
+using OfficeOpenXml;
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Common;
+
+namespace Peers.Moderno.Services.FrentesInternas.Common;
+
+public class ExportHelper : IExportHelper
+{
+    private readonly ITelemetryService _telemetryService;
+    private const int MAX_EXPORT_RECORDS = 50000;
+
+    public ExportHelper(ITelemetryService telemetryService)
+    {
+        _telemetryService = telemetryService;
+        ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+    }
+
+    public async Task<byte[]> ExportarAvaliacoesAlocacaoAsync(List<AlocacaoExportModel> avaliacoes, string fileName)
+    {
+        try
+        {
+            if (!await ValidarDadosExportacaoAsync(avaliacoes))
+                throw new InvalidOperationException("Dados de exportação inválidos");
+
+            using var package = new ExcelPackage();
+            var worksheet = package.Workbook.Worksheets.Add("Avaliações Alocação Interna");
+
+            var headers = new string[]
+            {
+                "ID Avaliação",
+                "ID Alocação Interna",
+                "Alocação Interna",
+                "ID Período",
+                "Período",
+                "ID Líder Alocação",
+                "Líder Alocação",
+                "ID Avaliado",
+                "Avaliado",
+                "ID Nota",
+                "Nota",
+                "Comentários",
+                "Data/Hora Nota",
+                "Validado MD",
+                "Data/Hora Validado MD"
+            };
+
+            for (int i = 0; i < headers.Length; i++)
+            {
+                worksheet.Cells[1, i + 1].Value = headers[i];
+                worksheet.Cells[1, i + 1].Style.Font.Bold = true;
+            }
+
+            for (int i = 0; i < avaliacoes.Count; i++)
+            {
+                var avaliacao = avaliacoes[i];
+                var row = i + 2;
+
+                worksheet.Cells[row, 1].Value = avaliacao.IdAvaliacaoAlocacao;
+                worksheet.Cells[row, 2].Value = avaliacao.IdAlocacaoInterna;
+                worksheet.Cells[row, 3].Value = avaliacao.AlocacaoInterna;
+                worksheet.Cells[row, 4].Value = avaliacao.IdPeriodo;
+                worksheet.Cells[row, 5].Value = avaliacao.Periodo;
+                worksheet.Cells[row, 6].Value = avaliacao.IdLiderAlocacao;
+                worksheet.Cells[row, 7].Value = avaliacao.LiderAlocacao;
+                worksheet.Cells[row, 8].Value = avaliacao.IdAvaliado;
+                worksheet.Cells[row, 9].Value = avaliacao.Avaliado;
+                worksheet.Cells[row, 10].Value = avaliacao.IdNota;
+                worksheet.Cells[row, 11].Value = avaliacao.Nota;
+                worksheet.Cells[row, 12].Value = avaliacao.Comentarios;
+                worksheet.Cells[row, 13].Value = avaliacao.DHCNota;
+                worksheet.Cells[row, 14].Value = avaliacao.ValidadoMD;
+                worksheet.Cells[row, 15].Value = avaliacao.DHCValidadoMD;
+            }
+
+            worksheet.Cells[worksheet.Dimension.Address].AutoFitColumns();
+
+            _telemetryService.TrackEvent("FrentesInternas_ExportarAvaliacoes", new Dictionary<string, string>
+            {
+                { "TotalRegistros", avaliacoes.Count.ToString() },
+                { "NomeArquivo", fileName }
+            });
+
+            return await Task.FromResult(package.GetAsByteArray());
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            throw;
+        }
+    }
+
+    public async Task<byte[]> ExportarFrentesInternasAsync(List<FrenteInternaModel> frentes, string fileName)
+    {
+        try
+        {
+            if (!await ValidarDadosExportacaoAsync(frentes))
+                throw new InvalidOperationException("Dados de exportação inválidos");
+
+            using var package = new ExcelPackage();
+            var worksheet = package.Workbook.Worksheets.Add("Frentes Internas");
+
+            var headers = new string[]
+            {
+                "ID",
+                "Frente Interna",
+                "Total Líderes",
+                "Líderes",
+                "Status",
+                "Data Criação",
+                "Usuário"
+            };
+
+            for (int i = 0; i < headers.Length; i++)
+            {
+                worksheet.Cells[1, i + 1].Value = headers[i];
+                worksheet.Cells[1, i + 1].Style.Font.Bold = true;
+            }
+
+            for (int i = 0; i < frentes.Count; i++)
+            {
+                var frente = frentes[i];
+                var row = i + 2;
+
+                worksheet.Cells[row, 1].Value = frente.IdFrenteInterna;
+                worksheet.Cells[row, 2].Value = frente.FrenteInterna;
+                worksheet.Cells[row, 3].Value = frente.TotalLideres;
+                worksheet.Cells[row, 4].Value = frente.Lideres.Replace("<br/>", "; ");
+                worksheet.Cells[row, 5].Value = frente.Ativo ? "Ativo" : "Inativo";
+                worksheet.Cells[row, 6].Value = frente.DHC.ToString("dd/MM/yyyy HH:mm");
+                worksheet.Cells[row, 7].Value = frente.USR;
+            }
+
+            worksheet.Cells[worksheet.Dimension.Address].AutoFitColumns();
+
+            _telemetryService.TrackEvent("FrentesInternas_ExportarFrentes", new Dictionary<string, string>
+            {
+                { "TotalRegistros", frentes.Count.ToString() },
+                { "NomeArquivo", fileName }
+            });
+
+            return await Task.FromResult(package.GetAsByteArray());
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            throw;
+        }
+    }
+
+    public string GerarNomeArquivo(string prefixo, string extensao = ".xlsx")
+    {
+        var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+        return $"{prefixo}_{timestamp}{extensao}";
+    }
+
+    public async Task<bool> ValidarDadosExportacaoAsync<T>(List<T> dados) where T : class
+    {
+        await Task.CompletedTask;
+        
+        if (dados == null || !dados.Any())
+            return false;
+
+        if (dados.Count > MAX_EXPORT_RECORDS)
+        {
+            throw new InvalidOperationException($"Número de registros excede o limite máximo de {MAX_EXPORT_RECORDS}");
+        }
+
+        return true;
+    }
+}

--- a/Services/FrentesInternas/Common/IExportHelper.cs
+++ b/Services/FrentesInternas/Common/IExportHelper.cs
@@ -1,0 +1,11 @@
+using Peers.Moderno.Models;
+
+namespace Peers.Moderno.Services.FrentesInternas.Common;
+
+public interface IExportHelper
+{
+    Task<byte[]> ExportarAvaliacoesAlocacaoAsync(List<AlocacaoExportModel> avaliacoes, string fileName);
+    Task<byte[]> ExportarFrentesInternasAsync(List<FrenteInternaModel> frentes, string fileName);
+    string GerarNomeArquivo(string prefixo, string extensao = ".xlsx");
+    Task<bool> ValidarDadosExportacaoAsync<T>(List<T> dados) where T : class;
+}

--- a/Services/FrentesInternas/Common/IStatusHelper.cs
+++ b/Services/FrentesInternas/Common/IStatusHelper.cs
@@ -1,0 +1,18 @@
+namespace Peers.Moderno.Services.FrentesInternas.Common;
+
+public interface IStatusHelper
+{
+    string ConvertStatusToText(bool ativo);
+    string ConvertStatusToText(int status);
+    bool ConvertTextToStatus(string statusText);
+    int ConvertBoolToInt(bool ativo);
+    bool ConvertIntToBool(int status);
+    List<StatusItem> GetStatusItems();
+}
+
+public class StatusItem
+{
+    public string Value { get; set; } = string.Empty;
+    public string Text { get; set; } = string.Empty;
+    public bool Selected { get; set; }
+}

--- a/Services/FrentesInternas/Common/StatusHelper.cs
+++ b/Services/FrentesInternas/Common/StatusHelper.cs
@@ -1,0 +1,40 @@
+namespace Peers.Moderno.Services.FrentesInternas.Common;
+
+public class StatusHelper : IStatusHelper
+{
+    public string ConvertStatusToText(bool ativo)
+    {
+        return ativo ? "Ativo" : "Inativo";
+    }
+
+    public string ConvertStatusToText(int status)
+    {
+        return status == 1 ? "Ativo" : "Inativo";
+    }
+
+    public bool ConvertTextToStatus(string statusText)
+    {
+        return string.Equals(statusText, "Ativo", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(statusText, "True", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(statusText, "Verdadeiro", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public int ConvertBoolToInt(bool ativo)
+    {
+        return ativo ? 1 : 0;
+    }
+
+    public bool ConvertIntToBool(int status)
+    {
+        return status == 1;
+    }
+
+    public List<StatusItem> GetStatusItems()
+    {
+        return new List<StatusItem>
+        {
+            new StatusItem { Value = "1", Text = "Ativo", Selected = true },
+            new StatusItem { Value = "0", Text = "Inativo", Selected = false }
+        };
+    }
+}

--- a/Services/FrentesInternas/FrentesInternasService.cs
+++ b/Services/FrentesInternas/FrentesInternasService.cs
@@ -1,0 +1,481 @@
+using Microsoft.EntityFrameworkCore;
+using Peers.Moderno.Data;
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Common;
+using Peers.Moderno.Services.FrentesInternas.Common;
+
+namespace Peers.Moderno.Services.FrentesInternas;
+
+public class FrentesInternasService : IFrentesInternasService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ITelemetryService _telemetryService;
+    private readonly IStatusHelper _statusHelper;
+
+    public FrentesInternasService(
+        ApplicationDbContext context,
+        ITelemetryService telemetryService,
+        IStatusHelper statusHelper)
+    {
+        _context = context;
+        _telemetryService = telemetryService;
+        _statusHelper = statusHelper;
+    }
+
+    public async Task<List<FrenteInternaModel>> ObterFrentesInternasAsync()
+    {
+        try
+        {
+            var frentes = await _context.Set<dynamic>()
+                .FromSqlRaw(@"
+                    SELECT 
+                        fi.idFrenteInterna,
+                        fi.FrenteInterna,
+                        fi.ATV,
+                        fi.DHC,
+                        fi.USR,
+                        COUNT(DISTINCT lfi.idLiderFrenteInterna) as TotalLideres,
+                        STRING_AGG(a.Nome, '<br/>') as Lideres
+                    FROM FRENTEINTERNA fi
+                    LEFT JOIN LIDERESFRENTEINTERNA lfi ON fi.idFrenteInterna = lfi.idFrenteInterna AND lfi.ATV = 1
+                    LEFT JOIN ASSOCIADOS a ON lfi.idAssociado = a.IdAssociado
+                    GROUP BY fi.idFrenteInterna, fi.FrenteInterna, fi.ATV, fi.DHC, fi.USR
+                    ORDER BY fi.FrenteInterna")
+                .ToListAsync();
+
+            var resultado = frentes.Select(f => new FrenteInternaModel
+            {
+                IdFrenteInterna = f.idFrenteInterna,
+                FrenteInterna = f.FrenteInterna ?? string.Empty,
+                ATV = f.ATV ? 1 : 0,
+                TotalLideres = f.TotalLideres,
+                Lideres = f.Lideres ?? string.Empty,
+                DHC = f.DHC,
+                USR = f.USR
+            }).ToList();
+
+            _telemetryService.TrackEvent("FrentesInternas_ObterLista", new Dictionary<string, string>
+            {
+                { "TotalFrentes", resultado.Count.ToString() }
+            });
+
+            return resultado;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            throw;
+        }
+    }
+
+    public async Task<FrenteInternaModel?> ObterFrenteInternaAsync(int id)
+    {
+        try
+        {
+            var frente = await _context.Set<dynamic>()
+                .FromSqlRaw(@"
+                    SELECT 
+                        idFrenteInterna,
+                        FrenteInterna,
+                        ATV,
+                        DHC,
+                        USR
+                    FROM FRENTEINTERNA 
+                    WHERE idFrenteInterna = {0}", id)
+                .FirstOrDefaultAsync();
+
+            if (frente == null)
+                return null;
+
+            var resultado = new FrenteInternaModel
+            {
+                IdFrenteInterna = frente.idFrenteInterna,
+                FrenteInterna = frente.FrenteInterna ?? string.Empty,
+                ATV = frente.ATV ? 1 : 0,
+                DHC = frente.DHC,
+                USR = frente.USR
+            };
+
+            resultado.LideresLista = await ObterLideresFrenteInternaAsync(id);
+            resultado.ParticipantesLista = await ObterParticipantesFrenteInternaAsync(id);
+
+            return resultado;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            throw;
+        }
+    }
+
+    public async Task<bool> GerirFrenteInternaAsync(FrenteInternaModel frenteInterna)
+    {
+        try
+        {
+            var isUpdate = frenteInterna.IdFrenteInterna > 0;
+            
+            if (isUpdate)
+            {
+                await _context.Database.ExecuteSqlRawAsync(@"
+                    UPDATE FRENTEINTERNA 
+                    SET FrenteInterna = {0}, ATV = {1}, DHC = {2}, USR = {3}
+                    WHERE idFrenteInterna = {4}",
+                    frenteInterna.FrenteInterna,
+                    frenteInterna.Ativo,
+                    DateTime.Now,
+                    frenteInterna.USR,
+                    frenteInterna.IdFrenteInterna);
+            }
+            else
+            {
+                await _context.Database.ExecuteSqlRawAsync(@"
+                    INSERT INTO FRENTEINTERNA (FrenteInterna, ATV, DHC, USR)
+                    VALUES ({0}, {1}, {2}, {3})",
+                    frenteInterna.FrenteInterna,
+                    frenteInterna.Ativo,
+                    DateTime.Now,
+                    frenteInterna.USR);
+            }
+
+            _telemetryService.TrackEvent("FrentesInternas_Gerir", new Dictionary<string, string>
+            {
+                { "Operacao", isUpdate ? "Update" : "Insert" },
+                { "IdFrenteInterna", frenteInterna.IdFrenteInterna.ToString() }
+            });
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            return false;
+        }
+    }
+
+    public async Task<bool> ExcluirFrenteInternaAsync(int id)
+    {
+        try
+        {
+            await _context.Database.ExecuteSqlRawAsync(@"
+                UPDATE FRENTEINTERNA 
+                SET ATV = 0
+                WHERE idFrenteInterna = {0}", id);
+
+            _telemetryService.TrackEvent("FrentesInternas_Excluir", new Dictionary<string, string>
+            {
+                { "IdFrenteInterna", id.ToString() }
+            });
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            return false;
+        }
+    }
+
+    public async Task<List<LiderFrenteInternaModel>> ObterLideresFrenteInternaAsync(int idFrenteInterna)
+    {
+        try
+        {
+            var lideres = await _context.Set<dynamic>()
+                .FromSqlRaw(@"
+                    SELECT 
+                        lfi.idLiderFrenteInterna,
+                        lfi.idFrenteInterna,
+                        lfi.idAssociado,
+                        a.Nome as NomeAssociado,
+                        lfi.ATV,
+                        lfi.DHC,
+                        lfi.USR
+                    FROM LIDERESFRENTEINTERNA lfi
+                    INNER JOIN ASSOCIADOS a ON lfi.idAssociado = a.IdAssociado
+                    WHERE lfi.idFrenteInterna = {0}
+                    ORDER BY a.Nome", idFrenteInterna)
+                .ToListAsync();
+
+            return lideres.Select(l => new LiderFrenteInternaModel
+            {
+                IdLiderFrenteInterna = l.idLiderFrenteInterna,
+                IdFrenteInterna = l.idFrenteInterna,
+                IdAssociado = l.idAssociado,
+                NomeAssociado = l.NomeAssociado ?? string.Empty,
+                ATV = l.ATV,
+                DHC = l.DHC,
+                USR = l.USR
+            }).ToList();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            throw;
+        }
+    }
+
+    public async Task<bool> GerirLiderFrenteInternaAsync(LiderFrenteInternaModel lider)
+    {
+        try
+        {
+            var isUpdate = lider.IdLiderFrenteInterna > 0;
+            
+            if (isUpdate)
+            {
+                await _context.Database.ExecuteSqlRawAsync(@"
+                    UPDATE LIDERESFRENTEINTERNA 
+                    SET ATV = {0}, DHC = {1}, USR = {2}
+                    WHERE idLiderFrenteInterna = {3}",
+                    lider.ATV,
+                    DateTime.Now,
+                    lider.USR,
+                    lider.IdLiderFrenteInterna);
+            }
+            else
+            {
+                await _context.Database.ExecuteSqlRawAsync(@"
+                    INSERT INTO LIDERESFRENTEINTERNA (idFrenteInterna, idAssociado, ATV, DHC, USR)
+                    VALUES ({0}, {1}, {2}, {3}, {4})",
+                    lider.IdFrenteInterna,
+                    lider.IdAssociado,
+                    lider.ATV,
+                    DateTime.Now,
+                    lider.USR);
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            return false;
+        }
+    }
+
+    public async Task<bool> ExcluirLiderFrenteInternaAsync(int id)
+    {
+        try
+        {
+            await _context.Database.ExecuteSqlRawAsync(@"
+                UPDATE LIDERESFRENTEINTERNA 
+                SET ATV = 0
+                WHERE idLiderFrenteInterna = {0}", id);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            return false;
+        }
+    }
+
+    public async Task<List<ParticipanteFrenteInternaModel>> ObterParticipantesFrenteInternaAsync(int idFrenteInterna)
+    {
+        try
+        {
+            var participantes = await _context.Set<dynamic>()
+                .FromSqlRaw(@"
+                    SELECT 
+                        pfi.idParticipanteFrenteInterna,
+                        pfi.idFrenteInterna,
+                        pfi.idAssociado,
+                        a.Nome as NomeAssociado,
+                        pfi.ATV,
+                        pfi.DHC,
+                        pfi.USR
+                    FROM PARTICIPANTESFRENTEINTERNA pfi
+                    INNER JOIN ASSOCIADOS a ON pfi.idAssociado = a.IdAssociado
+                    WHERE pfi.idFrenteInterna = {0}
+                    ORDER BY a.Nome", idFrenteInterna)
+                .ToListAsync();
+
+            return participantes.Select(p => new ParticipanteFrenteInternaModel
+            {
+                IdParticipanteFrenteInterna = p.idParticipanteFrenteInterna,
+                IdFrenteInterna = p.idFrenteInterna,
+                IdAssociado = p.idAssociado,
+                NomeAssociado = p.NomeAssociado ?? string.Empty,
+                ATV = p.ATV,
+                DHC = p.DHC,
+                USR = p.USR
+            }).ToList();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            throw;
+        }
+    }
+
+    public async Task<bool> GerirParticipanteFrenteInternaAsync(ParticipanteFrenteInternaModel participante)
+    {
+        try
+        {
+            var isUpdate = participante.IdParticipanteFrenteInterna > 0;
+            
+            if (isUpdate)
+            {
+                await _context.Database.ExecuteSqlRawAsync(@"
+                    UPDATE PARTICIPANTESFRENTEINTERNA 
+                    SET ATV = {0}, DHC = {1}, USR = {2}
+                    WHERE idParticipanteFrenteInterna = {3}",
+                    participante.ATV,
+                    DateTime.Now,
+                    participante.USR,
+                    participante.IdParticipanteFrenteInterna);
+            }
+            else
+            {
+                await _context.Database.ExecuteSqlRawAsync(@"
+                    INSERT INTO PARTICIPANTESFRENTEINTERNA (idFrenteInterna, idAssociado, ATV, DHC, USR)
+                    VALUES ({0}, {1}, {2}, {3}, {4})",
+                    participante.IdFrenteInterna,
+                    participante.IdAssociado,
+                    participante.ATV,
+                    DateTime.Now,
+                    participante.USR);
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            return false;
+        }
+    }
+
+    public async Task<bool> ExcluirParticipanteFrenteInternaAsync(int id)
+    {
+        try
+        {
+            await _context.Database.ExecuteSqlRawAsync(@"
+                UPDATE PARTICIPANTESFRENTEINTERNA 
+                SET ATV = 0
+                WHERE idParticipanteFrenteInterna = {0}", id);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            return false;
+        }
+    }
+
+    public async Task<List<AlocacaoExportModel>> ObterAvaliacoesAlocacaoAsync()
+    {
+        try
+        {
+            var avaliacoes = await _context.Set<dynamic>()
+                .FromSqlRaw(@"
+                    SELECT 
+                        aai.idAvaliacaoAlocacaoInterna,
+                        fi.idFrenteInterna,
+                        fi.FrenteInterna,
+                        aai.idPeriodo,
+                        pa.Periodo,
+                        aai.idAvaliador,
+                        av.Nome as NomeAvaliador,
+                        aai.idAssociado,
+                        a.Nome as NomeAvaliado,
+                        aai.idNota,
+                        nai.Descricao as DescricaoNota,
+                        aai.Comentarios,
+                        aai.DHC,
+                        aai.ValidadoMD,
+                        aai.DHCValidadoMD
+                    FROM AVALIACOESALOCACOESINTERNAS aai
+                    INNER JOIN FRENTEINTERNA fi ON aai.idFrenteInterna = fi.idFrenteInterna
+                    INNER JOIN PERIODOSAVALIACOES pa ON aai.idPeriodo = pa.idPeriodo
+                    INNER JOIN ASSOCIADOS av ON aai.idAvaliador = av.IdAssociado
+                    INNER JOIN ASSOCIADOS a ON aai.idAssociado = a.IdAssociado
+                    INNER JOIN NOTASALOCACOESINTERNAS nai ON aai.idNota = nai.idNota
+                    ORDER BY aai.idPeriodo, fi.FrenteInterna, a.Nome")
+                .ToListAsync();
+
+            return avaliacoes.Select(a => new AlocacaoExportModel
+            {
+                IdAvaliacaoAlocacao = a.idAvaliacaoAlocacaoInterna,
+                IdAlocacaoInterna = a.idFrenteInterna,
+                AlocacaoInterna = a.FrenteInterna ?? string.Empty,
+                IdPeriodo = a.idPeriodo,
+                Periodo = a.Periodo ?? string.Empty,
+                IdLiderAlocacao = a.idAvaliador,
+                LiderAlocacao = a.NomeAvaliador ?? string.Empty,
+                IdAvaliado = a.idAssociado,
+                Avaliado = a.NomeAvaliado ?? string.Empty,
+                IdNota = a.idNota,
+                Nota = a.DescricaoNota ?? string.Empty,
+                Comentarios = a.Comentarios ?? string.Empty,
+                DHCNota = a.DHC.ToString(),
+                ValidadoMD = a.ValidadoMD ? "Validado" : "Pendente",
+                DHCValidadoMD = a.DHCValidadoMD?.ToString() ?? string.Empty
+            }).ToList();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            throw;
+        }
+    }
+
+    public async Task<List<int>> ObterFrentesLideradasPorAssociadoAsync(int idAssociado)
+    {
+        try
+        {
+            var frentes = await _context.Set<dynamic>()
+                .FromSqlRaw(@"
+                    SELECT DISTINCT idFrenteInterna
+                    FROM LIDERESFRENTEINTERNA
+                    WHERE idAssociado = {0} AND ATV = 1", idAssociado)
+                .ToListAsync();
+
+            return frentes.Select(f => (int)f.idFrenteInterna).ToList();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            throw;
+        }
+    }
+
+    public async Task<bool> ValidarPermissaoEdicaoAsync(int idAssociado, int? idFrenteInterna = null)
+    {
+        try
+        {
+            var perfilAssociado = await _context.Set<dynamic>()
+                .FromSqlRaw(@"
+                    SELECT IdPerfil
+                    FROM ASSOCIADOS
+                    WHERE IdAssociado = {0}", idAssociado)
+                .FirstOrDefaultAsync();
+
+            if (perfilAssociado == null)
+                return false;
+
+            if (perfilAssociado.IdPerfil >= 3)
+                return true;
+
+            if (idFrenteInterna.HasValue)
+            {
+                var frentesLideradas = await ObterFrentesLideradasPorAssociadoAsync(idAssociado);
+                return frentesLideradas.Contains(idFrenteInterna.Value);
+            }
+
+            var temFrentesLideradas = await _context.Set<dynamic>()
+                .FromSqlRaw(@"
+                    SELECT COUNT(*) as Total
+                    FROM LIDERESFRENTEINTERNA
+                    WHERE idAssociado = {0} AND ATV = 1", idAssociado)
+                .FirstOrDefaultAsync();
+
+            return temFrentesLideradas?.Total > 0;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex);
+            return false;
+        }
+    }
+}

--- a/Services/FrentesInternas/IFrentesInternasService.cs
+++ b/Services/FrentesInternas/IFrentesInternasService.cs
@@ -1,0 +1,23 @@
+using Peers.Moderno.Models;
+
+namespace Peers.Moderno.Services.FrentesInternas;
+
+public interface IFrentesInternasService
+{
+    Task<List<FrenteInternaModel>> ObterFrentesInternasAsync();
+    Task<FrenteInternaModel?> ObterFrenteInternaAsync(int id);
+    Task<bool> GerirFrenteInternaAsync(FrenteInternaModel frenteInterna);
+    Task<bool> ExcluirFrenteInternaAsync(int id);
+    
+    Task<List<LiderFrenteInternaModel>> ObterLideresFrenteInternaAsync(int idFrenteInterna);
+    Task<bool> GerirLiderFrenteInternaAsync(LiderFrenteInternaModel lider);
+    Task<bool> ExcluirLiderFrenteInternaAsync(int id);
+    
+    Task<List<ParticipanteFrenteInternaModel>> ObterParticipantesFrenteInternaAsync(int idFrenteInterna);
+    Task<bool> GerirParticipanteFrenteInternaAsync(ParticipanteFrenteInternaModel participante);
+    Task<bool> ExcluirParticipanteFrenteInternaAsync(int id);
+    
+    Task<List<AlocacaoExportModel>> ObterAvaliacoesAlocacaoAsync();
+    Task<List<int>> ObterFrentesLideradasPorAssociadoAsync(int idAssociado);
+    Task<bool> ValidarPermissaoEdicaoAsync(int idAssociado, int? idFrenteInterna = null);
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -100,6 +100,22 @@
     "CacheExpirationMinutes": 15,
     "EnableValidacaoFormato": true
   },
+  "FrentesInternas": {
+    "MaxFrenteInternaLength": 500,
+    "MaxExportRecords": 50000,
+    "MaxImportRecords": 10000,
+    "MaxFileSizeMB": 10,
+    "AllowedFileExtensions": [".xlsx", ".xls"],
+    "ExportTempPath": "temp/exports",
+    "ImportTempPath": "temp/imports",
+    "EnableValidation": true,
+    "EnableCompression": false,
+    "CacheExpirationMinutes": 30,
+    "DefaultStatus": 1,
+    "EnableAutoRedirect": true,
+    "MinPerfilEdicao": 3,
+    "EnableLiderPermissions": true
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",
@@ -109,7 +125,8 @@
       "Peers.Moderno.Services.Consolidacao": "Debug",
       "Peers.Moderno.Services.Cargos": "Debug",
       "Peers.Moderno.Services.Dashboard": "Debug",
-      "Peers.Moderno.Services.Eixos": "Debug"
+      "Peers.Moderno.Services.Eixos": "Debug",
+      "Peers.Moderno.Services.FrentesInternas": "Debug"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
Este PR implementa a estrutura inicial para a funcionalidade de Frentes Internas, seguindo o padrão de organização do projeto e as premissas de reuso e documentação. Foram criados modelos de dados, contratos de serviço, implementações de serviço, helpers reutilizáveis (StatusHelper e ExportHelper), além do registro dos serviços no DI e configuração dedicada no appsettings.json. Também foi criada uma documentação técnica em markdown na pasta docs, detalhando o funcionamento, integração e fluxo de alto nível do módulo usando diagrama mermaid.

Mudanças principais:
- Modelos: FrenteInternaModel, LiderFrenteInternaModel, ParticipanteFrenteInternaModel, AlocacaoExportModel.
- Serviços: IFrentesInternasService, FrentesInternasService.
- Helpers reutilizáveis na pasta Common: IStatusHelper/StatusHelper, IExportHelper/ExportHelper.
- Registro dos serviços no Program.cs.
- Configuração dedicada em appsettings.json.
- Documentação técnica em docs/frentes-internas.md.

Esta estrutura segue as melhores práticas para reuso, testabilidade e documentação, facilitando a evolução incremental do sistema.