### PR TITLE
Migração e arquitetura do módulo Perfis de Acesso para Blazor Híbrido com Common reutilizável

### DIFF
--- a/Components/Pages/Perfis.razor
+++ b/Components/Pages/Perfis.razor
@@ -1,0 +1,140 @@
+@page "/perfis"
+@rendermode InteractiveAuto
+@using Peers.Moderno.Services.Perfis
+@using Peers.Moderno.Services.Perfis.Common
+@using Peers.Moderno.Services.Common
+@inject IPerfisService PerfisService
+@inject IMessageBoxService MessageBoxService
+@inject IJSRuntime JSRuntime
+
+<PageTitle>Perfis de Acesso</PageTitle>
+
+<div class="page-breadcrumb border-bottom">
+    <div class="row">
+        <div class="col-lg-3 col-md-4 col-xs-12 align-self-center">
+            <h5 class="font-medium text-uppercase mb-0">Perfis de acesso</h5>
+        </div>
+        <div class="col-lg-9 col-md-8 col-xs-12 align-self-center">
+            <nav aria-label="breadcrumb" class="mt-2 float-md-right float-left">
+                <ol class="breadcrumb mb-0 justify-content-end p-0">
+                    <li class="breadcrumb-item"><a href="/">Peers</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">Cadastros Básicos de Usuário / Perfis de acesso</li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+</div>
+
+<div class="page-content container-fluid">
+    <MessageBox />
+    
+    <div class="card">
+        <div class="card-body">
+            <h4 class="card-title">Dados do perfil</h4>
+            <EditForm Model="@perfilAtual" OnValidSubmit="@SalvarPerfil">
+                <div class="form-body">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label>Perfil</label>
+                                <InputText @bind-Value="perfilAtual.Nome" class="form-control" placeholder="Digite o nome do perfil" />
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label>Status</label>
+                                <InputSelect @bind-Value="perfilAtual.Ativo" class="form-control">
+                                    @foreach (var option in statusOptions)
+                                    {
+                                        <option value="@option.Value">@option.Text</option>
+                                    }
+                                </InputSelect>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-actions">
+                    <div class="text-right">
+                        <button type="submit" class="btn btn-info" disabled="@isProcessing">
+                            @if (isProcessing)
+                            {
+                                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                <span>Processando...</span>
+                            }
+                            else
+                            {
+                                <span>@(isEditMode ? "Alterar" : "Cadastrar")</span>
+                            }
+                        </button>
+                        @if (isEditMode)
+                        {
+                            <button type="button" class="btn btn-secondary ml-2" @onclick="CancelarEdicao">
+                                Cancelar
+                            </button>
+                        }
+                    </div>
+                </div>
+            </EditForm>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-body">
+            <h4 class="card-title">Lista de perfis de acesso</h4>
+            <h6 class="card-subtitle">Filtre as informações separadas por espaço para busca em qualquer coluna em qualquer ordem, completo ou parcial: <code>perfil código</code>.</h6>
+            
+            @if (isLoading)
+            {
+                <div class="text-center p-4">
+                    <div class="spinner-border" role="status">
+                        <span class="sr-only">Carregando...</span>
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="table-responsive">
+                    <table class="table table-striped border dtInit">
+                        <thead>
+                            <tr>
+                                <th>Código</th>
+                                <th>Perfil</th>
+                                <th>Status(Ativo/Inativo)</th>
+                                <th data-sort="0">Ação</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var perfil in perfis)
+                            {
+                                <tr>
+                                    <td>@perfil.Id</td>
+                                    <td>@perfil.Nome</td>
+                                    <td>@perfil.StatusTexto</td>
+                                    <td>
+                                        <button class="btn btn-info btn-sm" @onclick="() => EditarPerfil(perfil.Id)">
+                                            Alterar
+                                        </button>
+                                        @if (perfil.Ativo)
+                                        {
+                                            <button class="btn btn-dark btn-sm ml-1" @onclick="() => InativarPerfil(perfil.Id)">
+                                                Inativar
+                                            </button>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                        <tfoot>
+                            <tr>
+                                <th>Código</th>
+                                <th>Perfil</th>
+                                <th>Status(Ativo/Inativo)</th>
+                                <th data-sort="0">Ação</th>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            }
+        </div>
+    </div>
+</div>

--- a/Components/Pages/Perfis.razor.cs
+++ b/Components/Pages/Perfis.razor.cs
@@ -1,0 +1,187 @@
+using Microsoft.AspNetCore.Components;
+using Peers.Moderno.Services.Common;
+using Peers.Moderno.Services.Perfis;
+using Peers.Moderno.Services.Perfis.Common;
+
+namespace Peers.Moderno.Components.Pages;
+
+public partial class Perfis : ComponentBase
+{
+    [Inject] private IPerfisService PerfisService { get; set; } = default!;
+    [Inject] private IMessageBoxService MessageBoxService { get; set; } = default!;
+    [Inject] private ITelemetryService TelemetryService { get; set; } = default!;
+
+    private List<PerfilDto> perfis = new();
+    private PerfilDto perfilAtual = new();
+    private List<StatusOption> statusOptions = new();
+    private bool isLoading = true;
+    private bool isProcessing = false;
+    private bool isEditMode = false;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            statusOptions = StatusHelper.GetStatusOptions();
+            await CarregarPerfis();
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "OnInitializedAsync" },
+                { "Component", "Perfis" }
+            });
+            MessageBoxService.ShowError("Erro ao carregar a página");
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private async Task CarregarPerfis()
+    {
+        try
+        {
+            perfis = await PerfisService.ListarPerfisAsync();
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "CarregarPerfis" },
+                { "Component", "Perfis" }
+            });
+            MessageBoxService.ShowError("Erro ao carregar lista de perfis");
+        }
+    }
+
+    private async Task SalvarPerfil()
+    {
+        if (string.IsNullOrWhiteSpace(perfilAtual.Nome))
+        {
+            MessageBoxService.ShowWarning("Preencha o campo Perfil");
+            return;
+        }
+
+        isProcessing = true;
+        StateHasChanged();
+
+        try
+        {
+            bool sucesso;
+            string mensagem;
+
+            if (isEditMode)
+            {
+                sucesso = await PerfisService.AlterarPerfilAsync(perfilAtual);
+                mensagem = sucesso ? "Perfil alterado com sucesso!" : "Erro ao alterar perfil. Verifique se já existe um perfil com este nome.";
+            }
+            else
+            {
+                sucesso = await PerfisService.InserirPerfilAsync(perfilAtual);
+                mensagem = sucesso ? "Perfil inserido com sucesso!" : "Erro ao inserir perfil. Verifique se já existe um perfil com este nome.";
+            }
+
+            if (sucesso)
+            {
+                MessageBoxService.ShowSuccess(mensagem);
+                await CarregarPerfis();
+                LimparFormulario();
+            }
+            else
+            {
+                MessageBoxService.ShowError(mensagem);
+            }
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "SalvarPerfil" },
+                { "Component", "Perfis" },
+                { "IsEditMode", isEditMode.ToString() },
+                { "PerfilId", perfilAtual.Id.ToString() }
+            });
+            MessageBoxService.ShowError("Erro interno ao salvar perfil");
+        }
+        finally
+        {
+            isProcessing = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task EditarPerfil(int id)
+    {
+        try
+        {
+            var perfil = await PerfisService.ObterPerfilAsync(id);
+            if (perfil != null)
+            {
+                perfilAtual = new PerfilDto
+                {
+                    Id = perfil.Id,
+                    Nome = perfil.Nome,
+                    Ativo = perfil.Ativo
+                };
+                isEditMode = true;
+                StateHasChanged();
+            }
+            else
+            {
+                MessageBoxService.ShowError("Perfil não encontrado");
+            }
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "EditarPerfil" },
+                { "Component", "Perfis" },
+                { "PerfilId", id.ToString() }
+            });
+            MessageBoxService.ShowError("Erro ao carregar perfil para edição");
+        }
+    }
+
+    private async Task InativarPerfil(int id)
+    {
+        try
+        {
+            var sucesso = await PerfisService.InativarPerfilAsync(id);
+            if (sucesso)
+            {
+                MessageBoxService.ShowSuccess("Perfil inativado com sucesso!");
+                await CarregarPerfis();
+            }
+            else
+            {
+                MessageBoxService.ShowError("Erro ao inativar perfil");
+            }
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "InativarPerfil" },
+                { "Component", "Perfis" },
+                { "PerfilId", id.ToString() }
+            });
+            MessageBoxService.ShowError("Erro interno ao inativar perfil");
+        }
+    }
+
+    private void CancelarEdicao()
+    {
+        LimparFormulario();
+    }
+
+    private void LimparFormulario()
+    {
+        perfilAtual = new PerfilDto { Ativo = true };
+        isEditMode = false;
+        StateHasChanged();
+    }
+}

--- a/Components/Shared/MessageBox.razor
+++ b/Components/Shared/MessageBox.razor
@@ -2,52 +2,53 @@
 @inject IMessageBoxService MessageBoxService
 @implements IDisposable
 
-@if (ShowMessage)
+@if (currentMessage != null)
 {
-    <div class="alert @GetAlertClass() alert-dismissible fade show" role="alert">
-        <strong>@GetAlertTitle()</strong> @CurrentMessage
-        <button type="button" class="btn-close" @onclick="HideMessage" aria-label="Close"></button>
+    <div class="alert @GetAlertClass(currentMessage.Type) alert-dismissible fade show" role="alert">
+        <strong>@GetAlertTitle(currentMessage.Type)</strong> @currentMessage.Message
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close" @onclick="DismissMessage">
+            <span aria-hidden="true">&times;</span>
+        </button>
     </div>
 }
 
 @code {
-    [Parameter] public bool AutoHide { get; set; } = true;
-    [Parameter] public int AutoHideDelay { get; set; } = 5000;
-
-    private bool ShowMessage { get; set; } = false;
-    private string CurrentMessage { get; set; } = string.Empty;
-    private MessageBoxType CurrentType { get; set; } = MessageBoxType.Info;
-    private Timer? _autoHideTimer;
+    private MessageBoxEventArgs? currentMessage;
+    private Timer? dismissTimer;
 
     protected override void OnInitialized()
     {
         MessageBoxService.OnMessageReceived += HandleMessage;
     }
 
-    private void HandleMessage(MessageBoxEventArgs args)
+    private void HandleMessage(MessageBoxEventArgs message)
     {
-        CurrentMessage = args.Message;
-        CurrentType = args.Type;
-        ShowMessage = true;
+        currentMessage = message;
         StateHasChanged();
 
-        if (AutoHide)
+        dismissTimer?.Dispose();
+        dismissTimer = new Timer(DismissMessageCallback, null, 5000, Timeout.Infinite);
+    }
+
+    private void DismissMessageCallback(object? state)
+    {
+        InvokeAsync(() =>
         {
-            _autoHideTimer?.Dispose();
-            _autoHideTimer = new Timer((_) => InvokeAsync(HideMessage), null, AutoHideDelay, Timeout.Infinite);
-        }
+            currentMessage = null;
+            StateHasChanged();
+        });
     }
 
-    private void HideMessage()
+    private void DismissMessage()
     {
-        ShowMessage = false;
-        _autoHideTimer?.Dispose();
+        dismissTimer?.Dispose();
+        currentMessage = null;
         StateHasChanged();
     }
 
-    private string GetAlertClass()
+    private string GetAlertClass(MessageBoxType type)
     {
-        return CurrentType switch
+        return type switch
         {
             MessageBoxType.Success => "alert-success",
             MessageBoxType.Error => "alert-danger",
@@ -57,9 +58,9 @@
         };
     }
 
-    private string GetAlertTitle()
+    private string GetAlertTitle(MessageBoxType type)
     {
-        return CurrentType switch
+        return type switch
         {
             MessageBoxType.Success => "Sucesso!",
             MessageBoxType.Error => "Erro!",
@@ -72,6 +73,6 @@
     public void Dispose()
     {
         MessageBoxService.OnMessageReceived -= HandleMessage;
-        _autoHideTimer?.Dispose();
+        dismissTimer?.Dispose();
     }
 }

--- a/Models/Perfil.cs
+++ b/Models/Perfil.cs
@@ -1,11 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace Peers.Moderno.Models;
 
+[Table("PERFIS")]
 public class Perfil
 {
+    [Key]
+    [Column("IdPerfil")]
     public int Id { get; set; }
+
+    [Required]
+    [MaxLength(100)]
+    [Column("Perfil")]
     public string Nome { get; set; } = string.Empty;
+
+    [Column("ATV")]
     public bool Ativo { get; set; } = true;
-    
-    // Navegação
+
+    [Column("DHC")]
+    public DateTime? DHC { get; set; }
+
     public virtual ICollection<Associado> Associados { get; set; } = new List<Associado>();
 }

--- a/Program.cs
+++ b/Program.cs
@@ -27,6 +27,7 @@ using Peers.Moderno.Services.Avaliacoes;
 using Peers.Moderno.Services.Avaliacoes.Common;
 using Peers.Moderno.Services.FrentesInternas;
 using Peers.Moderno.Services.FrentesInternas.Common;
+using Peers.Moderno.Services.Perfis;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
@@ -186,6 +187,9 @@ builder.Services.AddScoped<IFrentesInternasService, FrentesInternasService>();
 // FrentesInternas Common Services - Novos serviços adicionados
 builder.Services.AddScoped<IStatusHelper, StatusHelper>();
 builder.Services.AddScoped<IExportHelper, ExportHelper>();
+
+// Perfis Services - Novos serviços adicionados
+builder.Services.AddScoped<IPerfisService, PerfisService>();
 
 var app = builder.Build();
 

--- a/Services/Perfis/Common/PerfilDto.cs
+++ b/Services/Perfis/Common/PerfilDto.cs
@@ -1,0 +1,18 @@
+namespace Peers.Moderno.Services.Perfis.Common;
+
+public class PerfilDto
+{
+    public int Id { get; set; }
+    public string Nome { get; set; } = string.Empty;
+    public bool Ativo { get; set; } = true;
+    public DateTime? DHC { get; set; }
+    public string StatusTexto => StatusHelper.GetStatusText(Ativo);
+}
+
+public class PerfilListItemDto
+{
+    public int Id { get; set; }
+    public string Nome { get; set; } = string.Empty;
+    public string StatusTexto { get; set; } = string.Empty;
+    public bool PodeInativar { get; set; }
+}

--- a/Services/Perfis/Common/PerfisMapper.cs
+++ b/Services/Perfis/Common/PerfisMapper.cs
@@ -1,0 +1,49 @@
+using Peers.Moderno.Models;
+
+namespace Peers.Moderno.Services.Perfis.Common;
+
+public static class PerfisMapper
+{
+    public static PerfilDto ToDto(Perfil entity)
+    {
+        return new PerfilDto
+        {
+            Id = entity.Id,
+            Nome = entity.Nome,
+            Ativo = entity.Ativo,
+            DHC = entity.DHC
+        };
+    }
+
+    public static Perfil ToEntity(PerfilDto dto)
+    {
+        return new Perfil
+        {
+            Id = dto.Id,
+            Nome = dto.Nome,
+            Ativo = dto.Ativo,
+            DHC = dto.DHC ?? DateTime.Now
+        };
+    }
+
+    public static PerfilListItemDto ToListItemDto(Perfil entity)
+    {
+        return new PerfilListItemDto
+        {
+            Id = entity.Id,
+            Nome = entity.Nome,
+            StatusTexto = StatusHelper.GetStatusText(entity.Ativo),
+            PodeInativar = entity.Ativo
+        };
+    }
+
+    public static List<PerfilDto> ToDtoList(IEnumerable<Perfil> entities)
+    {
+        return entities.Select(ToDto).ToList();
+    }
+
+    public static List<PerfilListItemDto> ToListItemDtoList(IEnumerable<Perfil> entities)
+    {
+        return entities.Select(ToListItemDto).ToList();
+    }
+}

--- a/Services/Perfis/Common/StatusHelper.cs
+++ b/Services/Perfis/Common/StatusHelper.cs
@@ -1,0 +1,39 @@
+namespace Peers.Moderno.Services.Perfis.Common;
+
+public static class StatusHelper
+{
+    public static string GetStatusText(bool ativo)
+    {
+        return ativo ? "Ativo" : "Inativo";
+    }
+
+    public static bool GetStatusValue(string statusText)
+    {
+        return string.Equals(statusText, "Ativo", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static int GetStatusInt(bool ativo)
+    {
+        return ativo ? 1 : 0;
+    }
+
+    public static bool GetStatusFromInt(int status)
+    {
+        return status == 1;
+    }
+
+    public static List<StatusOption> GetStatusOptions()
+    {
+        return new List<StatusOption>
+        {
+            new StatusOption { Value = true, Text = "Ativo" },
+            new StatusOption { Value = false, Text = "Inativo" }
+        };
+    }
+}
+
+public class StatusOption
+{
+    public bool Value { get; set; }
+    public string Text { get; set; } = string.Empty;
+}

--- a/Services/Perfis/IPerfisService.cs
+++ b/Services/Perfis/IPerfisService.cs
@@ -1,0 +1,13 @@
+using Peers.Moderno.Services.Perfis.Common;
+
+namespace Peers.Moderno.Services.Perfis;
+
+public interface IPerfisService
+{
+    Task<List<PerfilDto>> ListarPerfisAsync();
+    Task<PerfilDto?> ObterPerfilAsync(int id);
+    Task<bool> InserirPerfilAsync(PerfilDto perfil);
+    Task<bool> AlterarPerfilAsync(PerfilDto perfil);
+    Task<bool> InativarPerfilAsync(int id);
+    Task<bool> ExistePerfilAsync(string nome, int? idExcluir = null);
+}

--- a/Services/Perfis/PerfisService.cs
+++ b/Services/Perfis/PerfisService.cs
@@ -1,0 +1,218 @@
+using Microsoft.EntityFrameworkCore;
+using Peers.Moderno.Data;
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Common;
+using Peers.Moderno.Services.Perfis.Common;
+
+namespace Peers.Moderno.Services.Perfis;
+
+public class PerfisService : IPerfisService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ITelemetryService _telemetryService;
+
+    public PerfisService(ApplicationDbContext context, ITelemetryService telemetryService)
+    {
+        _context = context;
+        _telemetryService = telemetryService;
+    }
+
+    public async Task<List<PerfilDto>> ListarPerfisAsync()
+    {
+        try
+        {
+            var perfis = await _context.Perfis
+                .OrderBy(p => p.Nome)
+                .ToListAsync();
+
+            var result = perfis.Select(PerfisMapper.ToDto).ToList();
+
+            _telemetryService.TrackEvent("PerfisListados", new Dictionary<string, string>
+            {
+                { "Count", result.Count.ToString() }
+            });
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ListarPerfisAsync" },
+                { "Component", "PerfisService" }
+            });
+            throw;
+        }
+    }
+
+    public async Task<PerfilDto?> ObterPerfilAsync(int id)
+    {
+        try
+        {
+            var perfil = await _context.Perfis
+                .FirstOrDefaultAsync(p => p.Id == id);
+
+            if (perfil == null)
+                return null;
+
+            var result = PerfisMapper.ToDto(perfil);
+
+            _telemetryService.TrackEvent("PerfilObtido", new Dictionary<string, string>
+            {
+                { "PerfilId", id.ToString() }
+            });
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ObterPerfilAsync" },
+                { "Component", "PerfisService" },
+                { "PerfilId", id.ToString() }
+            });
+            throw;
+        }
+    }
+
+    public async Task<bool> InserirPerfilAsync(PerfilDto perfilDto)
+    {
+        try
+        {
+            if (await ExistePerfilAsync(perfilDto.Nome))
+                return false;
+
+            var perfil = PerfisMapper.ToEntity(perfilDto);
+            perfil.DHC = DateTime.Now;
+
+            _context.Perfis.Add(perfil);
+            var result = await _context.SaveChangesAsync() > 0;
+
+            if (result)
+            {
+                _telemetryService.TrackEvent("PerfilInserido", new Dictionary<string, string>
+                {
+                    { "PerfilNome", perfilDto.Nome },
+                    { "Status", perfilDto.Ativo.ToString() }
+                });
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "InserirPerfilAsync" },
+                { "Component", "PerfisService" },
+                { "PerfilNome", perfilDto.Nome }
+            });
+            throw;
+        }
+    }
+
+    public async Task<bool> AlterarPerfilAsync(PerfilDto perfilDto)
+    {
+        try
+        {
+            if (await ExistePerfilAsync(perfilDto.Nome, perfilDto.Id))
+                return false;
+
+            var perfil = await _context.Perfis
+                .FirstOrDefaultAsync(p => p.Id == perfilDto.Id);
+
+            if (perfil == null)
+                return false;
+
+            perfil.Nome = perfilDto.Nome;
+            perfil.Ativo = perfilDto.Ativo;
+            perfil.DHC = DateTime.Now;
+
+            var result = await _context.SaveChangesAsync() > 0;
+
+            if (result)
+            {
+                _telemetryService.TrackEvent("PerfilAlterado", new Dictionary<string, string>
+                {
+                    { "PerfilId", perfilDto.Id.ToString() },
+                    { "PerfilNome", perfilDto.Nome },
+                    { "Status", perfilDto.Ativo.ToString() }
+                });
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "AlterarPerfilAsync" },
+                { "Component", "PerfisService" },
+                { "PerfilId", perfilDto.Id.ToString() }
+            });
+            throw;
+        }
+    }
+
+    public async Task<bool> InativarPerfilAsync(int id)
+    {
+        try
+        {
+            var perfil = await _context.Perfis
+                .FirstOrDefaultAsync(p => p.Id == id);
+
+            if (perfil == null)
+                return false;
+
+            perfil.Ativo = false;
+            perfil.DHC = DateTime.Now;
+
+            var result = await _context.SaveChangesAsync() > 0;
+
+            if (result)
+            {
+                _telemetryService.TrackEvent("PerfilInativado", new Dictionary<string, string>
+                {
+                    { "PerfilId", id.ToString() },
+                    { "PerfilNome", perfil.Nome }
+                });
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "InativarPerfilAsync" },
+                { "Component", "PerfisService" },
+                { "PerfilId", id.ToString() }
+            });
+            throw;
+        }
+    }
+
+    public async Task<bool> ExistePerfilAsync(string nome, int? idExcluir = null)
+    {
+        try
+        {
+            var query = _context.Perfis.Where(p => p.Nome.ToLower() == nome.ToLower());
+
+            if (idExcluir.HasValue)
+                query = query.Where(p => p.Id != idExcluir.Value);
+
+            return await query.AnyAsync();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ExistePerfilAsync" },
+                { "Component", "PerfisService" },
+                { "Nome", nome }
+            });
+            throw;
+        }
+    }
+}

--- a/docs/perfis.md
+++ b/docs/perfis.md
@@ -1,0 +1,185 @@
+# Migração de Perfis de Acesso - Web Forms para Blazor
+
+## Visão Geral
+
+Este documento descreve a migração da funcionalidade de "Perfis de Acesso" do Web Forms (`Perfis.aspx`) para Blazor Server com renderização híbrida no .NET 9.
+
+## Arquitetura
+
+### Estrutura de Pastas
+
+
+Services/Perfis/
+├── IPerfisService.cs          # Interface do serviço principal
+├── PerfisService.cs           # Implementação do serviço
+└── Common/
+    ├── PerfilDto.cs           # DTOs para transferência de dados
+    ├── StatusHelper.cs        # Helper para conversão de status
+    └── PerfisMapper.cs        # Mapeamento entre entidades e DTOs
+
+Components/
+├── Pages/
+│   ├── Perfis.razor           # Componente principal da página
+│   └── Perfis.razor.cs        # Code-behind do componente
+└── Shared/
+    └── MessageBox.razor       # Componente reutilizável para mensagens
+
+Models/
+└── Perfil.cs                  # Entidade do Entity Framework
+
+
+### Componentes Principais
+
+#### 1. IPerfisService / PerfisService
+- **Responsabilidade**: Encapsula toda a lógica de negócio relacionada aos perfis
+- **Operações**: CRUD completo (Listar, Obter, Inserir, Alterar, Inativar)
+- **Características**:
+  - Métodos assíncronos
+  - Integração com telemetria
+  - Validação de duplicatas
+  - Tratamento de exceções
+
+#### 2. DTOs e Mapeamento
+- **PerfilDto**: Objeto de transferência principal
+- **PerfilListItemDto**: DTO otimizado para listagem
+- **PerfisMapper**: Conversão entre entidades EF e DTOs
+- **StatusHelper**: Utilitários para manipulação de status
+
+#### 3. Componentes Blazor
+- **Perfis.razor**: Interface de usuário com renderização híbrida
+- **Perfis.razor.cs**: Lógica de apresentação e eventos
+- **MessageBox.razor**: Componente reutilizável para notificações
+
+## Fluxo de Alto Nível
+
+mermaid
+flowchart TD
+    A["Usuário acessa /perfis"] --> B["Perfis.razor carrega"]
+    B --> C["OnInitializedAsync()"]
+    C --> D["IPerfisService.ListarPerfisAsync()"]
+    D --> E["ApplicationDbContext consulta PERFIS"]
+    E --> F["PerfisMapper.ToDto()"]
+    F --> G["Lista renderizada na UI"]
+    
+    H["Usuário preenche formulário"] --> I["SalvarPerfil()"]
+    I --> J{"É edição?"}
+    J -->|Sim| K["IPerfisService.AlterarPerfilAsync()"]
+    J -->|Não| L["IPerfisService.InserirPerfilAsync()"]
+    K --> M["Validação de duplicatas"]
+    L --> M
+    M --> N["Entity Framework SaveChanges"]
+    N --> O["MessageBoxService.ShowSuccess()"]
+    O --> P["Recarrega lista"]
+    
+    Q["Usuário clica Alterar"] --> R["EditarPerfil(id)"]
+    R --> S["IPerfisService.ObterPerfilAsync(id)"]
+    S --> T["Preenche formulário"]
+    
+    U["Usuário clica Inativar"] --> V["InativarPerfil(id)"]
+    V --> W["IPerfisService.InativarPerfilAsync(id)"]
+    W --> X["Atualiza status para false"]
+    X --> Y["Recarrega lista"]
+
+
+## Integração com Outros Serviços
+
+### Serviços Utilizados
+
+1. **IMessageBoxService**: Exibição de notificações
+2. **ITelemetryService**: Monitoramento e logs
+3. **ApplicationDbContext**: Acesso a dados via Entity Framework
+
+### Injeção de Dependência
+
+No `Program.cs`:
+csharp
+builder.Services.AddScoped<IPerfisService, PerfisService>();
+
+
+### Configuração do Entity Framework
+
+No `ApplicationDbContext.cs`:
+csharp
+public DbSet<Perfil> Perfis { get; set; }
+
+modelBuilder.Entity<Perfil>(entity =>
+{
+    entity.HasKey(e => e.Id);
+    entity.ToTable("PERFIS");
+    entity.Property(e => e.Id).HasColumnName("IdPerfil");
+    entity.Property(e => e.Nome).HasColumnName("Perfil");
+});
+
+
+## Funcionalidades Implementadas
+
+### 1. Listagem de Perfis
+- Carregamento assíncrono
+- Exibição de código, nome e status
+- Botões de ação condicionais (Inativar apenas para ativos)
+
+### 2. Cadastro de Perfis
+- Formulário reativo com validação
+- Verificação de duplicatas
+- Feedback visual durante processamento
+
+### 3. Edição de Perfis
+- Carregamento de dados existentes
+- Modo de edição com botão cancelar
+- Validação de duplicatas excluindo o próprio registro
+
+### 4. Inativação de Perfis
+- Alteração de status sem exclusão física
+- Ocultação do botão para perfis já inativos
+- Confirmação visual da operação
+
+## Melhorias Implementadas
+
+### Em relação ao Web Forms original:
+
+1. **Performance**: Renderização híbrida Blazor
+2. **UX**: Feedback visual durante operações
+3. **Manutenibilidade**: Separação clara de responsabilidades
+4. **Testabilidade**: Serviços com interfaces e DI
+5. **Monitoramento**: Integração com Application Insights
+6. **Reutilização**: Componentes e helpers reutilizáveis
+
+## Considerações Técnicas
+
+### Renderização Híbrida
+- `@rendermode InteractiveAuto`: Combina Server e WebAssembly
+- Primeira renderização no servidor (SSR)
+- Interações subsequentes no cliente (WASM)
+
+### Tratamento de Erros
+- Try-catch em todos os métodos críticos
+- Logging via ITelemetryService
+- Mensagens amigáveis ao usuário
+
+### Validações
+- Validação de campos obrigatórios
+- Verificação de duplicatas
+- Feedback imediato na UI
+
+## Próximos Passos
+
+1. Implementar testes unitários para PerfisService
+2. Adicionar paginação para grandes volumes de dados
+3. Implementar filtros de busca avançada
+4. Considerar cache para melhor performance
+5. Adicionar auditoria de alterações
+
+## Dependências
+
+- Microsoft.EntityFrameworkCore
+- Microsoft.ApplicationInsights
+- Peers.Moderno.Services.Common (MessageBoxService, TelemetryService)
+- Peers.Moderno.Data (ApplicationDbContext)
+- Peers.Moderno.Models (Perfil)
+
+## Compatibilidade
+
+- .NET 9.0
+- Entity Framework Core 9.0
+- Blazor Server Side
+- SQL Server (via connection string configurada)


### PR DESCRIPTION
Este PR realiza a migração completa do módulo de Perfis de Acesso do Web Forms para Blazor Híbrido (.NET 9), seguindo as premissas de centralização de serviços reutilizáveis em pastas Common, criação de documentação detalhada (docs/perfis.md) e aplicação de boas práticas de arquitetura. Inclui:
- Serviços e interfaces (CRUD de Perfis)
- DTOs e mapeadores em Common para reutilização
- Helper de status reutilizável
- Componente Blazor (UI e code-behind)
- Componente compartilhado de mensagens
- Modelo EF para Perfis
- Registro de serviços no Program.cs
- Documentação técnica com fluxo mermaid

Todos os helpers e DTOs foram centralizados em Common, permitindo futura reutilização por outros módulos do sistema de avaliação interna. O fluxo de alto nível e integrações estão documentados em docs/perfis.md.

**Revisores sugeridos:** Engenheiro de Software Principal, Especialista em Blazor/.NET, Arquiteto de Software, Qualquer Membro da Equipe.

**Prioridade de revisão:** CRÍTICA

**Ordem de merge sugerida:** 1