### PR TITLE
Migração e padronização dos componentes Blazor de Projetos + documentação técnica

### DIFF
--- a/Components/Projetos/AssociadosProjeto.razor
+++ b/Components/Projetos/AssociadosProjeto.razor
@@ -1,0 +1,481 @@
+@page "/projetos/{ProjetoId:int}/associados"
+@using Peers.Moderno.Models
+@using Peers.Moderno.Services.Projetos
+@using Peers.Moderno.Services.Projetos.Common
+@using Peers.Moderno.Services.Common
+@inject IProjetosService ProjetosService
+@inject IProjetosComboHelper ProjetosComboHelper
+@inject IMessageBoxService MessageBoxService
+@inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
+@rendermode InteractiveAuto
+
+<div class="page-breadcrumb border-bottom">
+    <div class="row">
+        <div class="col-lg-6 col-md-8 col-xs-12 align-self-center">
+            <h5 class="font-medium text-uppercase mb-0">Associados do Projeto: @projeto?.Nome</h5>
+        </div>
+        <div class="col-lg-6 col-md-4 col-xs-12 align-self-center">
+            <nav aria-label="breadcrumb" class="mt-2 float-md-right float-left">
+                <ol class="breadcrumb mb-0 justify-content-end p-0">
+                    <li class="breadcrumb-item"><a href="/">Peers</a></li>
+                    <li class="breadcrumb-item"><a href="/projetos">Projetos</a></li>
+                    <li class="breadcrumb-item active">Associados</li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+</div>
+
+<div class="page-content container-fluid">
+    @if (isLoadingProjeto)
+    {
+        <div class="text-center p-4">
+            <div class="spinner-border" role="status">
+                <span class="sr-only">Carregando...</span>
+            </div>
+            <p class="mt-2">Carregando dados do projeto...</p>
+        </div>
+    }
+    else if (projeto == null)
+    {
+        <div class="alert alert-danger">
+            <h4>Projeto não encontrado</h4>
+            <p>O projeto solicitado não foi encontrado ou você não tem permissão para acessá-lo.</p>
+            <button type="button" class="btn btn-primary" @onclick="VoltarParaProjetos">
+                <i class="fa fa-arrow-left"></i> Voltar para Projetos
+            </button>
+        </div>
+    }
+    else
+    {
+        <div class="card">
+            <div class="card-body">
+                <div class="d-flex justify-content-between align-items-center mb-4">
+                    <h4 class="card-title mb-0">
+                        Associados no Projeto 
+                        <button type="button" class="btn btn-primary btn-sm ml-2" @onclick="AbrirModalAssociado">
+                            <i class="fa fa-plus"></i> Adicionar Associado
+                        </button>
+                    </h4>
+                    <button type="button" class="btn btn-secondary" @onclick="VoltarParaProjetos">
+                        <i class="fa fa-arrow-left"></i> Voltar
+                    </button>
+                </div>
+                
+                @if (isLoadingAssociados)
+                {
+                    <div class="text-center p-4">
+                        <div class="spinner-border" role="status">
+                            <span class="sr-only">Carregando...</span>
+                        </div>
+                        <p class="mt-2">Carregando associados...</p>
+                    </div>
+                }
+                else if (associadosProjeto?.Any() == true)
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped border">
+                            <thead>
+                                <tr>
+                                    <th>Associado</th>
+                                    <th>Cargo Projeto</th>
+                                    <th>Avaliador</th>
+                                    <th>Data Início</th>
+                                    <th>Data Término</th>
+                                    <th>Status</th>
+                                    <th>Ações</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var associadoProjeto in associadosProjeto)
+                                {
+                                    <tr>
+                                        <td>@associadoProjeto.Associado?.Nome</td>
+                                        <td>@associadoProjeto.CargoProjeto?.Nome</td>
+                                        <td>@associadoProjeto.Avaliador?.Nome</td>
+                                        <td>@associadoProjeto.DataInicio?.ToString("dd/MM/yyyy")</td>
+                                        <td>@associadoProjeto.DataFim?.ToString("dd/MM/yyyy")</td>
+                                        <td>
+                                            <span class="badge @(associadoProjeto.Ativo ? "badge-success" : "badge-secondary")">
+                                                @(associadoProjeto.Ativo ? "Ativo" : "Inativo")
+                                            </span>
+                                        </td>
+                                        <td>
+                                            <div class="btn-group" role="group">
+                                                <button type="button" class="btn btn-sm btn-primary" 
+                                                        @onclick="() => EditarAssociado(associadoProjeto)" title="Editar">
+                                                    <i class="fa fa-edit"></i>
+                                                </button>
+                                                @if (associadoProjeto.Ativo)
+                                                {
+                                                    <button type="button" class="btn btn-sm btn-warning" 
+                                                            @onclick="() => InativarAssociado(associadoProjeto.Id)" title="Inativar">
+                                                        <i class="fa fa-pause"></i>
+                                                    </button>
+                                                }
+                                                else
+                                                {
+                                                    <button type="button" class="btn btn-sm btn-success" 
+                                                            @onclick="() => AtivarAssociado(associadoProjeto.Id)" title="Ativar">
+                                                        <i class="fa fa-play"></i>
+                                                    </button>
+                                                }
+                                                <button type="button" class="btn btn-sm btn-danger" 
+                                                        @onclick="() => RemoverAssociado(associadoProjeto.Id)" title="Remover">
+                                                    <i class="fa fa-trash"></i>
+                                                </button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+                else
+                {
+                    <div class="text-center p-4">
+                        <i class="fa fa-users fa-3x text-muted mb-3"></i>
+                        <h5 class="text-muted">Nenhum associado no projeto</h5>
+                        <p class="text-muted">Este projeto ainda não possui associados alocados.</p>
+                        <button type="button" class="btn btn-primary" @onclick="AbrirModalAssociado">
+                            <i class="fa fa-plus"></i> Adicionar Primeiro Associado
+                        </button>
+                    </div>
+                }
+            </div>
+        </div>
+    }
+</div>
+
+<!-- Modal para Adicionar/Editar Associado -->
+@if (showModalAssociado)
+{
+    <div class="modal fade show" style="display: block; background-color: rgba(0,0,0,0.5);" tabindex="-1">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title">@(associadoEdicao?.Id > 0 ? "Editar" : "Adicionar") Associado</h4>
+                    <button type="button" class="close" @onclick="FecharModalAssociado">
+                        <span>&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <EditForm Model="@associadoEdicao" OnValidSubmit="@SalvarAssociado">
+                        <DataAnnotationsValidator />
+                        <ValidationSummary />
+                        
+                        <div class="form-body">
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Associado *</label>
+                                        <InputSelect @bind-Value="associadoEdicao.IdAssociado" class="form-control" disabled="@(associadoEdicao?.Id > 0)">
+                                            <option value="0">Selecione</option>
+                                            @if (associadosDisponiveis != null)
+                                            {
+                                                @foreach (var associado in associadosDisponiveis)
+                                                {
+                                                    <option value="@associado.Id">@associado.Nome</option>
+                                                }
+                                            }
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Cargo no Projeto</label>
+                                        <InputSelect @bind-Value="associadoEdicao.IdCargoProjeto" class="form-control">
+                                            <option value="0">Selecione</option>
+                                            @if (cargos != null)
+                                            {
+                                                @foreach (var cargo in cargos)
+                                                {
+                                                    <option value="@cargo.IdCargo">@cargo.Nome</option>
+                                                }
+                                            }
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Avaliador</label>
+                                        <InputSelect @bind-Value="associadoEdicao.IdAvaliador" class="form-control">
+                                            <option value="0">Selecione</option>
+                                            @if (avaliadores != null)
+                                            {
+                                                @foreach (var avaliador in avaliadores)
+                                                {
+                                                    <option value="@avaliador.Id">@avaliador.Nome</option>
+                                                }
+                                            }
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Status</label>
+                                        <InputSelect @bind-Value="associadoEdicao.Ativo" class="form-control">
+                                            <option value="true">Ativo</option>
+                                            <option value="false">Inativo</option>
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Data Início</label>
+                                        <InputDate @bind-Value="associadoEdicao.DataInicio" class="form-control" />
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Data Término</label>
+                                        <InputDate @bind-Value="associadoEdicao.DataFim" class="form-control" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" @onclick="FecharModalAssociado">Cancelar</button>
+                            <button type="submit" class="btn btn-primary" disabled="@isSavingAssociado">
+                                @if (isSavingAssociado)
+                                {
+                                    <span class="spinner-border spinner-border-sm" role="status"></span>
+                                    <span>Salvando...</span>
+                                }
+                                else
+                                {
+                                    <span>@(associadoEdicao?.Id > 0 ? "Atualizar" : "Adicionar")</span>
+                                }
+                            </button>
+                        </div>
+                    </EditForm>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public int ProjetoId { get; set; }
+    
+    private Projeto? projeto;
+    private List<AssociadoProjeto>? associadosProjeto;
+    private List<Associado>? associadosDisponiveis;
+    private List<Associado>? avaliadores;
+    private List<Cargo>? cargos;
+    
+    private bool isLoadingProjeto = true;
+    private bool isLoadingAssociados = true;
+    private bool showModalAssociado = false;
+    private bool isSavingAssociado = false;
+    private AssociadoProjeto associadoEdicao = new();
+    
+    protected override async Task OnInitializedAsync()
+    {
+        await CarregarProjeto();
+        if (projeto != null)
+        {
+            await CarregarAssociadosProjeto();
+            await CarregarCombos();
+        }
+    }
+    
+    private async Task CarregarProjeto()
+    {
+        try
+        {
+            isLoadingProjeto = true;
+            projeto = await ProjetosService.ObterProjetoAsync(ProjetoId);
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao carregar projeto: {ex.Message}");
+        }
+        finally
+        {
+            isLoadingProjeto = false;
+        }
+    }
+    
+    private async Task CarregarAssociadosProjeto()
+    {
+        try
+        {
+            isLoadingAssociados = true;
+            associadosProjeto = await ProjetosService.ObterAssociadosProjetoAsync(ProjetoId);
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao carregar associados: {ex.Message}");
+            associadosProjeto = new List<AssociadoProjeto>();
+        }
+        finally
+        {
+            isLoadingAssociados = false;
+        }
+    }
+    
+    private async Task CarregarCombos()
+    {
+        try
+        {
+            associadosDisponiveis = await ProjetosComboHelper.GetAssociadosAsync();
+            avaliadores = await ProjetosComboHelper.GetAvaliadoresAsync();
+            cargos = await ProjetosComboHelper.GetCargosAsync();
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao carregar dados: {ex.Message}");
+        }
+    }
+    
+    private void AbrirModalAssociado()
+    {
+        associadoEdicao = new AssociadoProjeto 
+        { 
+            IdProjeto = ProjetoId,
+            Ativo = true,
+            DataInicio = DateTime.Today
+        };
+        showModalAssociado = true;
+    }
+    
+    private void EditarAssociado(AssociadoProjeto associado)
+    {
+        associadoEdicao = new AssociadoProjeto
+        {
+            Id = associado.Id,
+            IdProjeto = associado.IdProjeto,
+            IdAssociado = associado.IdAssociado,
+            IdCargoProjeto = associado.IdCargoProjeto,
+            IdAvaliador = associado.IdAvaliador,
+            DataInicio = associado.DataInicio,
+            DataFim = associado.DataFim,
+            Ativo = associado.Ativo
+        };
+        showModalAssociado = true;
+    }
+    
+    private void FecharModalAssociado()
+    {
+        showModalAssociado = false;
+        associadoEdicao = new();
+    }
+    
+    private async Task SalvarAssociado()
+    {
+        if (isSavingAssociado) return;
+        
+        try
+        {
+            isSavingAssociado = true;
+            
+            bool success;
+            if (associadoEdicao.Id > 0)
+            {
+                success = await ProjetosService.AtualizarAssociadoProjetoAsync(associadoEdicao);
+                if (success)
+                {
+                    MessageBoxService.ShowSuccess("Associado atualizado com sucesso!");
+                }
+            }
+            else
+            {
+                success = await ProjetosService.AdicionarAssociadoProjetoAsync(associadoEdicao);
+                if (success)
+                {
+                    MessageBoxService.ShowSuccess("Associado adicionado com sucesso!");
+                }
+            }
+            
+            if (success)
+            {
+                FecharModalAssociado();
+                await CarregarAssociadosProjeto();
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao salvar associado: {ex.Message}");
+        }
+        finally
+        {
+            isSavingAssociado = false;
+        }
+    }
+    
+    private async Task InativarAssociado(int id)
+    {
+        var confirmado = await JSRuntime.InvokeAsync<bool>("confirm", "Deseja realmente inativar este associado no projeto?");
+        if (confirmado)
+        {
+            try
+            {
+                var success = await ProjetosService.InativarAssociadoProjetoAsync(id);
+                if (success)
+                {
+                    MessageBoxService.ShowSuccess("Associado inativado com sucesso!");
+                    await CarregarAssociadosProjeto();
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBoxService.ShowError($"Erro ao inativar associado: {ex.Message}");
+            }
+        }
+    }
+    
+    private async Task AtivarAssociado(int id)
+    {
+        var confirmado = await JSRuntime.InvokeAsync<bool>("confirm", "Deseja realmente ativar este associado no projeto?");
+        if (confirmado)
+        {
+            try
+            {
+                var success = await ProjetosService.AtivarAssociadoProjetoAsync(id);
+                if (success)
+                {
+                    MessageBoxService.ShowSuccess("Associado ativado com sucesso!");
+                    await CarregarAssociadosProjeto();
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBoxService.ShowError($"Erro ao ativar associado: {ex.Message}");
+            }
+        }
+    }
+    
+    private async Task RemoverAssociado(int id)
+    {
+        var confirmado = await JSRuntime.InvokeAsync<bool>("confirm", "Deseja realmente remover este associado do projeto? Esta ação não pode ser desfeita.");
+        if (confirmado)
+        {
+            try
+            {
+                var success = await ProjetosService.RemoverAssociadoProjetoAsync(id);
+                if (success)
+                {
+                    MessageBoxService.ShowSuccess("Associado removido com sucesso!");
+                    await CarregarAssociadosProjeto();
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBoxService.ShowError($"Erro ao remover associado: {ex.Message}");
+            }
+        }
+    }
+    
+    private void VoltarParaProjetos()
+    {
+        Navigation.NavigateTo("/projetos");
+    }
+}

--- a/Components/Projetos/Modals/ComplexidadeModal.razor
+++ b/Components/Projetos/Modals/ComplexidadeModal.razor
@@ -1,0 +1,220 @@
+@using Peers.Moderno.Models
+@using Peers.Moderno.Services.Complexidades
+@using Peers.Moderno.Services.Common
+@inject IComplexidadeService ComplexidadeService
+@inject IMessageBoxService MessageBoxService
+@rendermode InteractiveAuto
+
+@if (IsVisible)
+{
+    <div class="modal fade show" style="display: block; background-color: rgba(0,0,0,0.5);" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title">Cadastro de Complexidade</h4>
+                    <button type="button" class="close" @onclick="Close">
+                        <span>&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <EditForm Model="@complexidade" OnValidSubmit="@SalvarComplexidade">
+                        <DataAnnotationsValidator />
+                        <ValidationSummary />
+                        
+                        <div class="form-body">
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <div class="form-group">
+                                        <label>Nome da Complexidade *</label>
+                                        <InputText @bind-Value="complexidade.Nome" class="form-control" placeholder="Digite o nome da complexidade" maxlength="500" />
+                                        <small class="form-text text-muted">Máximo 500 caracteres</small>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Código</label>
+                                        <InputText @bind-Value="complexidade.Codigo" class="form-control" placeholder="Código identificador" maxlength="100" />
+                                        <small class="form-text text-muted">Código único para identificação</small>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Status</label>
+                                        <InputSelect @bind-Value="complexidade.Ativo" class="form-control">
+                                            <option value="true">Ativo</option>
+                                            <option value="false">Inativo</option>
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Peso</label>
+                                        <InputNumber @bind-Value="complexidade.Peso" class="form-control" step="0.01" min="0.01" max="999.99" />
+                                        <small class="form-text text-muted">Valor entre 0,01 e 999,99</small>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Ponderação (%)</label>
+                                        <InputNumber @bind-Value="complexidade.Ponderacao" class="form-control" step="0.01" min="0.01" max="100.00" />
+                                        <small class="form-text text-muted">Percentual entre 0,01% e 100%</small>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <div class="form-group">
+                                        <label>Descrição</label>
+                                        <InputTextArea @bind-Value="complexidade.Descricao" class="form-control" rows="3" 
+                                                      placeholder="Descreva as características desta complexidade" maxlength="1000" />
+                                        <small class="form-text text-muted">Máximo 1000 caracteres</small>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" @onclick="Close">Fechar</button>
+                            <button type="submit" class="btn btn-primary" disabled="@isSaving">
+                                @if (isSaving)
+                                {
+                                    <span class="spinner-border spinner-border-sm" role="status"></span>
+                                    <span>Salvando...</span>
+                                }
+                                else
+                                {
+                                    <span>Cadastrar</span>
+                                }
+                            </button>
+                        </div>
+                    </EditForm>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+    [Parameter] public EventCallback<ProjetoComplexidade> OnComplexidadeCadastrada { get; set; }
+    
+    private ProjetoComplexidade complexidade = new();
+    private bool isSaving = false;
+    
+    protected override void OnParametersSet()
+    {
+        if (IsVisible)
+        {
+            LimparFormulario();
+        }
+    }
+    
+    private void LimparFormulario()
+    {
+        complexidade = new ProjetoComplexidade
+        {
+            Ativo = true,
+            Peso = 1.0m,
+            Ponderacao = 1.0m,
+            DataCriacao = DateTime.Now
+        };
+    }
+    
+    private async Task SalvarComplexidade()
+    {
+        if (isSaving) return;
+        
+        try
+        {
+            isSaving = true;
+            
+            // Validações básicas
+            if (string.IsNullOrWhiteSpace(complexidade.Nome))
+            {
+                MessageBoxService.ShowWarning("Nome da complexidade é obrigatório");
+                return;
+            }
+            
+            if (complexidade.Nome.Length > 500)
+            {
+                MessageBoxService.ShowWarning("Nome da complexidade deve ter no máximo 500 caracteres");
+                return;
+            }
+            
+            if (!string.IsNullOrEmpty(complexidade.Codigo) && complexidade.Codigo.Length > 100)
+            {
+                MessageBoxService.ShowWarning("Código deve ter no máximo 100 caracteres");
+                return;
+            }
+            
+            if (!string.IsNullOrEmpty(complexidade.Descricao) && complexidade.Descricao.Length > 1000)
+            {
+                MessageBoxService.ShowWarning("Descrição deve ter no máximo 1000 caracteres");
+                return;
+            }
+            
+            if (complexidade.Peso < 0.01m || complexidade.Peso > 999.99m)
+            {
+                MessageBoxService.ShowWarning("Peso deve estar entre 0,01 e 999,99");
+                return;
+            }
+            
+            if (complexidade.Ponderacao < 0.01m || complexidade.Ponderacao > 100.00m)
+            {
+                MessageBoxService.ShowWarning("Ponderação deve estar entre 0,01% e 100%");
+                return;
+            }
+            
+            // Verificar se já existe uma complexidade com o mesmo nome
+            var complexidadeExistente = await ComplexidadeService.ObterComplexidadePorNomeAsync(complexidade.Nome);
+            if (complexidadeExistente != null)
+            {
+                MessageBoxService.ShowWarning("Já existe uma complexidade com este nome");
+                return;
+            }
+            
+            // Verificar se já existe uma complexidade com o mesmo código (se informado)
+            if (!string.IsNullOrEmpty(complexidade.Codigo))
+            {
+                var complexidadeComCodigo = await ComplexidadeService.ObterComplexidadePorCodigoAsync(complexidade.Codigo);
+                if (complexidadeComCodigo != null)
+                {
+                    MessageBoxService.ShowWarning("Já existe uma complexidade com este código");
+                    return;
+                }
+            }
+            
+            // Salvar complexidade
+            var success = await ComplexidadeService.InserirComplexidadeAsync(complexidade);
+            
+            if (success)
+            {
+                MessageBoxService.ShowSuccess("Complexidade cadastrada com sucesso!");
+                await OnComplexidadeCadastrada.InvokeAsync(complexidade);
+                await Close();
+            }
+            else
+            {
+                MessageBoxService.ShowError("Erro ao cadastrar complexidade");
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao cadastrar complexidade: {ex.Message}");
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+    
+    private async Task Close()
+    {
+        await OnClose.InvokeAsync();
+    }
+}

--- a/Components/Projetos/Modals/GestorModal.razor
+++ b/Components/Projetos/Modals/GestorModal.razor
@@ -1,0 +1,252 @@
+@using Peers.Moderno.Models
+@using Peers.Moderno.Services.Associados
+@using Peers.Moderno.Services.Common
+@inject IAssociadosService AssociadosService
+@inject IMessageBoxService MessageBoxService
+@rendermode InteractiveAuto
+
+@if (IsVisible)
+{
+    <div class="modal fade show" style="display: block; background-color: rgba(0,0,0,0.5);" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title">Cadastro de Gestor</h4>
+                    <button type="button" class="close" @onclick="Close">
+                        <span>&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <EditForm Model="@gestor" OnValidSubmit="@SalvarGestor">
+                        <DataAnnotationsValidator />
+                        <ValidationSummary />
+                        
+                        <div class="form-body">
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <div class="form-group">
+                                        <label>Nome *</label>
+                                        <InputText @bind-Value="gestor.Nome" class="form-control" placeholder="Digite o nome do gestor" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Email *</label>
+                                        <InputText @bind-Value="gestor.Email" class="form-control" type="email" placeholder="email@exemplo.com" />
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Telefone</label>
+                                        <InputText @bind-Value="gestor.Telefone" class="form-control" placeholder="(11) 99999-9999" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Cargo</label>
+                                        <InputSelect @bind-Value="gestor.IdCargo" class="form-control">
+                                            <option value="0">Selecione</option>
+                                            @if (cargos != null)
+                                            {
+                                                @foreach (var cargo in cargos)
+                                                {
+                                                    <option value="@cargo.IdCargo">@cargo.Nome</option>
+                                                }
+                                            }
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Perfil</label>
+                                        <InputSelect @bind-Value="gestor.IdPerfil" class="form-control">
+                                            <option value="0">Selecione</option>
+                                            @if (perfis != null)
+                                            {
+                                                @foreach (var perfil in perfis)
+                                                {
+                                                    <option value="@perfil.Id">@perfil.Nome</option>
+                                                }
+                                            }
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Vertical</label>
+                                        <InputSelect @bind-Value="gestor.IdVertical" class="form-control">
+                                            <option value="0">Selecione</option>
+                                            @if (verticais != null)
+                                            {
+                                                @foreach (var vertical in verticais)
+                                                {
+                                                    <option value="@vertical.Id">@vertical.Nome</option>
+                                                }
+                                            }
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Status</label>
+                                        <InputSelect @bind-Value="gestor.Ativo" class="form-control">
+                                            <option value="true">Ativo</option>
+                                            <option value="false">Inativo</option>
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" @onclick="Close">Fechar</button>
+                            <button type="submit" class="btn btn-primary" disabled="@isSaving">
+                                @if (isSaving)
+                                {
+                                    <span class="spinner-border spinner-border-sm" role="status"></span>
+                                    <span>Salvando...</span>
+                                }
+                                else
+                                {
+                                    <span>Cadastrar</span>
+                                }
+                            </button>
+                        </div>
+                    </EditForm>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+    [Parameter] public EventCallback<Associado> OnGestorCadastrado { get; set; }
+    
+    private Associado gestor = new();
+    private List<Cargo>? cargos;
+    private List<Perfil>? perfis;
+    private List<Vertical>? verticais;
+    private bool isSaving = false;
+    
+    protected override async Task OnParametersSetAsync()
+    {
+        if (IsVisible && (cargos == null || perfis == null || verticais == null))
+        {
+            await CarregarCombos();
+        }
+        
+        if (IsVisible)
+        {
+            LimparFormulario();
+        }
+    }
+    
+    private async Task CarregarCombos()
+    {
+        try
+        {
+            // Carregar cargos com perfil de gestor (perfil 2)
+            var associadosComCargos = await AssociadosService.ObterAssociadosPorPerfilAsync(2);
+            cargos = associadosComCargos.Select(a => a.Cargo).Distinct().Where(c => c != null).ToList()!;
+            
+            // Carregar perfis disponíveis
+            perfis = await AssociadosService.ObterPerfisAsync();
+            
+            // Carregar verticais
+            verticais = await AssociadosService.ObterVerticaisAsync();
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao carregar dados: {ex.Message}");
+        }
+    }
+    
+    private void LimparFormulario()
+    {
+        gestor = new Associado
+        {
+            Ativo = true,
+            IdPerfil = 2, // Perfil padrão para gestor
+            DataCadastro = DateTime.Now,
+            Senha = "avaliacao" // Senha padrão
+        };
+    }
+    
+    private async Task SalvarGestor()
+    {
+        if (isSaving) return;
+        
+        try
+        {
+            isSaving = true;
+            
+            // Validações básicas
+            if (string.IsNullOrWhiteSpace(gestor.Nome))
+            {
+                MessageBoxService.ShowWarning("Nome é obrigatório");
+                return;
+            }
+            
+            if (string.IsNullOrWhiteSpace(gestor.Email))
+            {
+                MessageBoxService.ShowWarning("Email é obrigatório");
+                return;
+            }
+            
+            if (gestor.IdCargo == 0)
+            {
+                MessageBoxService.ShowWarning("Selecione um cargo");
+                return;
+            }
+            
+            if (gestor.IdPerfil == 0)
+            {
+                MessageBoxService.ShowWarning("Selecione um perfil");
+                return;
+            }
+            
+            // Verificar se email já existe
+            var emailExistente = await AssociadosService.ObterAssociadoPorEmailAsync(gestor.Email);
+            if (emailExistente != null)
+            {
+                MessageBoxService.ShowWarning("Já existe um associado com este email");
+                return;
+            }
+            
+            // Salvar gestor
+            var success = await AssociadosService.InserirAssociadoAsync(gestor);
+            
+            if (success)
+            {
+                MessageBoxService.ShowSuccess("Gestor cadastrado com sucesso!");
+                await OnGestorCadastrado.InvokeAsync(gestor);
+                await Close();
+            }
+            else
+            {
+                MessageBoxService.ShowError("Erro ao cadastrar gestor");
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao cadastrar gestor: {ex.Message}");
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+    
+    private async Task Close()
+    {
+        await OnClose.InvokeAsync();
+    }
+}

--- a/Components/Projetos/Modals/ResponsavelModal.razor
+++ b/Components/Projetos/Modals/ResponsavelModal.razor
@@ -1,0 +1,233 @@
+@using Peers.Moderno.Models
+@using Peers.Moderno.Services.Associados
+@using Peers.Moderno.Services.Common
+@inject IAssociadosService AssociadosService
+@inject IMessageBoxService MessageBoxService
+@rendermode InteractiveAuto
+
+@if (IsVisible)
+{
+    <div class="modal fade show" style="display: block; background-color: rgba(0,0,0,0.5);" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title">Cadastro de Responsável</h4>
+                    <button type="button" class="close" @onclick="Close">
+                        <span>&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <EditForm Model="@responsavel" OnValidSubmit="@SalvarResponsavel">
+                        <DataAnnotationsValidator />
+                        <ValidationSummary />
+                        
+                        <div class="form-body">
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <div class="form-group">
+                                        <label>Nome *</label>
+                                        <InputText @bind-Value="responsavel.Nome" class="form-control" placeholder="Digite o nome do responsável" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Email *</label>
+                                        <InputText @bind-Value="responsavel.Email" class="form-control" type="email" placeholder="email@exemplo.com" />
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Telefone</label>
+                                        <InputText @bind-Value="responsavel.Telefone" class="form-control" placeholder="(11) 99999-9999" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Cargo</label>
+                                        <InputSelect @bind-Value="responsavel.IdCargo" class="form-control">
+                                            <option value="0">Selecione</option>
+                                            @if (cargos != null)
+                                            {
+                                                @foreach (var cargo in cargos)
+                                                {
+                                                    <option value="@cargo.IdCargo">@cargo.Nome</option>
+                                                }
+                                            }
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Perfil</label>
+                                        <InputSelect @bind-Value="responsavel.IdPerfil" class="form-control">
+                                            <option value="0">Selecione</option>
+                                            @if (perfis != null)
+                                            {
+                                                @foreach (var perfil in perfis)
+                                                {
+                                                    <option value="@perfil.Id">@perfil.Nome</option>
+                                                }
+                                            }
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <div class="form-group">
+                                        <label>Status</label>
+                                        <InputSelect @bind-Value="responsavel.Ativo" class="form-control">
+                                            <option value="true">Ativo</option>
+                                            <option value="false">Inativo</option>
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" @onclick="Close">Fechar</button>
+                            <button type="submit" class="btn btn-primary" disabled="@isSaving">
+                                @if (isSaving)
+                                {
+                                    <span class="spinner-border spinner-border-sm" role="status"></span>
+                                    <span>Salvando...</span>
+                                }
+                                else
+                                {
+                                    <span>Cadastrar</span>
+                                }
+                            </button>
+                        </div>
+                    </EditForm>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+    [Parameter] public EventCallback<Associado> OnResponsavelCadastrado { get; set; }
+    
+    private Associado responsavel = new();
+    private List<Cargo>? cargos;
+    private List<Perfil>? perfis;
+    private bool isSaving = false;
+    
+    protected override async Task OnParametersSetAsync()
+    {
+        if (IsVisible && (cargos == null || perfis == null))
+        {
+            await CarregarCombos();
+        }
+        
+        if (IsVisible)
+        {
+            LimparFormulario();
+        }
+    }
+    
+    private async Task CarregarCombos()
+    {
+        try
+        {
+            // Carregar cargos com perfil de responsável (perfil 3)
+            var associadosComCargos = await AssociadosService.ObterAssociadosPorPerfilAsync(3);
+            cargos = associadosComCargos.Select(a => a.Cargo).Distinct().Where(c => c != null).ToList()!;
+            
+            // Carregar perfis disponíveis
+            perfis = await AssociadosService.ObterPerfisAsync();
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao carregar dados: {ex.Message}");
+        }
+    }
+    
+    private void LimparFormulario()
+    {
+        responsavel = new Associado
+        {
+            Ativo = true,
+            IdPerfil = 3, // Perfil padrão para responsável
+            DataCadastro = DateTime.Now,
+            Senha = "avaliacao" // Senha padrão
+        };
+    }
+    
+    private async Task SalvarResponsavel()
+    {
+        if (isSaving) return;
+        
+        try
+        {
+            isSaving = true;
+            
+            // Validações básicas
+            if (string.IsNullOrWhiteSpace(responsavel.Nome))
+            {
+                MessageBoxService.ShowWarning("Nome é obrigatório");
+                return;
+            }
+            
+            if (string.IsNullOrWhiteSpace(responsavel.Email))
+            {
+                MessageBoxService.ShowWarning("Email é obrigatório");
+                return;
+            }
+            
+            if (responsavel.IdCargo == 0)
+            {
+                MessageBoxService.ShowWarning("Selecione um cargo");
+                return;
+            }
+            
+            if (responsavel.IdPerfil == 0)
+            {
+                MessageBoxService.ShowWarning("Selecione um perfil");
+                return;
+            }
+            
+            // Verificar se email já existe
+            var emailExistente = await AssociadosService.ObterAssociadoPorEmailAsync(responsavel.Email);
+            if (emailExistente != null)
+            {
+                MessageBoxService.ShowWarning("Já existe um associado com este email");
+                return;
+            }
+            
+            // Salvar responsável
+            var success = await AssociadosService.InserirAssociadoAsync(responsavel);
+            
+            if (success)
+            {
+                MessageBoxService.ShowSuccess("Responsável cadastrado com sucesso!");
+                await OnResponsavelCadastrado.InvokeAsync(responsavel);
+                await Close();
+            }
+            else
+            {
+                MessageBoxService.ShowError("Erro ao cadastrar responsável");
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao cadastrar responsável: {ex.Message}");
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+    
+    private async Task Close()
+    {
+        await OnClose.InvokeAsync();
+    }
+}

--- a/Components/Projetos/Modals/TipoProjetoModal.razor
+++ b/Components/Projetos/Modals/TipoProjetoModal.razor
@@ -1,0 +1,190 @@
+@using Peers.Moderno.Models
+@using Peers.Moderno.Services.Projetos
+@using Peers.Moderno.Services.Common
+@inject IProjetosService ProjetosService
+@inject IMessageBoxService MessageBoxService
+@rendermode InteractiveAuto
+
+@if (IsVisible)
+{
+    <div class="modal fade show" style="display: block; background-color: rgba(0,0,0,0.5);" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title">Cadastro de Tipo de Projeto</h4>
+                    <button type="button" class="close" @onclick="Close">
+                        <span>&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <EditForm Model="@tipoProjeto" OnValidSubmit="@SalvarTipoProjeto">
+                        <DataAnnotationsValidator />
+                        <ValidationSummary />
+                        
+                        <div class="form-body">
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <div class="form-group">
+                                        <label>Nome do Tipo *</label>
+                                        <InputText @bind-Value="tipoProjeto.Nome" class="form-control" placeholder="Digite o nome do tipo de projeto" maxlength="500" />
+                                        <small class="form-text text-muted">Máximo 500 caracteres</small>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <div class="form-group">
+                                        <label>Descrição</label>
+                                        <InputTextArea @bind-Value="tipoProjeto.Descricao" class="form-control" rows="3" 
+                                                      placeholder="Descreva as características deste tipo de projeto" maxlength="1000" />
+                                        <small class="form-text text-muted">Máximo 1000 caracteres</small>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Código</label>
+                                        <InputText @bind-Value="tipoProjeto.Codigo" class="form-control" placeholder="Código identificador" maxlength="50" />
+                                        <small class="form-text text-muted">Código único para identificação</small>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label>Status</label>
+                                        <InputSelect @bind-Value="tipoProjeto.Ativo" class="form-control">
+                                            <option value="true">Ativo</option>
+                                            <option value="false">Inativo</option>
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" @onclick="Close">Fechar</button>
+                            <button type="submit" class="btn btn-primary" disabled="@isSaving">
+                                @if (isSaving)
+                                {
+                                    <span class="spinner-border spinner-border-sm" role="status"></span>
+                                    <span>Salvando...</span>
+                                }
+                                else
+                                {
+                                    <span>Cadastrar</span>
+                                }
+                            </button>
+                        </div>
+                    </EditForm>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public EventCallback OnClose { get; set; }
+    [Parameter] public EventCallback<TipoProjeto> OnTipoProjetoCadastrado { get; set; }
+    
+    private TipoProjeto tipoProjeto = new();
+    private bool isSaving = false;
+    
+    protected override void OnParametersSet()
+    {
+        if (IsVisible)
+        {
+            LimparFormulario();
+        }
+    }
+    
+    private void LimparFormulario()
+    {
+        tipoProjeto = new TipoProjeto
+        {
+            Ativo = true,
+            DataCriacao = DateTime.Now
+        };
+    }
+    
+    private async Task SalvarTipoProjeto()
+    {
+        if (isSaving) return;
+        
+        try
+        {
+            isSaving = true;
+            
+            // Validações básicas
+            if (string.IsNullOrWhiteSpace(tipoProjeto.Nome))
+            {
+                MessageBoxService.ShowWarning("Nome do tipo é obrigatório");
+                return;
+            }
+            
+            if (tipoProjeto.Nome.Length > 500)
+            {
+                MessageBoxService.ShowWarning("Nome do tipo deve ter no máximo 500 caracteres");
+                return;
+            }
+            
+            if (!string.IsNullOrEmpty(tipoProjeto.Descricao) && tipoProjeto.Descricao.Length > 1000)
+            {
+                MessageBoxService.ShowWarning("Descrição deve ter no máximo 1000 caracteres");
+                return;
+            }
+            
+            if (!string.IsNullOrEmpty(tipoProjeto.Codigo) && tipoProjeto.Codigo.Length > 50)
+            {
+                MessageBoxService.ShowWarning("Código deve ter no máximo 50 caracteres");
+                return;
+            }
+            
+            // Verificar se já existe um tipo com o mesmo nome
+            var tipoExistente = await ProjetosService.ObterTipoProjetoPorNomeAsync(tipoProjeto.Nome);
+            if (tipoExistente != null)
+            {
+                MessageBoxService.ShowWarning("Já existe um tipo de projeto com este nome");
+                return;
+            }
+            
+            // Verificar se já existe um tipo com o mesmo código (se informado)
+            if (!string.IsNullOrEmpty(tipoProjeto.Codigo))
+            {
+                var tipoComCodigo = await ProjetosService.ObterTipoProjetoPorCodigoAsync(tipoProjeto.Codigo);
+                if (tipoComCodigo != null)
+                {
+                    MessageBoxService.ShowWarning("Já existe um tipo de projeto com este código");
+                    return;
+                }
+            }
+            
+            // Salvar tipo de projeto
+            var success = await ProjetosService.InserirTipoProjetoAsync(tipoProjeto);
+            
+            if (success)
+            {
+                MessageBoxService.ShowSuccess("Tipo de projeto cadastrado com sucesso!");
+                await OnTipoProjetoCadastrado.InvokeAsync(tipoProjeto);
+                await Close();
+            }
+            else
+            {
+                MessageBoxService.ShowError("Erro ao cadastrar tipo de projeto");
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao cadastrar tipo de projeto: {ex.Message}");
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+    
+    private async Task Close()
+    {
+        await OnClose.InvokeAsync();
+    }
+}

--- a/Components/Projetos/ProjetoForm.razor
+++ b/Components/Projetos/ProjetoForm.razor
@@ -1,0 +1,302 @@
+@page "/projetos/form"
+@page "/projetos/form/{ProjetoId:int}"
+@using Peers.Moderno.Models
+@using Peers.Moderno.Services.Projetos
+@using Peers.Moderno.Services.Projetos.Common
+@using Peers.Moderno.Services.Common
+@inject IProjetosService ProjetosService
+@inject IProjetosComboHelper ProjetosComboHelper
+@inject IMessageBoxService MessageBoxService
+@inject NavigationManager Navigation
+@rendermode InteractiveAuto
+
+<div class="card">
+    <div class="card-body">
+        <h4 class="card-title">Dados do Projeto</h4>
+        
+        <EditForm Model="@projeto" OnValidSubmit="@HandleValidSubmit">
+            <DataAnnotationsValidator />
+            <ValidationSummary />
+            
+            <div class="form-body">
+                <div class="row">
+                    <div class="col-md-2">
+                        <div class="form-group">
+                            <label>Código</label>
+                            <InputText @bind-Value="projeto.Codigo" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div class="form-group">
+                            <label>Projeto</label>
+                            <InputText @bind-Value="projeto.Nome" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div class="form-group">
+                            <label>Empresa / Cliente</label>
+                            <InputSelect @bind-Value="projeto.IdCliente" class="form-control">
+                                <option value="0">Selecione</option>
+                                @if (clientes != null)
+                                {
+                                    @foreach (var cliente in clientes)
+                                    {
+                                        <option value="@cliente.IdCliente">@cliente.Nome</option>
+                                    }
+                                }
+                            </InputSelect>
+                        </div>
+                    </div>
+                    <div class="col-md-2">
+                        <div class="form-group">
+                            <label>Início</label>
+                            <InputDate @bind-Value="projeto.DataInicio" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="col-md-2">
+                        <div class="form-group">
+                            <label>Término</label>
+                            <InputDate @bind-Value="projeto.DataFim" class="form-control" />
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="row">
+                    <div class="col-md-3">
+                        <div class="form-group">
+                            <label>Responsável 
+                                <button type="button" class="btn btn-link p-0 ml-2" @onclick="OpenResponsavelModal">
+                                    <i class="fa fa-plus" title="Adicionar"></i>
+                                </button>
+                            </label>
+                            <InputSelect @bind-Value="projeto.IdAssociadoResponsavel" class="form-control">
+                                <option value="0">Selecione</option>
+                                @if (responsaveis != null)
+                                {
+                                    @foreach (var responsavel in responsaveis)
+                                    {
+                                        <option value="@responsavel.Id">@responsavel.Nome</option>
+                                    }
+                                }
+                            </InputSelect>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div class="form-group">
+                            <label>Gestor 
+                                <button type="button" class="btn btn-link p-0 ml-2" @onclick="OpenGestorModal">
+                                    <i class="fa fa-plus" title="Adicionar"></i>
+                                </button>
+                            </label>
+                            <InputSelect @bind-Value="projeto.IdAssociadoGestor" class="form-control">
+                                <option value="0">Selecione</option>
+                                @if (gestores != null)
+                                {
+                                    @foreach (var gestor in gestores)
+                                    {
+                                        <option value="@gestor.Id">@gestor.Nome</option>
+                                    }
+                                }
+                            </InputSelect>
+                        </div>
+                    </div>
+                    <div class="col-md-2">
+                        <div class="form-group">
+                            <label>Status</label>
+                            <InputSelect @bind-Value="projeto.Ativo" class="form-control">
+                                <option value="true">Ativo</option>
+                                <option value="false">Inativo</option>
+                            </InputSelect>
+                        </div>
+                    </div>
+                    <div class="col-md-2">
+                        <div class="form-group">
+                            <label>Tipo de Projeto
+                                <button type="button" class="btn btn-link p-0 ml-2" @onclick="OpenTipoModal">
+                                    <i class="fa fa-plus" title="Adicionar"></i>
+                                </button>
+                            </label>
+                            <InputSelect @bind-Value="projeto.IdTipoProjeto" class="form-control">
+                                <option value="0">Selecione</option>
+                                @if (tiposProjeto != null)
+                                {
+                                    @foreach (var tipo in tiposProjeto)
+                                    {
+                                        <option value="@tipo.IdTipo">@tipo.Nome</option>
+                                    }
+                                }
+                            </InputSelect>
+                        </div>
+                    </div>
+                    <div class="col-md-2">
+                        <div class="form-group">
+                            <label>Complexidade 
+                                <button type="button" class="btn btn-link p-0 ml-2" @onclick="OpenComplexidadeModal">
+                                    <i class="fa fa-plus" title="Adicionar"></i>
+                                </button>
+                            </label>
+                            <InputSelect @bind-Value="projeto.IdComplexidade" class="form-control">
+                                <option value="0">Selecione</option>
+                                @if (complexidades != null)
+                                {
+                                    @foreach (var complexidade in complexidades)
+                                    {
+                                        <option value="@complexidade.IdComplexidade">@complexidade.Nome</option>
+                                    }
+                                }
+                            </InputSelect>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="form-actions">
+                <div class="text-right">
+                    <button type="submit" class="btn btn-info" disabled="@isLoading">
+                        @if (isLoading)
+                        {
+                            <span class="spinner-border spinner-border-sm" role="status"></span>
+                            <span>Salvando...</span>
+                        }
+                        else
+                        {
+                            <span>Cadastrar/Salvar</span>
+                        }
+                    </button>
+                    <button type="button" class="btn btn-secondary ml-2" @onclick="Cancel">Cancelar</button>
+                </div>
+            </div>
+        </EditForm>
+    </div>
+</div>
+
+@code {
+    [Parameter] public int? ProjetoId { get; set; }
+    
+    private Projeto projeto = new();
+    private List<Cliente>? clientes;
+    private List<Associado>? responsaveis;
+    private List<Associado>? gestores;
+    private List<TipoProjeto>? tiposProjeto;
+    private List<ProjetoComplexidade>? complexidades;
+    private bool isLoading = false;
+    
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadCombos();
+        
+        if (ProjetoId.HasValue && ProjetoId.Value > 0)
+        {
+            await LoadProjeto(ProjetoId.Value);
+        }
+    }
+    
+    private async Task LoadCombos()
+    {
+        try
+        {
+            clientes = await ProjetosComboHelper.GetClientesAsync();
+            responsaveis = await ProjetosComboHelper.GetResponsaveisAsync();
+            gestores = await ProjetosComboHelper.GetGestoresAsync();
+            tiposProjeto = await ProjetosComboHelper.GetTiposProjetoAsync();
+            complexidades = await ProjetosComboHelper.GetComplexidadesAsync();
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao carregar dados: {ex.Message}");
+        }
+    }
+    
+    private async Task LoadProjeto(int id)
+    {
+        try
+        {
+            var projetoExistente = await ProjetosService.ObterProjetoAsync(id);
+            if (projetoExistente != null)
+            {
+                projeto = projetoExistente;
+            }
+            else
+            {
+                MessageBoxService.ShowError("Projeto não encontrado");
+                Navigation.NavigateTo("/projetos");
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao carregar projeto: {ex.Message}");
+        }
+    }
+    
+    private async Task HandleValidSubmit()
+    {
+        if (isLoading) return;
+        
+        isLoading = true;
+        
+        try
+        {
+            if (projeto.DataInicio == default || projeto.DataFim == default)
+            {
+                MessageBoxService.ShowWarning("Data de Início e Término devem ser preenchidos.");
+                return;
+            }
+            
+            bool success;
+            if (ProjetoId.HasValue && ProjetoId.Value > 0)
+            {
+                success = await ProjetosService.AtualizarProjetoAsync(projeto);
+                if (success)
+                {
+                    MessageBoxService.ShowSuccess("Projeto atualizado com sucesso!");
+                }
+            }
+            else
+            {
+                success = await ProjetosService.InserirProjetoAsync(projeto);
+                if (success)
+                {
+                    MessageBoxService.ShowSuccess("Projeto cadastrado com sucesso!");
+                }
+            }
+            
+            if (success)
+            {
+                Navigation.NavigateTo("/projetos");
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao salvar projeto: {ex.Message}");
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+    
+    private void Cancel()
+    {
+        Navigation.NavigateTo("/projetos");
+    }
+    
+    private void OpenResponsavelModal()
+    {
+        // TODO: Implementar modal de responsável
+    }
+    
+    private void OpenGestorModal()
+    {
+        // TODO: Implementar modal de gestor
+    }
+    
+    private void OpenTipoModal()
+    {
+        // TODO: Implementar modal de tipo
+    }
+    
+    private void OpenComplexidadeModal()
+    {
+        // TODO: Implementar modal de complexidade
+    }
+}

--- a/Components/Projetos/ProjetosList.razor
+++ b/Components/Projetos/ProjetosList.razor
@@ -1,0 +1,374 @@
+@page "/projetos"
+@using Peers.Moderno.Models
+@using Peers.Moderno.Services.Projetos
+@using Peers.Moderno.Services.Common
+@inject IProjetosService ProjetosService
+@inject IMessageBoxService MessageBoxService
+@inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
+@rendermode InteractiveAuto
+
+<div class="page-breadcrumb border-bottom">
+    <div class="row">
+        <div class="col-lg-3 col-md-4 col-xs-12 align-self-center">
+            <h5 class="font-medium text-uppercase mb-0">Projetos</h5>
+        </div>
+        <div class="col-lg-9 col-md-8 col-xs-12 align-self-center">
+            <nav aria-label="breadcrumb" class="mt-2 float-md-right float-left">
+                <ol class="breadcrumb mb-0 justify-content-end p-0">
+                    <li class="breadcrumb-item"><a href="/">Peers</a></li>
+                    <li class="breadcrumb-item active">Cadastros de Projetos</li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+</div>
+
+<div class="page-content container-fluid">
+    <div class="card">
+        <div class="card-body">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h4 class="card-title mb-0">Lista de projetos</h4>
+                <button type="button" class="btn btn-primary" @onclick="NovoProjeto">
+                    <i class="fa fa-plus"></i> Novo Projeto
+                </button>
+            </div>
+            
+            <div class="row mb-3">
+                <div class="col-md-6">
+                    <div class="form-group">
+                        <label>Filtrar projetos:</label>
+                        <input type="text" class="form-control" @bind="filtro" @bind:event="oninput" @onkeyup="FiltrarProjetos" 
+                               placeholder="Digite para filtrar por projeto, cliente, responsável..." />
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="form-group">
+                        <label>Status:</label>
+                        <select class="form-control" @bind="filtroStatus" @onchange="FiltrarProjetos">
+                            <option value="">Todos</option>
+                            <option value="true">Ativo</option>
+                            <option value="false">Inativo</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="form-group">
+                        <label>&nbsp;</label>
+                        <div>
+                            <button type="button" class="btn btn-secondary" @onclick="LimparFiltros">
+                                <i class="fa fa-times"></i> Limpar
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
+            @if (isLoading)
+            {
+                <div class="text-center p-4">
+                    <div class="spinner-border" role="status">
+                        <span class="sr-only">Carregando...</span>
+                    </div>
+                    <p class="mt-2">Carregando projetos...</p>
+                </div>
+            }
+            else if (projetosFiltrados?.Any() == true)
+            {
+                <div class="table-responsive">
+                    <table class="table table-striped border">
+                        <thead>
+                            <tr>
+                                <th @onclick="() => OrdenarPor(nameof(Projeto.Nome))" style="cursor: pointer;">
+                                    Projeto 
+                                    @if (campoOrdenacao == nameof(Projeto.Nome))
+                                    {
+                                        <i class="fa @(ordemCrescente ? "fa-sort-up" : "fa-sort-down")"></i>
+                                    }
+                                </th>
+                                <th @onclick="() => OrdenarPor(nameof(Projeto.DataInicio))" style="cursor: pointer;">
+                                    Data Início 
+                                    @if (campoOrdenacao == nameof(Projeto.DataInicio))
+                                    {
+                                        <i class="fa @(ordemCrescente ? "fa-sort-up" : "fa-sort-down")"></i>
+                                    }
+                                </th>
+                                <th @onclick="() => OrdenarPor(nameof(Projeto.DataFim))" style="cursor: pointer;">
+                                    Data Término 
+                                    @if (campoOrdenacao == nameof(Projeto.DataFim))
+                                    {
+                                        <i class="fa @(ordemCrescente ? "fa-sort-up" : "fa-sort-down")"></i>
+                                    }
+                                </th>
+                                <th>Cliente</th>
+                                <th>Responsável</th>
+                                <th>Status</th>
+                                <th>Ações</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var projeto in projetosFiltrados)
+                            {
+                                <tr>
+                                    <td>@projeto.Nome</td>
+                                    <td>@projeto.DataInicio.ToString("dd/MM/yyyy")</td>
+                                    <td>@projeto.DataFim?.ToString("dd/MM/yyyy")</td>
+                                    <td>@projeto.Cliente?.Nome</td>
+                                    <td>@projeto.AssociadoResponsavel?.Nome</td>
+                                    <td>
+                                        <span class="badge @(projeto.Ativo ? "badge-success" : "badge-secondary")">
+                                            @(projeto.Ativo ? "Ativo" : "Inativo")
+                                        </span>
+                                    </td>
+                                    <td>
+                                        <div class="btn-group" role="group">
+                                            <button type="button" class="btn btn-sm btn-primary" 
+                                                    @onclick="() => EditarProjeto(projeto.Id)" title="Editar">
+                                                <i class="fa fa-edit"></i>
+                                            </button>
+                                            <button type="button" class="btn btn-sm btn-info" 
+                                                    @onclick="() => GerenciarAssociados(projeto.Id)" title="Gerenciar Associados">
+                                                <i class="fa fa-users"></i>
+                                            </button>
+                                            @if (projeto.Ativo)
+                                            {
+                                                <button type="button" class="btn btn-sm btn-warning" 
+                                                        @onclick="() => InativarProjeto(projeto.Id)" title="Inativar">
+                                                    <i class="fa fa-pause"></i>
+                                                </button>
+                                            }
+                                            else
+                                            {
+                                                <button type="button" class="btn btn-sm btn-success" 
+                                                        @onclick="() => AtivarProjeto(projeto.Id)" title="Ativar">
+                                                    <i class="fa fa-play"></i>
+                                                </button>
+                                            }
+                                            <button type="button" class="btn btn-sm btn-danger" 
+                                                    @onclick="() => ExcluirProjeto(projeto.Id)" title="Excluir">
+                                                <i class="fa fa-trash"></i>
+                                            </button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+                
+                <div class="d-flex justify-content-between align-items-center mt-3">
+                    <div>
+                        <small class="text-muted">
+                            Exibindo @projetosFiltrados.Count() de @(projetos?.Count() ?? 0) projetos
+                        </small>
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="text-center p-4">
+                    <i class="fa fa-folder-open fa-3x text-muted mb-3"></i>
+                    <h5 class="text-muted">Nenhum projeto encontrado</h5>
+                    <p class="text-muted">@(string.IsNullOrEmpty(filtro) ? "Não há projetos cadastrados." : "Nenhum projeto corresponde aos filtros aplicados.")</p>
+                    <button type="button" class="btn btn-primary" @onclick="NovoProjeto">
+                        <i class="fa fa-plus"></i> Cadastrar Primeiro Projeto
+                    </button>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+@code {
+    private List<Projeto>? projetos;
+    private IEnumerable<Projeto>? projetosFiltrados;
+    private string filtro = string.Empty;
+    private string filtroStatus = string.Empty;
+    private bool isLoading = true;
+    private string campoOrdenacao = nameof(Projeto.Nome);
+    private bool ordemCrescente = true;
+    
+    protected override async Task OnInitializedAsync()
+    {
+        await CarregarProjetos();
+    }
+    
+    private async Task CarregarProjetos()
+    {
+        try
+        {
+            isLoading = true;
+            projetos = await ProjetosService.ObterProjetosAsync();
+            AplicarFiltros();
+        }
+        catch (Exception ex)
+        {
+            MessageBoxService.ShowError($"Erro ao carregar projetos: {ex.Message}");
+            projetos = new List<Projeto>();
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+    
+    private void FiltrarProjetos()
+    {
+        AplicarFiltros();
+    }
+    
+    private void AplicarFiltros()
+    {
+        if (projetos == null)
+        {
+            projetosFiltrados = new List<Projeto>();
+            return;
+        }
+        
+        var query = projetos.AsEnumerable();
+        
+        if (!string.IsNullOrWhiteSpace(filtro))
+        {
+            var filtroLower = filtro.ToLower();
+            query = query.Where(p => 
+                (p.Nome?.ToLower().Contains(filtroLower) == true) ||
+                (p.Codigo?.ToLower().Contains(filtroLower) == true) ||
+                (p.Cliente?.Nome?.ToLower().Contains(filtroLower) == true) ||
+                (p.AssociadoResponsavel?.Nome?.ToLower().Contains(filtroLower) == true) ||
+                (p.AssociadoGestor?.Nome?.ToLower().Contains(filtroLower) == true)
+            );
+        }
+        
+        if (!string.IsNullOrEmpty(filtroStatus))
+        {
+            var statusFiltro = bool.Parse(filtroStatus);
+            query = query.Where(p => p.Ativo == statusFiltro);
+        }
+        
+        query = OrdenarQuery(query);
+        projetosFiltrados = query.ToList();
+    }
+    
+    private IEnumerable<Projeto> OrdenarQuery(IEnumerable<Projeto> query)
+    {
+        return campoOrdenacao switch
+        {
+            nameof(Projeto.Nome) => ordemCrescente ? query.OrderBy(p => p.Nome) : query.OrderByDescending(p => p.Nome),
+            nameof(Projeto.DataInicio) => ordemCrescente ? query.OrderBy(p => p.DataInicio) : query.OrderByDescending(p => p.DataInicio),
+            nameof(Projeto.DataFim) => ordemCrescente ? query.OrderBy(p => p.DataFim) : query.OrderByDescending(p => p.DataFim),
+            _ => ordemCrescente ? query.OrderBy(p => p.Nome) : query.OrderByDescending(p => p.Nome)
+        };
+    }
+    
+    private void OrdenarPor(string campo)
+    {
+        if (campoOrdenacao == campo)
+        {
+            ordemCrescente = !ordemCrescente;
+        }
+        else
+        {
+            campoOrdenacao = campo;
+            ordemCrescente = true;
+        }
+        
+        AplicarFiltros();
+    }
+    
+    private void LimparFiltros()
+    {
+        filtro = string.Empty;
+        filtroStatus = string.Empty;
+        AplicarFiltros();
+    }
+    
+    private void NovoProjeto()
+    {
+        Navigation.NavigateTo("/projetos/form");
+    }
+    
+    private void EditarProjeto(int id)
+    {
+        Navigation.NavigateTo($"/projetos/form/{id}");
+    }
+    
+    private void GerenciarAssociados(int id)
+    {
+        Navigation.NavigateTo($"/projetos/{id}/associados");
+    }
+    
+    private async Task InativarProjeto(int id)
+    {
+        var confirmado = await JSRuntime.InvokeAsync<bool>("confirm", "Deseja realmente inativar este projeto?");
+        if (confirmado)
+        {
+            try
+            {
+                var success = await ProjetosService.InativarProjetoAsync(id);
+                if (success)
+                {
+                    MessageBoxService.ShowSuccess("Projeto inativado com sucesso!");
+                    await CarregarProjetos();
+                }
+                else
+                {
+                    MessageBoxService.ShowError("Erro ao inativar projeto");
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBoxService.ShowError($"Erro ao inativar projeto: {ex.Message}");
+            }
+        }
+    }
+    
+    private async Task AtivarProjeto(int id)
+    {
+        var confirmado = await JSRuntime.InvokeAsync<bool>("confirm", "Deseja realmente ativar este projeto?");
+        if (confirmado)
+        {
+            try
+            {
+                var success = await ProjetosService.AtivarProjetoAsync(id);
+                if (success)
+                {
+                    MessageBoxService.ShowSuccess("Projeto ativado com sucesso!");
+                    await CarregarProjetos();
+                }
+                else
+                {
+                    MessageBoxService.ShowError("Erro ao ativar projeto");
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBoxService.ShowError($"Erro ao ativar projeto: {ex.Message}");
+            }
+        }
+    }
+    
+    private async Task ExcluirProjeto(int id)
+    {
+        var confirmado = await JSRuntime.InvokeAsync<bool>("confirm", "Deseja realmente excluir este projeto? Esta ação não pode ser desfeita.");
+        if (confirmado)
+        {
+            try
+            {
+                var success = await ProjetosService.RemoverProjetoAsync(id);
+                if (success)
+                {
+                    MessageBoxService.ShowSuccess("Projeto excluído com sucesso!");
+                    await CarregarProjetos();
+                }
+                else
+                {
+                    MessageBoxService.ShowError("Erro ao excluir projeto");
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBoxService.ShowError($"Erro ao excluir projeto: {ex.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Este PR implementa a migração dos principais componentes da página de projetos para Blazor, seguindo o padrão de reutilização e centralização de serviços em pastas 'Common'. Foram criados os formulários de cadastro/edição de projetos, listagem, gerenciamento de associados e modais para cadastro rápido de entidades relacionadas. Também foi criada a pasta 'docs' com documentação técnica detalhada e um fluxo mermaid de alto nível para facilitar a compreensão e integração dos novos componentes.