### PR TITLE
Implementação dos serviços de Projetos, utilitários reutilizáveis e documentação técnica

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -40,6 +40,11 @@ public class ApplicationDbContext : DbContext
     
     // Novo DbSet para Prazos
     public DbSet<Prazo> Prazos { get; set; }
+    
+    // Novos DbSets para Projetos
+    public DbSet<Projeto> Projetos { get; set; }
+    public DbSet<AssociadoProjeto> AssociadosProjetos { get; set; }
+    public DbSet<TipoProjeto> TiposProjetos { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -294,6 +299,72 @@ public class ApplicationDbContext : DbContext
                 
             entity.Property(e => e.DHC)
                 .HasDefaultValueSql("GETUTCDATE()");
+        });
+
+        // Configurações das entidades de Projetos
+        modelBuilder.Entity<Projeto>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.ToTable("PROJETOS");
+            entity.Property(e => e.Id).HasColumnName("IdProjeto");
+            
+            entity.HasOne(d => d.Cliente)
+                .WithMany()
+                .HasForeignKey(d => d.IdCliente)
+                .OnDelete(DeleteBehavior.Restrict);
+                
+            entity.HasOne(d => d.AssociadoResponsavel)
+                .WithMany()
+                .HasForeignKey(d => d.IdAssociadoResponsavel)
+                .OnDelete(DeleteBehavior.Restrict);
+                
+            entity.HasOne(d => d.AssociadoGestor)
+                .WithMany()
+                .HasForeignKey(d => d.IdAssociadoGestor)
+                .OnDelete(DeleteBehavior.Restrict);
+                
+            entity.HasOne(d => d.TipoProjeto)
+                .WithMany()
+                .HasForeignKey(d => d.IdTipoProjeto)
+                .OnDelete(DeleteBehavior.Restrict);
+                
+            entity.HasOne(d => d.Complexidade)
+                .WithMany()
+                .HasForeignKey(d => d.IdComplexidade)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<AssociadoProjeto>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.ToTable("ASSOCIADOS_PROJETOS");
+            
+            entity.HasOne(d => d.Projeto)
+                .WithMany(p => p.AssociadosProjeto)
+                .HasForeignKey(d => d.IdProjeto)
+                .OnDelete(DeleteBehavior.Restrict);
+                
+            entity.HasOne(d => d.Associado)
+                .WithMany()
+                .HasForeignKey(d => d.IdAssociado)
+                .OnDelete(DeleteBehavior.Restrict);
+                
+            entity.HasOne(d => d.CargoProjeto)
+                .WithMany()
+                .HasForeignKey(d => d.IdCargoProjeto)
+                .OnDelete(DeleteBehavior.Restrict);
+                
+            entity.HasOne(d => d.Avaliador)
+                .WithMany()
+                .HasForeignKey(d => d.IdAvaliador)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<TipoProjeto>(entity =>
+        {
+            entity.HasKey(e => e.IdTipo);
+            entity.ToTable("TIPOS_PROJETOS");
+            entity.Property(e => e.Nome).HasColumnName("ProjetoTipo");
         });
     }
 }

--- a/Models/Projeto.cs
+++ b/Models/Projeto.cs
@@ -1,0 +1,119 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Peers.Moderno.Models;
+
+[Table("PROJETOS")]
+public class Projeto
+{
+    [Key]
+    public int Id { get; set; }
+    
+    [Required]
+    [MaxLength(100)]
+    public string Codigo { get; set; } = string.Empty;
+    
+    [Required]
+    [MaxLength(500)]
+    public string Nome { get; set; } = string.Empty;
+    
+    public DateTime? DataInicio { get; set; }
+    
+    public DateTime? DataFim { get; set; }
+    
+    public int? IdCliente { get; set; }
+    
+    public int? IdAssociadoResponsavel { get; set; }
+    
+    public int? IdAssociadoGestor { get; set; }
+    
+    public int? IdTipoProjeto { get; set; }
+    
+    public int? IdComplexidade { get; set; }
+    
+    public bool Ativo { get; set; } = true;
+    
+    public int? UsuarioCriacao { get; set; }
+    
+    public DateTime? DataCriacao { get; set; }
+    
+    public int? UsuarioAlteracao { get; set; }
+    
+    public DateTime? DataAlteracao { get; set; }
+    
+    [MaxLength(1000)]
+    public string? Observacoes { get; set; }
+    
+    // Navigation Properties
+    [ForeignKey("IdCliente")]
+    public virtual Cliente? Cliente { get; set; }
+    
+    [ForeignKey("IdAssociadoResponsavel")]
+    public virtual Associado? AssociadoResponsavel { get; set; }
+    
+    [ForeignKey("IdAssociadoGestor")]
+    public virtual Associado? AssociadoGestor { get; set; }
+    
+    [ForeignKey("IdTipoProjeto")]
+    public virtual TipoProjeto? TipoProjeto { get; set; }
+    
+    [ForeignKey("IdComplexidade")]
+    public virtual ProjetoComplexidade? Complexidade { get; set; }
+    
+    public virtual ICollection<AssociadoProjeto> AssociadosProjeto { get; set; } = new List<AssociadoProjeto>();
+}
+
+[Table("ASSOCIADOS_PROJETOS")]
+public class AssociadoProjeto
+{
+    [Key]
+    public int Id { get; set; }
+    
+    public int IdProjeto { get; set; }
+    
+    public int IdAssociado { get; set; }
+    
+    public DateTime DataInicio { get; set; }
+    
+    public DateTime? DataFim { get; set; }
+    
+    public bool Ativo { get; set; } = true;
+    
+    public int? IdCargoProjeto { get; set; }
+    
+    public int? IdAvaliador { get; set; }
+    
+    // Navigation Properties
+    [ForeignKey("IdProjeto")]
+    public virtual Projeto Projeto { get; set; } = null!;
+    
+    [ForeignKey("IdAssociado")]
+    public virtual Associado Associado { get; set; } = null!;
+    
+    [ForeignKey("IdCargoProjeto")]
+    public virtual Cargo? CargoProjeto { get; set; }
+    
+    [ForeignKey("IdAvaliador")]
+    public virtual Associado? Avaliador { get; set; }
+}
+
+[Table("TIPOS_PROJETOS")]
+public class TipoProjeto
+{
+    [Key]
+    public int IdTipo { get; set; }
+    
+    [Required]
+    [MaxLength(500)]
+    public string Nome { get; set; } = string.Empty;
+    
+    public bool Ativo { get; set; } = true;
+    
+    public int? UsuarioCriacao { get; set; }
+    
+    public DateTime? DataCriacao { get; set; }
+    
+    public int? UsuarioAlteracao { get; set; }
+    
+    public DateTime? DataAlteracao { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -34,6 +34,8 @@ using Peers.Moderno.Services.Prazos;
 using Peers.Moderno.Services.Prazos.Common;
 using Peers.Moderno.Services.Premissas;
 using Peers.Moderno.Services.Premissas.Common;
+using Peers.Moderno.Services.Projetos;
+using Peers.Moderno.Services.Projetos.Common;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
@@ -213,6 +215,12 @@ builder.Services.AddScoped<IPrazosService, PrazosService>();
 
 // Prazos Common Services - Novos serviços adicionados
 builder.Services.AddScoped<IPrazosValidationHelper, PrazosValidationHelper>();
+
+// Projetos Services - Novos serviços adicionados
+builder.Services.AddScoped<IProjetosService, ProjetosService>();
+
+// Projetos Common Services - Novos serviços adicionados
+builder.Services.AddScoped<IProjetosComboHelper, ProjetosComboHelper>();
 
 var app = builder.Build();
 

--- a/Services/Projetos/Common/ProjetosComboHelper.cs
+++ b/Services/Projetos/Common/ProjetosComboHelper.cs
@@ -1,0 +1,318 @@
+using Microsoft.EntityFrameworkCore;
+using Peers.Moderno.Data;
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Common;
+
+namespace Peers.Moderno.Services.Projetos.Common;
+
+public interface IProjetosComboHelper
+{
+    Task<List<ComboItem>> GetClientesAsync();
+    Task<List<ComboItem>> GetClientesAsync(bool incluirSelecionar);
+    Task<List<ComboItem>> GetGestoresAsync();
+    Task<List<ComboItem>> GetGestoresAsync(bool incluirSelecionar);
+    Task<List<ComboItem>> GetResponsaveisAsync();
+    Task<List<ComboItem>> GetResponsaveisAsync(bool incluirSelecionar);
+    Task<List<ComboItem>> GetTiposProjetoAsync();
+    Task<List<ComboItem>> GetTiposProjetoAsync(bool incluirSelecionar);
+    Task<List<ComboItem>> GetComplexidadesAsync();
+    Task<List<ComboItem>> GetComplexidadesAsync(bool incluirSelecionar);
+    Task<List<ComboItem>> GetAssociadosAsync();
+    Task<List<ComboItem>> GetAssociadosAsync(bool incluirSelecionar);
+    Task<List<ComboItem>> GetAssociadosAsync(bool incluirSelecionar, bool apenasAtivos);
+    Task<List<ComboItem>> GetStatusProjetoAsync();
+    Task<List<ComboItem>> GetAssociadosPorPerfilAsync(int idPerfil);
+    Task<List<ComboItem>> GetAssociadosPorPerfilAsync(int idPerfil, bool incluirSelecionar);
+}
+
+public class ProjetosComboHelper : IProjetosComboHelper
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ITelemetryService _telemetryService;
+
+    public ProjetosComboHelper(
+        ApplicationDbContext context,
+        ITelemetryService telemetryService)
+    {
+        _context = context;
+        _telemetryService = telemetryService;
+    }
+
+    public async Task<List<ComboItem>> GetClientesAsync()
+    {
+        return await GetClientesAsync(true);
+    }
+
+    public async Task<List<ComboItem>> GetClientesAsync(bool incluirSelecionar)
+    {
+        try
+        {
+            var clientes = await _context.Clientes
+                .Where(c => c.Ativo)
+                .OrderBy(c => c.Nome)
+                .Select(c => new ComboItem
+                {
+                    Value = c.IdCliente.ToString(),
+                    Text = c.Nome
+                })
+                .ToListAsync();
+
+            if (incluirSelecionar)
+            {
+                clientes.Insert(0, new ComboItem { Value = "", Text = "[Selecionar]" });
+            }
+
+            _telemetryService.TrackEvent("ClientesComboCarregado", new Dictionary<string, string>
+            {
+                { "TotalClientes", clientes.Count.ToString() },
+                { "IncluirSelecionar", incluirSelecionar.ToString() }
+            });
+
+            return clientes;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetClientesAsync" },
+                { "Component", "ProjetosComboHelper" }
+            });
+            return incluirSelecionar ? new List<ComboItem> { new ComboItem { Value = "", Text = "[Selecionar]" } } : new List<ComboItem>();
+        }
+    }
+
+    public async Task<List<ComboItem>> GetGestoresAsync()
+    {
+        return await GetGestoresAsync(true);
+    }
+
+    public async Task<List<ComboItem>> GetGestoresAsync(bool incluirSelecionar)
+    {
+        return await GetAssociadosPorPerfilAsync(2, incluirSelecionar);
+    }
+
+    public async Task<List<ComboItem>> GetResponsaveisAsync()
+    {
+        return await GetResponsaveisAsync(true);
+    }
+
+    public async Task<List<ComboItem>> GetResponsaveisAsync(bool incluirSelecionar)
+    {
+        return await GetAssociadosPorPerfilAsync(3, incluirSelecionar);
+    }
+
+    public async Task<List<ComboItem>> GetTiposProjetoAsync()
+    {
+        return await GetTiposProjetoAsync(true);
+    }
+
+    public async Task<List<ComboItem>> GetTiposProjetoAsync(bool incluirSelecionar)
+    {
+        try
+        {
+            var tipos = await _context.TiposProjetos
+                .Where(t => t.Ativo)
+                .OrderBy(t => t.Nome)
+                .Select(t => new ComboItem
+                {
+                    Value = t.IdTipo.ToString(),
+                    Text = t.Nome
+                })
+                .ToListAsync();
+
+            if (incluirSelecionar)
+            {
+                tipos.Insert(0, new ComboItem { Value = "", Text = "[Selecionar]" });
+            }
+
+            _telemetryService.TrackEvent("TiposProjetoComboCarregado", new Dictionary<string, string>
+            {
+                { "TotalTipos", tipos.Count.ToString() },
+                { "IncluirSelecionar", incluirSelecionar.ToString() }
+            });
+
+            return tipos;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetTiposProjetoAsync" },
+                { "Component", "ProjetosComboHelper" }
+            });
+            return incluirSelecionar ? new List<ComboItem> { new ComboItem { Value = "", Text = "[Selecionar]" } } : new List<ComboItem>();
+        }
+    }
+
+    public async Task<List<ComboItem>> GetComplexidadesAsync()
+    {
+        return await GetComplexidadesAsync(true);
+    }
+
+    public async Task<List<ComboItem>> GetComplexidadesAsync(bool incluirSelecionar)
+    {
+        try
+        {
+            var complexidades = await _context.ProjetosComplexidades
+                .Where(c => c.Ativo)
+                .OrderBy(c => c.Nome)
+                .Select(c => new ComboItem
+                {
+                    Value = c.IdComplexidade.ToString(),
+                    Text = c.Nome
+                })
+                .ToListAsync();
+
+            if (incluirSelecionar)
+            {
+                complexidades.Insert(0, new ComboItem { Value = "", Text = "[Selecionar]" });
+            }
+
+            _telemetryService.TrackEvent("ComplexidadesComboCarregado", new Dictionary<string, string>
+            {
+                { "TotalComplexidades", complexidades.Count.ToString() },
+                { "IncluirSelecionar", incluirSelecionar.ToString() }
+            });
+
+            return complexidades;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetComplexidadesAsync" },
+                { "Component", "ProjetosComboHelper" }
+            });
+            return incluirSelecionar ? new List<ComboItem> { new ComboItem { Value = "", Text = "[Selecionar]" } } : new List<ComboItem>();
+        }
+    }
+
+    public async Task<List<ComboItem>> GetAssociadosAsync()
+    {
+        return await GetAssociadosAsync(true, true);
+    }
+
+    public async Task<List<ComboItem>> GetAssociadosAsync(bool incluirSelecionar)
+    {
+        return await GetAssociadosAsync(incluirSelecionar, true);
+    }
+
+    public async Task<List<ComboItem>> GetAssociadosAsync(bool incluirSelecionar, bool apenasAtivos)
+    {
+        try
+        {
+            var query = _context.Associados.AsQueryable();
+
+            if (apenasAtivos)
+            {
+                query = query.Where(a => a.Ativo);
+            }
+
+            var associados = await query
+                .OrderBy(a => a.Nome)
+                .Select(a => new ComboItem
+                {
+                    Value = a.Id.ToString(),
+                    Text = a.Nome
+                })
+                .ToListAsync();
+
+            if (incluirSelecionar)
+            {
+                associados.Insert(0, new ComboItem { Value = "", Text = "[Selecionar]" });
+            }
+
+            _telemetryService.TrackEvent("AssociadosComboCarregado", new Dictionary<string, string>
+            {
+                { "TotalAssociados", associados.Count.ToString() },
+                { "IncluirSelecionar", incluirSelecionar.ToString() },
+                { "ApenasAtivos", apenasAtivos.ToString() }
+            });
+
+            return associados;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetAssociadosAsync" },
+                { "Component", "ProjetosComboHelper" }
+            });
+            return incluirSelecionar ? new List<ComboItem> { new ComboItem { Value = "", Text = "[Selecionar]" } } : new List<ComboItem>();
+        }
+    }
+
+    public async Task<List<ComboItem>> GetStatusProjetoAsync()
+    {
+        try
+        {
+            var statusList = new List<ComboItem>
+            {
+                new ComboItem { Value = "", Text = "[Selecionar]" },
+                new ComboItem { Value = "1", Text = "Ativo" },
+                new ComboItem { Value = "0", Text = "Inativo" }
+            };
+
+            _telemetryService.TrackEvent("StatusProjetoComboCarregado", new Dictionary<string, string>
+            {
+                { "TotalStatus", statusList.Count.ToString() }
+            });
+
+            return statusList;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetStatusProjetoAsync" },
+                { "Component", "ProjetosComboHelper" }
+            });
+            return new List<ComboItem> { new ComboItem { Value = "", Text = "[Selecionar]" } };
+        }
+    }
+
+    public async Task<List<ComboItem>> GetAssociadosPorPerfilAsync(int idPerfil)
+    {
+        return await GetAssociadosPorPerfilAsync(idPerfil, true);
+    }
+
+    public async Task<List<ComboItem>> GetAssociadosPorPerfilAsync(int idPerfil, bool incluirSelecionar)
+    {
+        try
+        {
+            var associados = await _context.Associados
+                .Where(a => a.IdPerfil == idPerfil && a.Ativo)
+                .OrderBy(a => a.Nome)
+                .Select(a => new ComboItem
+                {
+                    Value = a.Id.ToString(),
+                    Text = a.Nome
+                })
+                .ToListAsync();
+
+            if (incluirSelecionar)
+            {
+                associados.Insert(0, new ComboItem { Value = "", Text = "[Selecionar]" });
+            }
+
+            _telemetryService.TrackEvent("AssociadosPorPerfilComboCarregado", new Dictionary<string, string>
+            {
+                { "PerfilId", idPerfil.ToString() },
+                { "TotalAssociados", associados.Count.ToString() },
+                { "IncluirSelecionar", incluirSelecionar.ToString() }
+            });
+
+            return associados;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetAssociadosPorPerfilAsync" },
+                { "Component", "ProjetosComboHelper" },
+                { "PerfilId", idPerfil.ToString() }
+            });
+            return incluirSelecionar ? new List<ComboItem> { new ComboItem { Value = "", Text = "[Selecionar]" } } : new List<ComboItem>();
+        }
+    }
+}

--- a/Services/Projetos/ProjetosService.cs
+++ b/Services/Projetos/ProjetosService.cs
@@ -1,0 +1,582 @@
+using Microsoft.EntityFrameworkCore;
+using Peers.Moderno.Data;
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Common;
+
+namespace Peers.Moderno.Services.Projetos;
+
+public interface IProjetosService
+{
+    Task<List<Projeto>> ObterProjetosAsync();
+    Task<List<Projeto>> ObterProjetosAsync(bool apenasAtivos);
+    Task<Projeto?> ObterProjetoAsync(int idProjeto);
+    Task<bool> InserirProjetoAsync(Projeto projeto);
+    Task<bool> AtualizarProjetoAsync(Projeto projeto);
+    Task<bool> RemoverProjetoAsync(int idProjeto);
+    Task<bool> InativarProjetoAsync(int idProjeto);
+    Task<bool> AtivarProjetoAsync(int idProjeto);
+    Task<List<Projeto>> ObterProjetosPorClienteAsync(int idCliente);
+    Task<List<Projeto>> ObterProjetosPorResponsavelAsync(int idResponsavel);
+    Task<List<Projeto>> ObterProjetosPorGestorAsync(int idGestor);
+    Task<bool> AdicionarAssociadoProjetoAsync(int idProjeto, int idAssociado, DateTime dataInicio, DateTime? dataFim = null);
+    Task<bool> RemoverAssociadoProjetoAsync(int idProjeto, int idAssociado);
+    Task<List<Associado>> ObterAssociadosProjetoAsync(int idProjeto);
+    Task<bool> ProjetoExisteAsync(string codigo);
+    Task<bool> ValidarPeriodoProjetoAsync(DateTime dataInicio, DateTime dataFim);
+}
+
+public class ProjetosService : IProjetosService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ITelemetryService _telemetryService;
+    private readonly IMessageBoxService _messageBoxService;
+    private readonly IUserContextService _userContextService;
+
+    public ProjetosService(
+        ApplicationDbContext context,
+        ITelemetryService telemetryService,
+        IMessageBoxService messageBoxService,
+        IUserContextService userContextService)
+    {
+        _context = context;
+        _telemetryService = telemetryService;
+        _messageBoxService = messageBoxService;
+        _userContextService = userContextService;
+    }
+
+    public async Task<List<Projeto>> ObterProjetosAsync()
+    {
+        return await ObterProjetosAsync(false);
+    }
+
+    public async Task<List<Projeto>> ObterProjetosAsync(bool apenasAtivos)
+    {
+        try
+        {
+            var query = _context.Projetos
+                .Include(p => p.Cliente)
+                .Include(p => p.AssociadoResponsavel)
+                .Include(p => p.AssociadoGestor)
+                .Include(p => p.TipoProjeto)
+                .Include(p => p.Complexidade)
+                .AsQueryable();
+
+            if (apenasAtivos)
+            {
+                query = query.Where(p => p.Ativo);
+            }
+
+            var projetos = await query.OrderBy(p => p.Nome).ToListAsync();
+
+            _telemetryService.TrackEvent("ProjetosListados", new Dictionary<string, string>
+            {
+                { "TotalProjetos", projetos.Count.ToString() },
+                { "ApenasAtivos", apenasAtivos.ToString() }
+            });
+
+            return projetos;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ObterProjetosAsync" },
+                { "Component", "ProjetosService" }
+            });
+            return new List<Projeto>();
+        }
+    }
+
+    public async Task<Projeto?> ObterProjetoAsync(int idProjeto)
+    {
+        try
+        {
+            var projeto = await _context.Projetos
+                .Include(p => p.Cliente)
+                .Include(p => p.AssociadoResponsavel)
+                .Include(p => p.AssociadoGestor)
+                .Include(p => p.TipoProjeto)
+                .Include(p => p.Complexidade)
+                .Include(p => p.AssociadosProjeto)
+                    .ThenInclude(ap => ap.Associado)
+                .FirstOrDefaultAsync(p => p.Id == idProjeto);
+
+            if (projeto != null)
+            {
+                _telemetryService.TrackEvent("ProjetoObtido", new Dictionary<string, string>
+                {
+                    { "ProjetoId", idProjeto.ToString() },
+                    { "ProjetoNome", projeto.Nome }
+                });
+            }
+
+            return projeto;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ObterProjetoAsync" },
+                { "Component", "ProjetosService" },
+                { "ProjetoId", idProjeto.ToString() }
+            });
+            return null;
+        }
+    }
+
+    public async Task<bool> InserirProjetoAsync(Projeto projeto)
+    {
+        try
+        {
+            if (!await ValidarProjetoAsync(projeto))
+            {
+                return false;
+            }
+
+            var usuario = await _userContextService.GetUsuarioLogadoAsync();
+            if (usuario != null)
+            {
+                projeto.UsuarioCriacao = usuario.Id;
+                projeto.DataCriacao = DateTime.Now;
+            }
+
+            _context.Projetos.Add(projeto);
+            var result = await _context.SaveChangesAsync() > 0;
+
+            if (result)
+            {
+                _messageBoxService.ShowSuccess("Projeto cadastrado com sucesso!");
+                _telemetryService.TrackEvent("ProjetoInserido", new Dictionary<string, string>
+                {
+                    { "ProjetoId", projeto.Id.ToString() },
+                    { "ProjetoNome", projeto.Nome },
+                    { "UsuarioId", usuario?.Id.ToString() ?? "Unknown" }
+                });
+            }
+            else
+            {
+                _messageBoxService.ShowError("Erro ao cadastrar projeto");
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "InserirProjetoAsync" },
+                { "Component", "ProjetosService" },
+                { "ProjetoNome", projeto?.Nome ?? "Unknown" }
+            });
+            _messageBoxService.ShowError("Erro interno ao cadastrar projeto");
+            return false;
+        }
+    }
+
+    public async Task<bool> AtualizarProjetoAsync(Projeto projeto)
+    {
+        try
+        {
+            if (!await ValidarProjetoAsync(projeto))
+            {
+                return false;
+            }
+
+            var projetoExistente = await _context.Projetos.FindAsync(projeto.Id);
+            if (projetoExistente == null)
+            {
+                _messageBoxService.ShowError("Projeto não encontrado");
+                return false;
+            }
+
+            var usuario = await _userContextService.GetUsuarioLogadoAsync();
+            if (usuario != null)
+            {
+                projeto.UsuarioAlteracao = usuario.Id;
+                projeto.DataAlteracao = DateTime.Now;
+            }
+
+            _context.Entry(projetoExistente).CurrentValues.SetValues(projeto);
+            var result = await _context.SaveChangesAsync() > 0;
+
+            if (result)
+            {
+                _messageBoxService.ShowSuccess("Projeto atualizado com sucesso!");
+                _telemetryService.TrackEvent("ProjetoAtualizado", new Dictionary<string, string>
+                {
+                    { "ProjetoId", projeto.Id.ToString() },
+                    { "ProjetoNome", projeto.Nome },
+                    { "UsuarioId", usuario?.Id.ToString() ?? "Unknown" }
+                });
+            }
+            else
+            {
+                _messageBoxService.ShowError("Erro ao atualizar projeto");
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "AtualizarProjetoAsync" },
+                { "Component", "ProjetosService" },
+                { "ProjetoId", projeto?.Id.ToString() ?? "Unknown" }
+            });
+            _messageBoxService.ShowError("Erro interno ao atualizar projeto");
+            return false;
+        }
+    }
+
+    public async Task<bool> RemoverProjetoAsync(int idProjeto)
+    {
+        try
+        {
+            var projeto = await _context.Projetos.FindAsync(idProjeto);
+            if (projeto == null)
+            {
+                _messageBoxService.ShowError("Projeto não encontrado");
+                return false;
+            }
+
+            _context.Projetos.Remove(projeto);
+            var result = await _context.SaveChangesAsync() > 0;
+
+            if (result)
+            {
+                _messageBoxService.ShowSuccess("Projeto removido com sucesso!");
+                _telemetryService.TrackEvent("ProjetoRemovido", new Dictionary<string, string>
+                {
+                    { "ProjetoId", idProjeto.ToString() },
+                    { "ProjetoNome", projeto.Nome }
+                });
+            }
+            else
+            {
+                _messageBoxService.ShowError("Erro ao remover projeto");
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "RemoverProjetoAsync" },
+                { "Component", "ProjetosService" },
+                { "ProjetoId", idProjeto.ToString() }
+            });
+            _messageBoxService.ShowError("Erro interno ao remover projeto");
+            return false;
+        }
+    }
+
+    public async Task<bool> InativarProjetoAsync(int idProjeto)
+    {
+        return await AlterarStatusProjetoAsync(idProjeto, false);
+    }
+
+    public async Task<bool> AtivarProjetoAsync(int idProjeto)
+    {
+        return await AlterarStatusProjetoAsync(idProjeto, true);
+    }
+
+    public async Task<List<Projeto>> ObterProjetosPorClienteAsync(int idCliente)
+    {
+        try
+        {
+            return await _context.Projetos
+                .Include(p => p.Cliente)
+                .Include(p => p.AssociadoResponsavel)
+                .Include(p => p.AssociadoGestor)
+                .Where(p => p.IdCliente == idCliente)
+                .OrderBy(p => p.Nome)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ObterProjetosPorClienteAsync" },
+                { "Component", "ProjetosService" },
+                { "ClienteId", idCliente.ToString() }
+            });
+            return new List<Projeto>();
+        }
+    }
+
+    public async Task<List<Projeto>> ObterProjetosPorResponsavelAsync(int idResponsavel)
+    {
+        try
+        {
+            return await _context.Projetos
+                .Include(p => p.Cliente)
+                .Include(p => p.AssociadoResponsavel)
+                .Include(p => p.AssociadoGestor)
+                .Where(p => p.IdAssociadoResponsavel == idResponsavel)
+                .OrderBy(p => p.Nome)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ObterProjetosPorResponsavelAsync" },
+                { "Component", "ProjetosService" },
+                { "ResponsavelId", idResponsavel.ToString() }
+            });
+            return new List<Projeto>();
+        }
+    }
+
+    public async Task<List<Projeto>> ObterProjetosPorGestorAsync(int idGestor)
+    {
+        try
+        {
+            return await _context.Projetos
+                .Include(p => p.Cliente)
+                .Include(p => p.AssociadoResponsavel)
+                .Include(p => p.AssociadoGestor)
+                .Where(p => p.IdAssociadoGestor == idGestor)
+                .OrderBy(p => p.Nome)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ObterProjetosPorGestorAsync" },
+                { "Component", "ProjetosService" },
+                { "GestorId", idGestor.ToString() }
+            });
+            return new List<Projeto>();
+        }
+    }
+
+    public async Task<bool> AdicionarAssociadoProjetoAsync(int idProjeto, int idAssociado, DateTime dataInicio, DateTime? dataFim = null)
+    {
+        try
+        {
+            var associadoProjeto = new AssociadoProjeto
+            {
+                IdProjeto = idProjeto,
+                IdAssociado = idAssociado,
+                DataInicio = dataInicio,
+                DataFim = dataFim,
+                Ativo = true
+            };
+
+            _context.AssociadosProjetos.Add(associadoProjeto);
+            var result = await _context.SaveChangesAsync() > 0;
+
+            if (result)
+            {
+                _messageBoxService.ShowSuccess("Associado adicionado ao projeto com sucesso!");
+                _telemetryService.TrackEvent("AssociadoAdicionadoProjeto", new Dictionary<string, string>
+                {
+                    { "ProjetoId", idProjeto.ToString() },
+                    { "AssociadoId", idAssociado.ToString() }
+                });
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "AdicionarAssociadoProjetoAsync" },
+                { "Component", "ProjetosService" },
+                { "ProjetoId", idProjeto.ToString() },
+                { "AssociadoId", idAssociado.ToString() }
+            });
+            _messageBoxService.ShowError("Erro ao adicionar associado ao projeto");
+            return false;
+        }
+    }
+
+    public async Task<bool> RemoverAssociadoProjetoAsync(int idProjeto, int idAssociado)
+    {
+        try
+        {
+            var associadoProjeto = await _context.AssociadosProjetos
+                .FirstOrDefaultAsync(ap => ap.IdProjeto == idProjeto && ap.IdAssociado == idAssociado);
+
+            if (associadoProjeto == null)
+            {
+                _messageBoxService.ShowError("Associação não encontrada");
+                return false;
+            }
+
+            _context.AssociadosProjetos.Remove(associadoProjeto);
+            var result = await _context.SaveChangesAsync() > 0;
+
+            if (result)
+            {
+                _messageBoxService.ShowSuccess("Associado removido do projeto com sucesso!");
+                _telemetryService.TrackEvent("AssociadoRemovidoProjeto", new Dictionary<string, string>
+                {
+                    { "ProjetoId", idProjeto.ToString() },
+                    { "AssociadoId", idAssociado.ToString() }
+                });
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "RemoverAssociadoProjetoAsync" },
+                { "Component", "ProjetosService" },
+                { "ProjetoId", idProjeto.ToString() },
+                { "AssociadoId", idAssociado.ToString() }
+            });
+            _messageBoxService.ShowError("Erro ao remover associado do projeto");
+            return false;
+        }
+    }
+
+    public async Task<List<Associado>> ObterAssociadosProjetoAsync(int idProjeto)
+    {
+        try
+        {
+            return await _context.AssociadosProjetos
+                .Include(ap => ap.Associado)
+                    .ThenInclude(a => a.Cargo)
+                .Where(ap => ap.IdProjeto == idProjeto && ap.Ativo)
+                .Select(ap => ap.Associado)
+                .OrderBy(a => a.Nome)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ObterAssociadosProjetoAsync" },
+                { "Component", "ProjetosService" },
+                { "ProjetoId", idProjeto.ToString() }
+            });
+            return new List<Associado>();
+        }
+    }
+
+    public async Task<bool> ProjetoExisteAsync(string codigo)
+    {
+        try
+        {
+            return await _context.Projetos.AnyAsync(p => p.Codigo == codigo);
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ProjetoExisteAsync" },
+                { "Component", "ProjetosService" },
+                { "Codigo", codigo }
+            });
+            return false;
+        }
+    }
+
+    public async Task<bool> ValidarPeriodoProjetoAsync(DateTime dataInicio, DateTime dataFim)
+    {
+        if (dataInicio >= dataFim)
+        {
+            _messageBoxService.ShowWarning("A data de início deve ser anterior à data de término");
+            return false;
+        }
+
+        if (dataInicio < DateTime.Today.AddYears(-10))
+        {
+            _messageBoxService.ShowWarning("A data de início não pode ser muito antiga");
+            return false;
+        }
+
+        if (dataFim > DateTime.Today.AddYears(10))
+        {
+            _messageBoxService.ShowWarning("A data de término não pode ser muito distante");
+            return false;
+        }
+
+        return true;
+    }
+
+    private async Task<bool> ValidarProjetoAsync(Projeto projeto)
+    {
+        if (string.IsNullOrWhiteSpace(projeto.Nome))
+        {
+            _messageBoxService.ShowWarning("O nome do projeto é obrigatório");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(projeto.Codigo))
+        {
+            _messageBoxService.ShowWarning("O código do projeto é obrigatório");
+            return false;
+        }
+
+        if (projeto.Id == 0 && await ProjetoExisteAsync(projeto.Codigo))
+        {
+            _messageBoxService.ShowWarning("Já existe um projeto com este código");
+            return false;
+        }
+
+        if (projeto.DataInicio.HasValue && projeto.DataFim.HasValue)
+        {
+            return await ValidarPeriodoProjetoAsync(projeto.DataInicio.Value, projeto.DataFim.Value);
+        }
+
+        return true;
+    }
+
+    private async Task<bool> AlterarStatusProjetoAsync(int idProjeto, bool ativo)
+    {
+        try
+        {
+            var projeto = await _context.Projetos.FindAsync(idProjeto);
+            if (projeto == null)
+            {
+                _messageBoxService.ShowError("Projeto não encontrado");
+                return false;
+            }
+
+            projeto.Ativo = ativo;
+            var usuario = await _userContextService.GetUsuarioLogadoAsync();
+            if (usuario != null)
+            {
+                projeto.UsuarioAlteracao = usuario.Id;
+                projeto.DataAlteracao = DateTime.Now;
+            }
+
+            var result = await _context.SaveChangesAsync() > 0;
+
+            if (result)
+            {
+                var statusTexto = ativo ? "ativado" : "inativado";
+                _messageBoxService.ShowSuccess($"Projeto {statusTexto} com sucesso!");
+                _telemetryService.TrackEvent("ProjetoStatusAlterado", new Dictionary<string, string>
+                {
+                    { "ProjetoId", idProjeto.ToString() },
+                    { "NovoStatus", ativo.ToString() },
+                    { "UsuarioId", usuario?.Id.ToString() ?? "Unknown" }
+                });
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "AlterarStatusProjetoAsync" },
+                { "Component", "ProjetosService" },
+                { "ProjetoId", idProjeto.ToString() },
+                { "NovoStatus", ativo.ToString() }
+            });
+            _messageBoxService.ShowError("Erro interno ao alterar status do projeto");
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Este PR implementa a estrutura de serviços para a funcionalidade de Projetos, seguindo as premissas de reutilização e organização modular. Inclui: (1) Serviço principal de Projetos (CRUD, validações, gerenciamento de associados), (2) Helper reutilizável para combos de Projetos em Common, (3) Modelos de domínio para Projeto, AssociadoProjeto e TipoProjeto, (4) Configuração do ApplicationDbContext para as novas entidades, (5) Registro dos serviços no DI container, e (6) documentação detalhada em markdown na pasta docs, incluindo explicação e fluxo mermaid de alto nível da integração dos componentes.