### PR TITLE
Criação dos utilitários comuns do módulo Performance (import/export, validação e combos)

### DIFF
--- a/Services/Performance/Common/PerformanceComboHelper.cs
+++ b/Services/Performance/Common/PerformanceComboHelper.cs
@@ -1,0 +1,234 @@
+using Peers.Moderno.Services.Common;
+using Peers.Moderno.Services.Cargos;
+using Peers.Moderno.Services.Avaliacoes;
+using Peers.Moderno.Models;
+
+namespace Peers.Moderno.Services.Performance.Common;
+
+public interface IPerformanceComboHelper
+{
+    Task<List<ComboItem>> GetCargosItemsAsync();
+    List<ComboItem> GetStatusItems();
+    List<ComboItem> GetAbrangenciaItems();
+    Task<List<ComboItem>> GetNotasPadraoItemsAsync();
+    List<ComboItem> GetInputCheckboxItems();
+    Task<List<ComboItem>> GetCargosItemsAsync(bool includeInactive);
+    Task<List<ComboItem>> GetNotasPadraoItemsAsync(bool includeEmpty);
+    string GetStatusText(int status);
+    string GetAbrangenciaText(string abrangencia);
+    string GetInputText(bool input);
+}
+
+public class PerformanceComboHelper : IPerformanceComboHelper
+{
+    private readonly ICargosService _cargosService;
+    private readonly IAvaliacoesService _avaliacoesService;
+    private readonly ITelemetryService _telemetryService;
+
+    public PerformanceComboHelper(
+        ICargosService cargosService,
+        IAvaliacoesService avaliacoesService,
+        ITelemetryService telemetryService)
+    {
+        _cargosService = cargosService;
+        _avaliacoesService = avaliacoesService;
+        _telemetryService = telemetryService;
+    }
+
+    public async Task<List<ComboItem>> GetCargosItemsAsync()
+    {
+        return await GetCargosItemsAsync(false);
+    }
+
+    public async Task<List<ComboItem>> GetCargosItemsAsync(bool includeInactive)
+    {
+        try
+        {
+            var cargos = await _cargosService.ObterListaCargosAsync(includeInactive);
+            var items = new List<ComboItem>
+            {
+                new ComboItem { Value = "0", Text = "[Selecionar]" }
+            };
+
+            items.AddRange(cargos.Select(c => new ComboItem
+            {
+                Value = c.IdCargo.ToString(),
+                Text = c.Nome
+            }));
+
+            _telemetryService.TrackEvent("PerformanceCargosComboLoaded", new Dictionary<string, string>
+            {
+                { "ItemCount", (items.Count - 1).ToString() },
+                { "IncludeInactive", includeInactive.ToString() }
+            });
+
+            return items;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetCargosItemsAsync" },
+                { "Component", "PerformanceComboHelper" }
+            });
+            return new List<ComboItem> { new ComboItem { Value = "0", Text = "[Erro ao carregar]" } };
+        }
+    }
+
+    public List<ComboItem> GetStatusItems()
+    {
+        return new List<ComboItem>
+        {
+            new ComboItem { Value = "1", Text = "Ativo" },
+            new ComboItem { Value = "0", Text = "Inativo" }
+        };
+    }
+
+    public List<ComboItem> GetAbrangenciaItems()
+    {
+        return new List<ComboItem>
+        {
+            new ComboItem { Value = "Individual", Text = "Individual" },
+            new ComboItem { Value = "Coletivo", Text = "Coletivo" }
+        };
+    }
+
+    public async Task<List<ComboItem>> GetNotasPadraoItemsAsync()
+    {
+        return await GetNotasPadraoItemsAsync(true);
+    }
+
+    public async Task<List<ComboItem>> GetNotasPadraoItemsAsync(bool includeEmpty)
+    {
+        try
+        {
+            var notas = await _avaliacoesService.ObterNotasPerformanceAsync();
+            var items = new List<ComboItem>();
+
+            if (includeEmpty)
+            {
+                items.Add(new ComboItem { Value = "0", Text = "[Selecionar]" });
+            }
+
+            items.AddRange(notas.Select(n => new ComboItem
+            {
+                Value = n.IdNota.ToString(),
+                Text = n.CodigoNota
+            }));
+
+            _telemetryService.TrackEvent("PerformanceNotasComboLoaded", new Dictionary<string, string>
+            {
+                { "ItemCount", (items.Count - (includeEmpty ? 1 : 0)).ToString() },
+                { "IncludeEmpty", includeEmpty.ToString() }
+            });
+
+            return items;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetNotasPadraoItemsAsync" },
+                { "Component", "PerformanceComboHelper" }
+            });
+            return new List<ComboItem> { new ComboItem { Value = "0", Text = "[Erro ao carregar]" } };
+        }
+    }
+
+    public List<ComboItem> GetInputCheckboxItems()
+    {
+        return new List<ComboItem>
+        {
+            new ComboItem { Value = "true", Text = "Habilitado" },
+            new ComboItem { Value = "false", Text = "Desabilitado" }
+        };
+    }
+
+    public string GetStatusText(int status)
+    {
+        return status switch
+        {
+            1 => "Ativo",
+            0 => "Inativo",
+            _ => "Desconhecido"
+        };
+    }
+
+    public string GetAbrangenciaText(string abrangencia)
+    {
+        if (string.IsNullOrWhiteSpace(abrangencia))
+            return "Não informado";
+
+        return abrangencia switch
+        {
+            "Individual" => "Individual",
+            "Coletivo" => "Coletivo",
+            _ => abrangencia
+        };
+    }
+
+    public string GetInputText(bool input)
+    {
+        return input ? "Habilitado" : "Desabilitado";
+    }
+
+    public static class PerformanceComboConstants
+    {
+        public static class Status
+        {
+            public const int Ativo = 1;
+            public const int Inativo = 0;
+        }
+
+        public static class Abrangencia
+        {
+            public const string Individual = "Individual";
+            public const string Coletivo = "Coletivo";
+        }
+
+        public static class Input
+        {
+            public const bool Habilitado = true;
+            public const bool Desabilitado = false;
+        }
+
+        public static class DefaultValues
+        {
+            public const int DefaultStatus = Status.Ativo;
+            public const string DefaultAbrangencia = Abrangencia.Individual;
+            public const bool DefaultInputAutoAvaliacao = Input.Habilitado;
+            public const bool DefaultInputAvaliacaoAsCegas = Input.Habilitado;
+            public const bool DefaultInputAvaliacaoGestor = Input.Habilitado;
+        }
+    }
+
+    public static class PerformanceComboExtensions
+    {
+        public static ComboItem ToComboItem(this Cargo cargo)
+        {
+            return new ComboItem
+            {
+                Value = cargo.IdCargo.ToString(),
+                Text = cargo.Nome
+            };
+        }
+
+        public static ComboItem ToComboItem(this AvaliacaoPerformanceNota nota)
+        {
+            return new ComboItem
+            {
+                Value = nota.IdNota.ToString(),
+                Text = nota.CodigoNota
+            };
+        }
+
+        public static List<ComboItem> ToComboItems<T>(this IEnumerable<T> items, Func<T, string> valueSelector, Func<T, string> textSelector)
+        {
+            return items.Select(item => new ComboItem
+            {
+                Value = valueSelector(item),
+                Text = textSelector(item)
+            }).ToList();
+        }
+    }
+}

--- a/Services/Performance/Common/PerformanceImportExportUtil.cs
+++ b/Services/Performance/Common/PerformanceImportExportUtil.cs
@@ -1,0 +1,374 @@
+using OfficeOpenXml;
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Common;
+using System.Data;
+
+namespace Peers.Moderno.Services.Performance.Common;
+
+public interface IPerformanceImportExportUtil
+{
+    Task<byte[]> ExportPerformancesToExcelAsync(List<Performance> performances);
+    Task<PerformanceImportResult> ImportPerformancesFromExcelAsync(Stream fileStream);
+    Task<List<PerformanceExportModel>> PrepareExportDataAsync(List<Performance> performances);
+    Task<List<PerformanceImportModel>> ParseImportDataAsync(DataTable dataTable);
+    bool ValidateExcelStructure(DataTable dataTable);
+}
+
+public class PerformanceImportExportUtil : IPerformanceImportExportUtil
+{
+    private readonly ITelemetryService _telemetryService;
+    private readonly IPerformanceValidationUtil _validationUtil;
+    private readonly IPerformanceComboHelper _comboHelper;
+
+    public PerformanceImportExportUtil(
+        ITelemetryService telemetryService,
+        IPerformanceValidationUtil validationUtil,
+        IPerformanceComboHelper comboHelper)
+    {
+        _telemetryService = telemetryService;
+        _validationUtil = validationUtil;
+        _comboHelper = comboHelper;
+    }
+
+    public async Task<byte[]> ExportPerformancesToExcelAsync(List<Performance> performances)
+    {
+        try
+        {
+            var exportData = await PrepareExportDataAsync(performances);
+            
+            using var package = new ExcelPackage();
+            var worksheet = package.Workbook.Worksheets.Add("Performances");
+            
+            // Headers
+            var headers = new string[]
+            {
+                "IdPerformance", "IdCargo", "Cargo", "Performance", "DescricaoAbaixo",
+                "DescricaoEsperado", "DescricaoAcima", "ATV", "Abrangencia",
+                "InputAutoAvaliacao", "IdNotaPadraoAutoAvaliacao", "NotaPadraoAutoAvaliacao",
+                "InputAvaliacaoAsCegas", "IdNotaPadraoAvaliacaoAsCegas", "NotaPadraoAvaliacaoAsCegas",
+                "InputAvaliacaoGestor", "IdNotaPadraoAvaliacaoGestor", "NotaPadraoAvaliacaoGestor"
+            };
+            
+            for (int i = 0; i < headers.Length; i++)
+            {
+                worksheet.Cells[1, i + 1].Value = headers[i];
+                worksheet.Cells[1, i + 1].Style.Font.Bold = true;
+            }
+            
+            // Data
+            for (int row = 0; row < exportData.Count; row++)
+            {
+                var item = exportData[row];
+                var excelRow = row + 2;
+                
+                worksheet.Cells[excelRow, 1].Value = item.IdPerformance;
+                worksheet.Cells[excelRow, 2].Value = item.IdCargo;
+                worksheet.Cells[excelRow, 3].Value = item.Cargo;
+                worksheet.Cells[excelRow, 4].Value = item.Performance;
+                worksheet.Cells[excelRow, 5].Value = item.DescricaoAbaixo;
+                worksheet.Cells[excelRow, 6].Value = item.DescricaoEsperado;
+                worksheet.Cells[excelRow, 7].Value = item.DescricaoAcima;
+                worksheet.Cells[excelRow, 8].Value = item.ATV;
+                worksheet.Cells[excelRow, 9].Value = item.Abrangencia;
+                worksheet.Cells[excelRow, 10].Value = item.InputAutoAvaliacao;
+                worksheet.Cells[excelRow, 11].Value = item.IdNotaPadraoAutoAvaliacao;
+                worksheet.Cells[excelRow, 12].Value = item.NotaPadraoAutoAvaliacao;
+                worksheet.Cells[excelRow, 13].Value = item.InputAvaliacaoAsCegas;
+                worksheet.Cells[excelRow, 14].Value = item.IdNotaPadraoAvaliacaoAsCegas;
+                worksheet.Cells[excelRow, 15].Value = item.NotaPadraoAvaliacaoAsCegas;
+                worksheet.Cells[excelRow, 16].Value = item.InputAvaliacaoGestor;
+                worksheet.Cells[excelRow, 17].Value = item.IdNotaPadraoAvaliacaoGestor;
+                worksheet.Cells[excelRow, 18].Value = item.NotaPadraoAvaliacaoGestor;
+            }
+            
+            worksheet.Cells.AutoFitColumns();
+            
+            _telemetryService.TrackEvent("PerformanceExported", new Dictionary<string, string>
+            {
+                { "RecordCount", exportData.Count.ToString() },
+                { "ExportType", "Excel" }
+            });
+            
+            return package.GetAsByteArray();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ExportPerformancesToExcelAsync" },
+                { "Component", "PerformanceImportExportUtil" }
+            });
+            throw;
+        }
+    }
+
+    public async Task<PerformanceImportResult> ImportPerformancesFromExcelAsync(Stream fileStream)
+    {
+        try
+        {
+            using var package = new ExcelPackage(fileStream);
+            var worksheet = package.Workbook.Worksheets.FirstOrDefault();
+            
+            if (worksheet == null)
+            {
+                return PerformanceImportResult.Error("Planilha não encontrada");
+            }
+            
+            var dataTable = new DataTable();
+            bool hasHeader = true;
+            
+            // Create columns
+            foreach (var firstRowCell in worksheet.Cells[1, 1, 1, worksheet.Dimension.End.Column])
+            {
+                dataTable.Columns.Add(hasHeader ? firstRowCell.Text : $"Column {firstRowCell.Start.Column}");
+            }
+            
+            // Validate structure
+            if (!ValidateExcelStructure(dataTable))
+            {
+                return PerformanceImportResult.Error("Estrutura da planilha inválida");
+            }
+            
+            // Read data
+            var startRow = hasHeader ? 2 : 1;
+            for (int rowNum = startRow; rowNum <= worksheet.Dimension.End.Row; rowNum++)
+            {
+                var wsRow = worksheet.Cells[rowNum, 1, rowNum, worksheet.Dimension.End.Column];
+                DataRow row = dataTable.NewRow();
+                foreach (var cell in wsRow)
+                {
+                    row[cell.Start.Column - 1] = cell.Text;
+                }
+                dataTable.Rows.Add(row);
+            }
+            
+            var importModels = await ParseImportDataAsync(dataTable);
+            var validationResults = new List<PerformanceValidationResult>();
+            
+            foreach (var model in importModels)
+            {
+                var validation = await _validationUtil.ValidatePerformanceAsync(model.ToPerformance());
+                validationResults.Add(validation);
+            }
+            
+            var validItems = importModels.Where((model, index) => validationResults[index].IsValid).ToList();
+            var invalidItems = importModels.Where((model, index) => !validationResults[index].IsValid)
+                .Select((model, index) => new PerformanceImportError
+                {
+                    RowNumber = index + 2,
+                    ErrorMessage = validationResults.FirstOrDefault(v => !v.IsValid)?.ErrorMessage ?? "Erro desconhecido",
+                    Data = model
+                }).ToList();
+            
+            _telemetryService.TrackEvent("PerformanceImported", new Dictionary<string, string>
+            {
+                { "TotalRecords", importModels.Count.ToString() },
+                { "ValidRecords", validItems.Count.ToString() },
+                { "InvalidRecords", invalidItems.Count.ToString() }
+            });
+            
+            return PerformanceImportResult.Success(validItems, invalidItems);
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ImportPerformancesFromExcelAsync" },
+                { "Component", "PerformanceImportExportUtil" }
+            });
+            return PerformanceImportResult.Error($"Erro ao importar: {ex.Message}");
+        }
+    }
+
+    public async Task<List<PerformanceExportModel>> PrepareExportDataAsync(List<Performance> performances)
+    {
+        var exportData = new List<PerformanceExportModel>();
+        
+        foreach (var performance in performances)
+        {
+            exportData.Add(new PerformanceExportModel
+            {
+                IdPerformance = performance.IdPerformance,
+                IdCargo = performance.IdCargo,
+                Cargo = performance.Cargo?.Nome ?? "",
+                Performance = performance.Nome,
+                DescricaoAbaixo = performance.PerformanceAbaixo,
+                DescricaoEsperado = performance.PerformanceEsperado,
+                DescricaoAcima = performance.PerformanceAcima,
+                ATV = performance.Ativo ? 1 : 0,
+                Abrangencia = performance.Abrangencia,
+                InputAutoAvaliacao = performance.InputAutoavaliacao ? 1 : 0,
+                IdNotaPadraoAutoAvaliacao = performance.NotaPadraoAutoAvaliacao,
+                NotaPadraoAutoAvaliacao = performance.NotaAutoAvaliacao?.CodigoNota ?? "",
+                InputAvaliacaoAsCegas = performance.InputAvaliacaoAsCegas ? 1 : 0,
+                IdNotaPadraoAvaliacaoAsCegas = performance.NotaPadraoAvaliacaoAsCegas,
+                NotaPadraoAvaliacaoAsCegas = performance.NotaAvaliacaoAsCegas?.CodigoNota ?? "",
+                InputAvaliacaoGestor = performance.InputAvaliacaoGestor ? 1 : 0,
+                IdNotaPadraoAvaliacaoGestor = performance.NotaPadraoAvaliacaoGestor,
+                NotaPadraoAvaliacaoGestor = performance.NotaAvaliacaoGestor?.CodigoNota ?? ""
+            });
+        }
+        
+        return await Task.FromResult(exportData);
+    }
+
+    public async Task<List<PerformanceImportModel>> ParseImportDataAsync(DataTable dataTable)
+    {
+        var importModels = new List<PerformanceImportModel>();
+        
+        foreach (DataRow row in dataTable.Rows)
+        {
+            var model = new PerformanceImportModel
+            {
+                IdPerformance = ParseInt(row[0]),
+                IdCargo = ParseInt(row[1]) ?? 0,
+                Performance = ParseString(row[3]),
+                DescricaoAbaixo = ParseString(row[4]),
+                DescricaoEsperado = ParseString(row[5]),
+                DescricaoAcima = ParseString(row[6]),
+                ATV = ParseInt(row[7]) ?? 1,
+                Abrangencia = ParseString(row[8]),
+                InputAutoAvaliacao = ParseInt(row[9]) ?? 1,
+                IdNotaPadraoAutoAvaliacao = ParseInt(row[10]),
+                InputAvaliacaoAsCegas = ParseInt(row[12]) ?? 1,
+                IdNotaPadraoAvaliacaoAsCegas = ParseInt(row[13]),
+                InputAvaliacaoGestor = ParseInt(row[15]) ?? 1,
+                IdNotaPadraoAvaliacaoGestor = ParseInt(row[16])
+            };
+            
+            importModels.Add(model);
+        }
+        
+        return await Task.FromResult(importModels);
+    }
+
+    public bool ValidateExcelStructure(DataTable dataTable)
+    {
+        var requiredColumns = new string[]
+        {
+            "IdPerformance", "IdCargo", "Cargo", "Performance", "DescricaoAbaixo",
+            "DescricaoEsperado", "DescricaoAcima", "ATV", "Abrangencia"
+        };
+        
+        return requiredColumns.All(col => dataTable.Columns.Contains(col));
+    }
+
+    private int? ParseInt(object value)
+    {
+        if (value == null || value == DBNull.Value || string.IsNullOrWhiteSpace(value.ToString()))
+            return null;
+        
+        if (int.TryParse(value.ToString(), out int result))
+            return result;
+        
+        return null;
+    }
+
+    private string ParseString(object value)
+    {
+        if (value == null || value == DBNull.Value)
+            return string.Empty;
+        
+        return value.ToString()?.Trim() ?? string.Empty;
+    }
+}
+
+public class PerformanceExportModel
+{
+    public int IdPerformance { get; set; }
+    public int IdCargo { get; set; }
+    public string Cargo { get; set; } = string.Empty;
+    public string Performance { get; set; } = string.Empty;
+    public string DescricaoAbaixo { get; set; } = string.Empty;
+    public string DescricaoEsperado { get; set; } = string.Empty;
+    public string DescricaoAcima { get; set; } = string.Empty;
+    public int ATV { get; set; }
+    public string Abrangencia { get; set; } = string.Empty;
+    public int InputAutoAvaliacao { get; set; }
+    public int? IdNotaPadraoAutoAvaliacao { get; set; }
+    public string NotaPadraoAutoAvaliacao { get; set; } = string.Empty;
+    public int InputAvaliacaoAsCegas { get; set; }
+    public int? IdNotaPadraoAvaliacaoAsCegas { get; set; }
+    public string NotaPadraoAvaliacaoAsCegas { get; set; } = string.Empty;
+    public int InputAvaliacaoGestor { get; set; }
+    public int? IdNotaPadraoAvaliacaoGestor { get; set; }
+    public string NotaPadraoAvaliacaoGestor { get; set; } = string.Empty;
+}
+
+public class PerformanceImportModel
+{
+    public int? IdPerformance { get; set; }
+    public int IdCargo { get; set; }
+    public string Performance { get; set; } = string.Empty;
+    public string DescricaoAbaixo { get; set; } = string.Empty;
+    public string DescricaoEsperado { get; set; } = string.Empty;
+    public string DescricaoAcima { get; set; } = string.Empty;
+    public int ATV { get; set; }
+    public string Abrangencia { get; set; } = string.Empty;
+    public int InputAutoAvaliacao { get; set; }
+    public int? IdNotaPadraoAutoAvaliacao { get; set; }
+    public int InputAvaliacaoAsCegas { get; set; }
+    public int? IdNotaPadraoAvaliacaoAsCegas { get; set; }
+    public int InputAvaliacaoGestor { get; set; }
+    public int? IdNotaPadraoAvaliacaoGestor { get; set; }
+
+    public Performance ToPerformance()
+    {
+        return new Performance
+        {
+            IdPerformance = IdPerformance ?? 0,
+            IdCargo = IdCargo,
+            Nome = Performance,
+            PerformanceAbaixo = DescricaoAbaixo,
+            PerformanceEsperado = DescricaoEsperado,
+            PerformanceAcima = DescricaoAcima,
+            Ativo = ATV == 1,
+            Abrangencia = Abrangencia,
+            InputAutoavaliacao = InputAutoAvaliacao == 1,
+            NotaPadraoAutoAvaliacao = IdNotaPadraoAutoAvaliacao,
+            InputAvaliacaoAsCegas = InputAvaliacaoAsCegas == 1,
+            NotaPadraoAvaliacaoAsCegas = IdNotaPadraoAvaliacaoAsCegas,
+            InputAvaliacaoGestor = InputAvaliacaoGestor == 1,
+            NotaPadraoAvaliacaoGestor = IdNotaPadraoAvaliacaoGestor
+        };
+    }
+}
+
+public class PerformanceImportResult
+{
+    public bool IsSuccess { get; private set; }
+    public string ErrorMessage { get; private set; } = string.Empty;
+    public List<PerformanceImportModel> ValidItems { get; private set; } = new();
+    public List<PerformanceImportError> InvalidItems { get; private set; } = new();
+    public int TotalProcessed => ValidItems.Count + InvalidItems.Count;
+    public int ValidCount => ValidItems.Count;
+    public int InvalidCount => InvalidItems.Count;
+
+    private PerformanceImportResult() { }
+
+    public static PerformanceImportResult Success(List<PerformanceImportModel> validItems, List<PerformanceImportError> invalidItems)
+    {
+        return new PerformanceImportResult
+        {
+            IsSuccess = true,
+            ValidItems = validItems,
+            InvalidItems = invalidItems
+        };
+    }
+
+    public static PerformanceImportResult Error(string errorMessage)
+    {
+        return new PerformanceImportResult
+        {
+            IsSuccess = false,
+            ErrorMessage = errorMessage
+        };
+    }
+}
+
+public class PerformanceImportError
+{
+    public int RowNumber { get; set; }
+    public string ErrorMessage { get; set; } = string.Empty;
+    public PerformanceImportModel Data { get; set; } = new();
+}

--- a/Services/Performance/Common/PerformanceValidationUtil.cs
+++ b/Services/Performance/Common/PerformanceValidationUtil.cs
@@ -1,0 +1,285 @@
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Common;
+
+namespace Peers.Moderno.Services.Performance.Common;
+
+public interface IPerformanceValidationUtil
+{
+    Task<PerformanceValidationResult> ValidatePerformanceAsync(Performance performance);
+    Task<PerformanceValidationResult> ValidatePerformanceForInsertAsync(Performance performance);
+    Task<PerformanceValidationResult> ValidatePerformanceForUpdateAsync(Performance performance);
+    Task<PerformanceValidationResult> ValidatePerformanceForDeleteAsync(int performanceId);
+    PerformanceValidationResult ValidateRequiredFields(Performance performance);
+    PerformanceValidationResult ValidateBusinessRules(Performance performance);
+    PerformanceValidationResult ValidateNotasConsistency(Performance performance);
+    PerformanceValidationResult ValidateInputsAndNotas(Performance performance);
+    bool IsValidAbrangencia(string abrangencia);
+    bool IsValidStatus(int status);
+}
+
+public class PerformanceValidationUtil : IPerformanceValidationUtil
+{
+    private readonly ITelemetryService _telemetryService;
+    private readonly IPerformanceComboHelper _comboHelper;
+    private const int MAX_PERFORMANCE_LENGTH = 500;
+    private const int MAX_DESCRICAO_LENGTH = 2000;
+
+    public PerformanceValidationUtil(
+        ITelemetryService telemetryService,
+        IPerformanceComboHelper comboHelper)
+    {
+        _telemetryService = telemetryService;
+        _comboHelper = comboHelper;
+    }
+
+    public async Task<PerformanceValidationResult> ValidatePerformanceAsync(Performance performance)
+    {
+        try
+        {
+            var requiredFieldsResult = ValidateRequiredFields(performance);
+            if (!requiredFieldsResult.IsValid)
+                return requiredFieldsResult;
+
+            var businessRulesResult = ValidateBusinessRules(performance);
+            if (!businessRulesResult.IsValid)
+                return businessRulesResult;
+
+            var notasConsistencyResult = ValidateNotasConsistency(performance);
+            if (!notasConsistencyResult.IsValid)
+                return notasConsistencyResult;
+
+            var inputsNotasResult = ValidateInputsAndNotas(performance);
+            if (!inputsNotasResult.IsValid)
+                return inputsNotasResult;
+
+            return await Task.FromResult(PerformanceValidationResult.Success());
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidatePerformanceAsync" },
+                { "Component", "PerformanceValidationUtil" },
+                { "PerformanceId", performance?.IdPerformance.ToString() ?? "0" }
+            });
+            return PerformanceValidationResult.Error("Erro interno na validação");
+        }
+    }
+
+    public async Task<PerformanceValidationResult> ValidatePerformanceForInsertAsync(Performance performance)
+    {
+        var baseValidation = await ValidatePerformanceAsync(performance);
+        if (!baseValidation.IsValid)
+            return baseValidation;
+
+        if (performance.IdPerformance > 0)
+        {
+            return PerformanceValidationResult.Error("ID deve ser zero para inserção");
+        }
+
+        return PerformanceValidationResult.Success();
+    }
+
+    public async Task<PerformanceValidationResult> ValidatePerformanceForUpdateAsync(Performance performance)
+    {
+        var baseValidation = await ValidatePerformanceAsync(performance);
+        if (!baseValidation.IsValid)
+            return baseValidation;
+
+        if (performance.IdPerformance <= 0)
+        {
+            return PerformanceValidationResult.Error("ID deve ser maior que zero para alteração");
+        }
+
+        return PerformanceValidationResult.Success();
+    }
+
+    public async Task<PerformanceValidationResult> ValidatePerformanceForDeleteAsync(int performanceId)
+    {
+        if (performanceId <= 0)
+        {
+            return PerformanceValidationResult.Error("ID inválido para exclusão");
+        }
+
+        return await Task.FromResult(PerformanceValidationResult.Success());
+    }
+
+    public PerformanceValidationResult ValidateRequiredFields(Performance performance)
+    {
+        if (performance == null)
+        {
+            return PerformanceValidationResult.Error("Performance não pode ser nula");
+        }
+
+        if (performance.IdCargo <= 0)
+        {
+            return PerformanceValidationResult.Error("Selecione o campo Cargo");
+        }
+
+        if (string.IsNullOrWhiteSpace(performance.Nome))
+        {
+            return PerformanceValidationResult.Error("Preencha o campo Performance");
+        }
+
+        if (string.IsNullOrWhiteSpace(performance.PerformanceAbaixo))
+        {
+            return PerformanceValidationResult.Error("Preencha o campo Performance Abaixo");
+        }
+
+        if (string.IsNullOrWhiteSpace(performance.PerformanceEsperado))
+        {
+            return PerformanceValidationResult.Error("Preencha o campo Performance Esperado");
+        }
+
+        if (string.IsNullOrWhiteSpace(performance.PerformanceAcima))
+        {
+            return PerformanceValidationResult.Error("Preencha o campo Performance Acima");
+        }
+
+        if (string.IsNullOrWhiteSpace(performance.Abrangencia))
+        {
+            return PerformanceValidationResult.Error("Selecione a Abrangência");
+        }
+
+        return PerformanceValidationResult.Success();
+    }
+
+    public PerformanceValidationResult ValidateBusinessRules(Performance performance)
+    {
+        if (performance.Nome.Length > MAX_PERFORMANCE_LENGTH)
+        {
+            return PerformanceValidationResult.Error($"Performance deve ter no máximo {MAX_PERFORMANCE_LENGTH} caracteres");
+        }
+
+        if (performance.PerformanceAbaixo.Length > MAX_DESCRICAO_LENGTH)
+        {
+            return PerformanceValidationResult.Error($"Descrição Abaixo deve ter no máximo {MAX_DESCRICAO_LENGTH} caracteres");
+        }
+
+        if (performance.PerformanceEsperado.Length > MAX_DESCRICAO_LENGTH)
+        {
+            return PerformanceValidationResult.Error($"Descrição Esperado deve ter no máximo {MAX_DESCRICAO_LENGTH} caracteres");
+        }
+
+        if (performance.PerformanceAcima.Length > MAX_DESCRICAO_LENGTH)
+        {
+            return PerformanceValidationResult.Error($"Descrição Acima deve ter no máximo {MAX_DESCRICAO_LENGTH} caracteres");
+        }
+
+        if (!IsValidAbrangencia(performance.Abrangencia))
+        {
+            return PerformanceValidationResult.Error("Abrangência inválida");
+        }
+
+        return PerformanceValidationResult.Success();
+    }
+
+    public PerformanceValidationResult ValidateNotasConsistency(Performance performance)
+    {
+        // Validar consistência entre inputs e notas padrão
+        if (!performance.InputAutoavaliacao && !performance.NotaPadraoAutoAvaliacao.HasValue)
+        {
+            return PerformanceValidationResult.Error("Selecione a nota padrão para auto avaliação");
+        }
+
+        if (!performance.InputAvaliacaoAsCegas && !performance.NotaPadraoAvaliacaoAsCegas.HasValue)
+        {
+            return PerformanceValidationResult.Error("Selecione a nota padrão para avaliação às cegas");
+        }
+
+        if (!performance.InputAvaliacaoGestor && !performance.NotaPadraoAvaliacaoGestor.HasValue)
+        {
+            return PerformanceValidationResult.Error("Selecione a nota padrão para avaliação do gestor");
+        }
+
+        return PerformanceValidationResult.Success();
+    }
+
+    public PerformanceValidationResult ValidateInputsAndNotas(Performance performance)
+    {
+        // Se input está habilitado, não deve ter nota padrão
+        if (performance.InputAutoavaliacao && performance.NotaPadraoAutoAvaliacao.HasValue)
+        {
+            return PerformanceValidationResult.Error("Auto avaliação com input habilitado não deve ter nota padrão");
+        }
+
+        if (performance.InputAvaliacaoAsCegas && performance.NotaPadraoAvaliacaoAsCegas.HasValue)
+        {
+            return PerformanceValidationResult.Error("Avaliação às cegas com input habilitado não deve ter nota padrão");
+        }
+
+        if (performance.InputAvaliacaoGestor && performance.NotaPadraoAvaliacaoGestor.HasValue)
+        {
+            return PerformanceValidationResult.Error("Avaliação do gestor com input habilitado não deve ter nota padrão");
+        }
+
+        // Validar se as notas padrão existem (quando especificadas)
+        if (performance.NotaPadraoAutoAvaliacao.HasValue && performance.NotaPadraoAutoAvaliacao.Value <= 0)
+        {
+            return PerformanceValidationResult.Error("Nota padrão para auto avaliação inválida");
+        }
+
+        if (performance.NotaPadraoAvaliacaoAsCegas.HasValue && performance.NotaPadraoAvaliacaoAsCegas.Value <= 0)
+        {
+            return PerformanceValidationResult.Error("Nota padrão para avaliação às cegas inválida");
+        }
+
+        if (performance.NotaPadraoAvaliacaoGestor.HasValue && performance.NotaPadraoAvaliacaoGestor.Value <= 0)
+        {
+            return PerformanceValidationResult.Error("Nota padrão para avaliação do gestor inválida");
+        }
+
+        return PerformanceValidationResult.Success();
+    }
+
+    public bool IsValidAbrangencia(string abrangencia)
+    {
+        if (string.IsNullOrWhiteSpace(abrangencia))
+            return false;
+
+        var validAbrangencias = _comboHelper.GetAbrangenciaItems().Select(x => x.Value).ToList();
+        return validAbrangencias.Contains(abrangencia, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public bool IsValidStatus(int status)
+    {
+        return status == 0 || status == 1;
+    }
+}
+
+public class PerformanceValidationResult
+{
+    public bool IsValid { get; private set; }
+    public string ErrorMessage { get; private set; } = string.Empty;
+    public List<string> Warnings { get; private set; } = new();
+
+    private PerformanceValidationResult() { }
+
+    public static PerformanceValidationResult Success()
+    {
+        return new PerformanceValidationResult { IsValid = true };
+    }
+
+    public static PerformanceValidationResult Error(string errorMessage)
+    {
+        return new PerformanceValidationResult
+        {
+            IsValid = false,
+            ErrorMessage = errorMessage
+        };
+    }
+
+    public static PerformanceValidationResult SuccessWithWarnings(List<string> warnings)
+    {
+        return new PerformanceValidationResult
+        {
+            IsValid = true,
+            Warnings = warnings
+        };
+    }
+
+    public void AddWarning(string warning)
+    {
+        Warnings.Add(warning);
+    }
+}

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -1,0 +1,201 @@
+# Módulo Performance - Documentação Técnica
+
+## Visão Geral
+
+O módulo Performance foi modernizado seguindo os padrões estabelecidos no projeto Peers.Moderno, com foco na reutilização de código e separação de responsabilidades. Os utilitários comuns foram criados na pasta `Services/Performance/Common/` para facilitar a manutenção e permitir reutilização em outros módulos.
+
+## Arquitetura
+
+### Estrutura de Pastas
+
+
+Services/Performance/Common/
+├── PerformanceImportExportUtil.cs    # Utilitário para import/export Excel
+├── PerformanceValidationUtil.cs      # Validações de regras de negócio
+└── PerformanceComboHelper.cs         # Helper para combos e dropdowns
+
+
+### Componentes Principais
+
+#### 1. PerformanceImportExportUtil
+- **Responsabilidade**: Gerenciar importação e exportação de planilhas Excel
+- **Tecnologia**: EPPlus para manipulação de arquivos Excel
+- **Funcionalidades**:
+  - Exportação de performances para Excel com formatação
+  - Importação com validação de estrutura
+  - Parsing de dados com tratamento de erros
+  - Integração com telemetria
+
+#### 2. PerformanceValidationUtil
+- **Responsabilidade**: Centralizar todas as validações de regras de negócio
+- **Funcionalidades**:
+  - Validação de campos obrigatórios
+  - Validação de regras de negócio (tamanhos, formatos)
+  - Validação de consistência entre inputs e notas padrão
+  - Validações específicas para inserção, alteração e exclusão
+
+#### 3. PerformanceComboHelper
+- **Responsabilidade**: Gerenciar dados para combos e dropdowns
+- **Funcionalidades**:
+  - Carregamento de cargos
+  - Opções de status (Ativo/Inativo)
+  - Opções de abrangência (Individual/Coletivo)
+  - Carregamento de notas padrão
+  - Formatação de textos para exibição
+
+## Fluxo de Alto Nível
+
+mermaid
+flowchart TD
+    UI[Performance UI Component]
+    
+    UI -->|Import/Export| ImportExportUtil[PerformanceImportExportUtil]
+    UI -->|Validation| ValidationUtil[PerformanceValidationUtil]
+    UI -->|Combos/Dropdowns| ComboHelper[PerformanceComboHelper]
+    
+    ImportExportUtil -->|Excel Processing| EPPlus[EPPlus Library]
+    ImportExportUtil -->|Validation| ValidationUtil
+    ImportExportUtil -->|Telemetry| TelemetryService[ITelemetryService]
+    
+    ValidationUtil -->|Business Rules| BusinessLogic[Business Rules Engine]
+    ValidationUtil -->|Combo Validation| ComboHelper
+    ValidationUtil -->|Telemetry| TelemetryService
+    
+    ComboHelper -->|Cargos| CargosService[ICargosService]
+    ComboHelper -->|Notas| AvaliacoesService[IAvaliacoesService]
+    ComboHelper -->|Telemetry| TelemetryService
+    
+    ImportExportUtil -->|Data Models| Models[Performance Models]
+    ValidationUtil -->|Data Models| Models
+    ComboHelper -->|Data Models| Models
+    
+    Models -->|Entity Framework| Database[(Database)]
+
+
+## Integração
+
+### Injeção de Dependência
+
+Os serviços devem ser registrados no `Program.cs`:
+
+csharp
+// Performance Common Services
+builder.Services.AddScoped<IPerformanceImportExportUtil, PerformanceImportExportUtil>();
+builder.Services.AddScoped<IPerformanceValidationUtil, PerformanceValidationUtil>();
+builder.Services.AddScoped<IPerformanceComboHelper, PerformanceComboHelper>();
+
+
+### Uso nos Componentes
+
+csharp
+public class PerformanceComponent : ComponentBase
+{
+    [Inject] private IPerformanceImportExportUtil ImportExportUtil { get; set; }
+    [Inject] private IPerformanceValidationUtil ValidationUtil { get; set; }
+    [Inject] private IPerformanceComboHelper ComboHelper { get; set; }
+    
+    // Implementação do componente
+}
+
+
+## Reutilização
+
+### Padrões de Reutilização Implementados
+
+1. **Validação Centralizada**: Todas as validações ficam no `PerformanceValidationUtil`, permitindo reutilização em diferentes fluxos (inserção, alteração, importação)
+
+2. **Import/Export Padronizado**: O `PerformanceImportExportUtil` segue o mesmo padrão usado em outros módulos, facilitando manutenção
+
+3. **Combos Centralizados**: O `PerformanceComboHelper` centraliza toda a lógica de carregamento de dados para dropdowns
+
+4. **Modelos de Dados**: Uso de modelos específicos para import/export que podem ser reutilizados
+
+### Extensibilidade
+
+- **Novos Tipos de Validação**: Facilmente adicionáveis no `PerformanceValidationUtil`
+- **Novos Formatos de Export**: Extensível no `PerformanceImportExportUtil`
+- **Novos Combos**: Facilmente adicionáveis no `PerformanceComboHelper`
+
+## Segurança
+
+### Validação de Dados
+- Validação de estrutura de arquivos Excel
+- Sanitização de dados de entrada
+- Validação de tipos de dados
+- Tratamento de exceções com telemetria
+
+### Telemetria
+- Rastreamento de operações de import/export
+- Logging de erros de validação
+- Métricas de performance
+
+## Configuração
+
+### Constantes e Configurações
+
+csharp
+public static class PerformanceComboConstants
+{
+    public static class DefaultValues
+    {
+        public const int DefaultStatus = Status.Ativo;
+        public const string DefaultAbrangencia = Abrangencia.Individual;
+        public const bool DefaultInputAutoAvaliacao = Input.Habilitado;
+    }
+}
+
+
+### Limites e Validações
+
+- **MAX_PERFORMANCE_LENGTH**: 500 caracteres
+- **MAX_DESCRICAO_LENGTH**: 2000 caracteres
+- Validação de abrangência: Individual ou Coletivo
+- Validação de status: 0 (Inativo) ou 1 (Ativo)
+
+## Tratamento de Erros
+
+### Estratégias Implementadas
+
+1. **Validação Preventiva**: Validações antes de operações críticas
+2. **Tratamento de Exceções**: Try-catch com logging via telemetria
+3. **Mensagens Amigáveis**: Retorno de mensagens claras para o usuário
+4. **Rollback Automático**: Em caso de erro durante importação
+
+### Tipos de Erro
+
+- **Erros de Validação**: Campos obrigatórios, formatos inválidos
+- **Erros de Negócio**: Inconsistências de dados, regras violadas
+- **Erros de Sistema**: Problemas de acesso a dados, falhas de rede
+- **Erros de Arquivo**: Estrutura inválida, formato não suportado
+
+## Performance
+
+### Otimizações Implementadas
+
+1. **Carregamento Assíncrono**: Operações de I/O são assíncronas
+2. **Cache de Combos**: Dados de combos podem ser cacheados
+3. **Validação em Lote**: Importações validam múltiplos registros eficientemente
+4. **Streaming de Arquivos**: Processamento de arquivos grandes sem carregar tudo na memória
+
+### Métricas
+
+- Tempo de processamento de importação/exportação
+- Número de registros processados
+- Taxa de erro por operação
+- Uso de memória durante processamento
+
+## Manutenção
+
+### Pontos de Atenção
+
+1. **Dependências**: EPPlus, Entity Framework, serviços de telemetria
+2. **Versionamento**: Compatibilidade com versões anteriores dos arquivos Excel
+3. **Testes**: Cobertura de testes para todos os cenários de validação
+4. **Documentação**: Manter documentação atualizada com mudanças
+
+### Evolução Futura
+
+- Suporte a outros formatos de arquivo (CSV, JSON)
+- Validações mais sofisticadas com IA
+- Cache distribuído para ambientes de alta disponibilidade
+- Processamento assíncrono para importações grandes


### PR DESCRIPTION
Este PR implementa os utilitários comuns do módulo Performance, centralizando lógicas reutilizáveis em Services/Performance/Common. Foram incluídos: (1) PerformanceImportExportUtil para importação/exportação de dados em Excel, (2) PerformanceValidationUtil para validação de regras de negócio e campos obrigatórios, e (3) PerformanceComboHelper para gerenciamento de combos e dropdowns. Também foi criada documentação técnica detalhada em docs/Performance.md, incluindo fluxo mermaid de alto nível. Todas as implementações seguem o padrão de reutilização e separação de responsabilidades, facilitando manutenção e extensão futura.