### PR TITLE
Serviços e modelos para SubCompetências com exportação reutilizável e documentação

### DIFF
--- a/Models/SubCompetencia.cs
+++ b/Models/SubCompetencia.cs
@@ -1,12 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace Peers.Moderno.Models;
 
+[Table("SUBCOMPETENCIAS")]
 public class SubCompetencia
 {
+    [Key]
     public int IdSubCompetencia { get; set; }
+
+    [Required]
+    [MaxLength(500)]
+    [Column("SubCompetencia")]
     public string Nome { get; set; } = string.Empty;
-    public int ATV { get; set; }
-    
-    // Navegação
+
+    [MaxLength(50)]
+    public string? TipoAvaliacao { get; set; }
+
+    public bool Ativo { get; set; } = true;
+
+    public DateTime DHC { get; set; }
+
+    public int USR { get; set; }
+
+    // Navigation properties
     public virtual ICollection<Competencia> Competencias { get; set; } = new List<Competencia>();
-    public virtual ICollection<RelacaoCargoSubcompetencia> RelacoesSubcompetencia { get; set; } = new List<RelacaoCargoSubcompetencia>();
 }

--- a/Models/SubcompetenciaModelExport.cs
+++ b/Models/SubcompetenciaModelExport.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel;
+
+namespace Peers.Moderno.Models;
+
+public class SubcompetenciaModelExport
+{
+    [DisplayName("Código")]
+    public int IdSubcompetencia { get; set; }
+
+    [DisplayName("Sub Competência")]
+    public string Subcompetencia { get; set; } = string.Empty;
+
+    [DisplayName("Tipo Avaliação")]
+    public string? TipoAvaliacao { get; set; }
+
+    [DisplayName("Status")]
+    public int ATV { get; set; }
+
+    [DisplayName("Status Texto")]
+    public string StatusTexto => ATV == 1 ? "Ativo" : "Inativo";
+}

--- a/Program.cs
+++ b/Program.cs
@@ -36,6 +36,7 @@ using Peers.Moderno.Services.Premissas;
 using Peers.Moderno.Services.Premissas.Common;
 using Peers.Moderno.Services.Projetos;
 using Peers.Moderno.Services.Projetos.Common;
+using Peers.Moderno.Services.SubCompetencias;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
@@ -125,6 +126,9 @@ builder.Services.AddScoped<ISubCompetenciasService, SubCompetenciasService>();
 builder.Services.AddScoped<IAvaliacoesService, AvaliacoesService>();
 builder.Services.AddScoped<IExportFileService, ExportFileService>();
 builder.Services.AddScoped<Services.Premissas.Common.IPremissasService, Services.Premissas.PremissasService>();
+
+// SubCompetencias Services - Novos serviços adicionados
+builder.Services.AddScoped<Services.SubCompetencias.ISubCompetenciasService, Services.SubCompetencias.SubCompetenciasService>();
 
 // Eixos Services
 builder.Services.AddScoped<Services.Eixos.IEixosService, Services.Eixos.EixosService>();

--- a/Services/Common/ExportFileService.cs
+++ b/Services/Common/ExportFileService.cs
@@ -1,0 +1,193 @@
+using OfficeOpenXml;
+using System.ComponentModel;
+using System.Reflection;
+using Peers.Moderno.Services.Common;
+
+namespace Peers.Moderno.Services.Common;
+
+public interface IExportFileService
+{
+    Task<byte[]> ExportToExcelAsync<T>(List<T> data, string sheetName = "Data");
+    Task<byte[]> ExportToExcelWithCustomColumnsAsync<T>(List<T> data, Dictionary<string, string> columnMappings, string sheetName = "Data");
+    Task<byte[]> GenerateExcelSubCompetenciasAsync<T>(string fileName, List<T> data);
+    Task<byte[]> GenerateExcelConsideracoesMentorAsync<T>(string fileName, List<T> data);
+    string GenerateFileName(string prefix, string extension = ".xlsx");
+}
+
+public class ExportFileService : IExportFileService
+{
+    private readonly ITelemetryService _telemetryService;
+
+    public ExportFileService(ITelemetryService telemetryService)
+    {
+        _telemetryService = telemetryService;
+        ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+    }
+
+    public async Task<byte[]> ExportToExcelAsync<T>(List<T> data, string sheetName = "Data")
+    {
+        try
+        {
+            using var package = new ExcelPackage();
+            var worksheet = package.Workbook.Worksheets.Add(sheetName);
+
+            if (data == null || !data.Any())
+            {
+                worksheet.Cells[1, 1].Value = "Nenhum dado encontrado";
+                return package.GetAsByteArray();
+            }
+
+            var properties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.CanRead && IsSimpleType(p.PropertyType))
+                .ToArray();
+
+            // Cabeçalhos
+            for (int i = 0; i < properties.Length; i++)
+            {
+                var displayName = GetDisplayName(properties[i]);
+                worksheet.Cells[1, i + 1].Value = displayName;
+                worksheet.Cells[1, i + 1].Style.Font.Bold = true;
+            }
+
+            // Dados
+            for (int row = 0; row < data.Count; row++)
+            {
+                for (int col = 0; col < properties.Length; col++)
+                {
+                    var value = properties[col].GetValue(data[row]);
+                    worksheet.Cells[row + 2, col + 1].Value = FormatCellValue(value);
+                }
+            }
+
+            // Auto-fit columns
+            worksheet.Cells[worksheet.Dimension.Address].AutoFitColumns();
+
+            _telemetryService.TrackEvent("ExcelExportCompleted", new Dictionary<string, string>
+            {
+                { "RecordCount", data.Count.ToString() },
+                { "SheetName", sheetName },
+                { "DataType", typeof(T).Name }
+            });
+
+            return package.GetAsByteArray();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ExportToExcelAsync" },
+                { "Component", "ExportFileService" },
+                { "DataType", typeof(T).Name }
+            });
+            throw;
+        }
+    }
+
+    public async Task<byte[]> ExportToExcelWithCustomColumnsAsync<T>(List<T> data, Dictionary<string, string> columnMappings, string sheetName = "Data")
+    {
+        try
+        {
+            using var package = new ExcelPackage();
+            var worksheet = package.Workbook.Worksheets.Add(sheetName);
+
+            if (data == null || !data.Any())
+            {
+                worksheet.Cells[1, 1].Value = "Nenhum dado encontrado";
+                return package.GetAsByteArray();
+            }
+
+            var properties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.CanRead && columnMappings.ContainsKey(p.Name))
+                .ToArray();
+
+            // Cabeçalhos personalizados
+            for (int i = 0; i < properties.Length; i++)
+            {
+                var columnName = columnMappings[properties[i].Name];
+                worksheet.Cells[1, i + 1].Value = columnName;
+                worksheet.Cells[1, i + 1].Style.Font.Bold = true;
+            }
+
+            // Dados
+            for (int row = 0; row < data.Count; row++)
+            {
+                for (int col = 0; col < properties.Length; col++)
+                {
+                    var value = properties[col].GetValue(data[row]);
+                    worksheet.Cells[row + 2, col + 1].Value = FormatCellValue(value);
+                }
+            }
+
+            worksheet.Cells[worksheet.Dimension.Address].AutoFitColumns();
+
+            return package.GetAsByteArray();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ExportToExcelWithCustomColumnsAsync" },
+                { "Component", "ExportFileService" },
+                { "DataType", typeof(T).Name }
+            });
+            throw;
+        }
+    }
+
+    public async Task<byte[]> GenerateExcelSubCompetenciasAsync<T>(string fileName, List<T> data)
+    {
+        var columnMappings = new Dictionary<string, string>
+        {
+            { "IdSubCompetencia", "Código" },
+            { "Nome", "Sub Competência" },
+            { "TipoAvaliacao", "Tipo Avaliação" },
+            { "Ativo", "Status" }
+        };
+
+        return await ExportToExcelWithCustomColumnsAsync(data, columnMappings, "SubCompetencias");
+    }
+
+    public async Task<byte[]> GenerateExcelConsideracoesMentorAsync<T>(string fileName, List<T> data)
+    {
+        return await ExportToExcelAsync(data, "ConsideracoesMentor");
+    }
+
+    public string GenerateFileName(string prefix, string extension = ".xlsx")
+    {
+        var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+        return $"{prefix}_{timestamp}{extension}";
+    }
+
+    private static bool IsSimpleType(Type type)
+    {
+        return type.IsPrimitive ||
+               type.IsEnum ||
+               type == typeof(string) ||
+               type == typeof(decimal) ||
+               type == typeof(DateTime) ||
+               type == typeof(DateTimeOffset) ||
+               type == typeof(TimeSpan) ||
+               type == typeof(Guid) ||
+               Nullable.GetUnderlyingType(type) != null;
+    }
+
+    private static string GetDisplayName(PropertyInfo property)
+    {
+        var displayAttribute = property.GetCustomAttribute<DisplayNameAttribute>();
+        return displayAttribute?.DisplayName ?? property.Name;
+    }
+
+    private static object? FormatCellValue(object? value)
+    {
+        if (value == null)
+            return string.Empty;
+
+        if (value is bool boolValue)
+            return boolValue ? "Ativo" : "Inativo";
+
+        if (value is DateTime dateValue)
+            return dateValue.ToString("dd/MM/yyyy HH:mm:ss");
+
+        return value;
+    }
+}

--- a/Services/SubCompetencias/ISubCompetenciasService.cs
+++ b/Services/SubCompetencias/ISubCompetenciasService.cs
@@ -1,0 +1,17 @@
+using Peers.Moderno.Models;
+
+namespace Peers.Moderno.Services.SubCompetencias;
+
+public interface ISubCompetenciasService
+{
+    Task<List<SubCompetencia>> ListarSubCompetenciasAsync();
+    Task<List<SubCompetencia>> ListarSubCompetenciasAtivasAsync();
+    Task<SubCompetencia?> ObterSubCompetenciaAsync(int id);
+    Task<bool> InserirSubCompetenciaAsync(SubCompetencia subCompetencia);
+    Task<bool> AlterarSubCompetenciaAsync(SubCompetencia subCompetencia);
+    Task<bool> ExcluirSubCompetenciaAsync(int id);
+    Task<bool> InativarSubCompetenciaAsync(int id);
+    Task<bool> ExisteSubCompetenciaAsync(string nome, int? idExcluir = null);
+    Task<int> ContarSubCompetenciasAtivasAsync();
+    Task<List<SubCompetencia>> BuscarSubCompetenciasPorNomeAsync(string nome);
+}

--- a/Services/SubCompetencias/SubCompetenciasService.cs
+++ b/Services/SubCompetencias/SubCompetenciasService.cs
@@ -1,0 +1,303 @@
+using Microsoft.EntityFrameworkCore;
+using Peers.Moderno.Data;
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Common;
+
+namespace Peers.Moderno.Services.SubCompetencias;
+
+public class SubCompetenciasService : ISubCompetenciasService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ITelemetryService _telemetryService;
+
+    public SubCompetenciasService(
+        ApplicationDbContext context,
+        ITelemetryService telemetryService)
+    {
+        _context = context;
+        _telemetryService = telemetryService;
+    }
+
+    public async Task<List<SubCompetencia>> ListarSubCompetenciasAsync()
+    {
+        try
+        {
+            var subCompetencias = await _context.SubCompetencias
+                .AsNoTracking()
+                .OrderBy(s => s.Nome)
+                .ToListAsync();
+
+            _telemetryService.TrackEvent("SubCompetenciasListadas", new Dictionary<string, string>
+            {
+                { "Count", subCompetencias.Count.ToString() }
+            });
+
+            return subCompetencias;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ListarSubCompetenciasAsync" },
+                { "Component", "SubCompetenciasService" }
+            });
+            throw;
+        }
+    }
+
+    public async Task<List<SubCompetencia>> ListarSubCompetenciasAtivasAsync()
+    {
+        try
+        {
+            var subCompetencias = await _context.SubCompetencias
+                .AsNoTracking()
+                .Where(s => s.Ativo)
+                .OrderBy(s => s.Nome)
+                .ToListAsync();
+
+            return subCompetencias;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ListarSubCompetenciasAtivasAsync" },
+                { "Component", "SubCompetenciasService" }
+            });
+            throw;
+        }
+    }
+
+    public async Task<SubCompetencia?> ObterSubCompetenciaAsync(int id)
+    {
+        try
+        {
+            return await _context.SubCompetencias
+                .FirstOrDefaultAsync(s => s.IdSubCompetencia == id);
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ObterSubCompetenciaAsync" },
+                { "Component", "SubCompetenciasService" },
+                { "Id", id.ToString() }
+            });
+            throw;
+        }
+    }
+
+    public async Task<bool> InserirSubCompetenciaAsync(SubCompetencia subCompetencia)
+    {
+        try
+        {
+            subCompetencia.DHC = DateTime.Now;
+            subCompetencia.Ativo = true;
+
+            _context.SubCompetencias.Add(subCompetencia);
+            var result = await _context.SaveChangesAsync() > 0;
+
+            if (result)
+            {
+                _telemetryService.TrackEvent("SubCompetenciaInserida", new Dictionary<string, string>
+                {
+                    { "Id", subCompetencia.IdSubCompetencia.ToString() },
+                    { "Nome", subCompetencia.Nome },
+                    { "Usuario", subCompetencia.USR.ToString() }
+                });
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "InserirSubCompetenciaAsync" },
+                { "Component", "SubCompetenciasService" },
+                { "Nome", subCompetencia?.Nome ?? "Unknown" }
+            });
+            throw;
+        }
+    }
+
+    public async Task<bool> AlterarSubCompetenciaAsync(SubCompetencia subCompetencia)
+    {
+        try
+        {
+            var subCompetenciaExistente = await ObterSubCompetenciaAsync(subCompetencia.IdSubCompetencia);
+            if (subCompetenciaExistente == null)
+                return false;
+
+            subCompetenciaExistente.Nome = subCompetencia.Nome;
+            subCompetenciaExistente.Ativo = subCompetencia.Ativo;
+            subCompetenciaExistente.DHC = DateTime.Now;
+            subCompetenciaExistente.USR = subCompetencia.USR;
+            subCompetenciaExistente.TipoAvaliacao = subCompetencia.TipoAvaliacao;
+
+            _context.SubCompetencias.Update(subCompetenciaExistente);
+            var result = await _context.SaveChangesAsync() > 0;
+
+            if (result)
+            {
+                _telemetryService.TrackEvent("SubCompetenciaAlterada", new Dictionary<string, string>
+                {
+                    { "Id", subCompetencia.IdSubCompetencia.ToString() },
+                    { "Nome", subCompetencia.Nome },
+                    { "Usuario", subCompetencia.USR.ToString() }
+                });
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "AlterarSubCompetenciaAsync" },
+                { "Component", "SubCompetenciasService" },
+                { "Id", subCompetencia?.IdSubCompetencia.ToString() ?? "Unknown" }
+            });
+            throw;
+        }
+    }
+
+    public async Task<bool> ExcluirSubCompetenciaAsync(int id)
+    {
+        try
+        {
+            var subCompetencia = await ObterSubCompetenciaAsync(id);
+            if (subCompetencia == null)
+                return false;
+
+            _context.SubCompetencias.Remove(subCompetencia);
+            var result = await _context.SaveChangesAsync() > 0;
+
+            if (result)
+            {
+                _telemetryService.TrackEvent("SubCompetenciaExcluida", new Dictionary<string, string>
+                {
+                    { "Id", id.ToString() },
+                    { "Nome", subCompetencia.Nome }
+                });
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ExcluirSubCompetenciaAsync" },
+                { "Component", "SubCompetenciasService" },
+                { "Id", id.ToString() }
+            });
+            throw;
+        }
+    }
+
+    public async Task<bool> InativarSubCompetenciaAsync(int id)
+    {
+        try
+        {
+            var subCompetencia = await ObterSubCompetenciaAsync(id);
+            if (subCompetencia == null)
+                return false;
+
+            subCompetencia.Ativo = false;
+            subCompetencia.DHC = DateTime.Now;
+
+            _context.SubCompetencias.Update(subCompetencia);
+            var result = await _context.SaveChangesAsync() > 0;
+
+            if (result)
+            {
+                _telemetryService.TrackEvent("SubCompetenciaInativada", new Dictionary<string, string>
+                {
+                    { "Id", id.ToString() },
+                    { "Nome", subCompetencia.Nome }
+                });
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "InativarSubCompetenciaAsync" },
+                { "Component", "SubCompetenciasService" },
+                { "Id", id.ToString() }
+            });
+            throw;
+        }
+    }
+
+    public async Task<bool> ExisteSubCompetenciaAsync(string nome, int? idExcluir = null)
+    {
+        try
+        {
+            var query = _context.SubCompetencias.Where(s => s.Nome.ToLower() == nome.ToLower());
+            
+            if (idExcluir.HasValue)
+            {
+                query = query.Where(s => s.IdSubCompetencia != idExcluir.Value);
+            }
+
+            return await query.AnyAsync();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ExisteSubCompetenciaAsync" },
+                { "Component", "SubCompetenciasService" },
+                { "Nome", nome }
+            });
+            throw;
+        }
+    }
+
+    public async Task<int> ContarSubCompetenciasAtivasAsync()
+    {
+        try
+        {
+            return await _context.SubCompetencias
+                .CountAsync(s => s.Ativo);
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ContarSubCompetenciasAtivasAsync" },
+                { "Component", "SubCompetenciasService" }
+            });
+            throw;
+        }
+    }
+
+    public async Task<List<SubCompetencia>> BuscarSubCompetenciasPorNomeAsync(string nome)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(nome))
+                return new List<SubCompetencia>();
+
+            return await _context.SubCompetencias
+                .AsNoTracking()
+                .Where(s => s.Nome.Contains(nome))
+                .OrderBy(s => s.Nome)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "BuscarSubCompetenciasPorNomeAsync" },
+                { "Component", "SubCompetenciasService" },
+                { "Nome", nome }
+            });
+            throw;
+        }
+    }
+}

--- a/docs/SubCompetencias.md
+++ b/docs/SubCompetencias.md
@@ -1,0 +1,140 @@
+# SubCompetências - Migração para Blazor
+
+## Visão Geral
+
+Este documento descreve a migração da funcionalidade de SubCompetências do Web Forms para Blazor, incluindo a criação de serviços reutilizáveis e a centralização da lógica de negócio.
+
+## Arquitetura
+
+### Serviços Implementados
+
+#### ISubCompetenciasService
+- **Localização**: `Services/SubCompetencias/`
+- **Responsabilidade**: Gerenciar todas as operações CRUD de SubCompetências
+- **Funcionalidades**:
+  - Listagem de SubCompetências (todas e apenas ativas)
+  - Inserção, alteração e exclusão
+  - Inativação de registros
+  - Busca por nome
+  - Validação de duplicatas
+
+#### IExportFileService
+- **Localização**: `Services/Common/`
+- **Responsabilidade**: Exportação de dados para Excel
+- **Funcionalidades**:
+  - Exportação genérica para qualquer tipo de dados
+  - Exportação com mapeamento customizado de colunas
+  - Formatação automática de valores (datas, booleanos)
+  - Geração de nomes de arquivo com timestamp
+
+#### IMessageBoxService
+- **Localização**: `Services/Common/`
+- **Responsabilidade**: Exibição de mensagens para o usuário
+- **Funcionalidades**:
+  - Mensagens de sucesso, erro, informação e aviso
+  - Sistema de eventos para comunicação com a UI
+
+### Modelos
+
+#### SubCompetencia
+- **Localização**: `Models/`
+- **Mapeamento**: Tabela `SUBCOMPETENCIAS`
+- **Propriedades**:
+  - `IdSubCompetencia`: Chave primária
+  - `Nome`: Nome da subcompetência
+  - `TipoAvaliacao`: Tipo de avaliação (opcional)
+  - `Ativo`: Status ativo/inativo
+  - `DHC`: Data/hora de criação
+  - `USR`: ID do usuário que criou/alterou
+
+#### SubcompetenciaModelExport
+- **Localização**: `Models/`
+- **Responsabilidade**: Modelo específico para exportação
+- **Características**:
+  - Propriedades com atributos `DisplayName`
+  - Formatação de status como texto
+  - Otimizado para geração de Excel
+
+## Integração
+
+### Injeção de Dependência
+
+Os serviços são registrados no `Program.cs`:
+
+csharp
+builder.Services.AddScoped<Services.SubCompetencias.ISubCompetenciasService, Services.SubCompetencias.SubCompetenciasService>();
+builder.Services.AddScoped<IExportFileService, ExportFileService>();
+builder.Services.AddScoped<IMessageBoxService, MessageBoxService>();
+
+
+### Uso em Componentes Blazor
+
+csharp
+@inject ISubCompetenciasService SubCompetenciasService
+@inject IExportFileService ExportService
+@inject IMessageBoxService MessageBox
+
+// Exemplo de uso
+var subCompetencias = await SubCompetenciasService.ListarSubCompetenciasAsync();
+var excelData = await ExportService.GenerateExcelSubCompetenciasAsync("SubCompetencias", subCompetencias);
+MessageBox.ShowSuccess("Operação realizada com sucesso!");
+
+
+## Fluxo de Alto Nível
+
+mermaid
+flowchart TD
+    A[Usuário acessa SubCompetencias.razor] --> B{Ação do Usuário}
+    
+    B -->|Listar| C[SubCompetenciasService.ListarSubCompetenciasAsync]
+    C --> D[Renderiza Tabela]
+    
+    B -->|Cadastrar/Editar| E[Validação de Dados]
+    E -->|Válido| F[SubCompetenciasService.InserirOuAlterarAsync]
+    E -->|Inválido| G[MessageBoxService.ShowError]
+    
+    F -->|Sucesso| H[MessageBoxService.ShowSuccess]
+    F -->|Erro| I[MessageBoxService.ShowError]
+    
+    B -->|Inativar| J[SubCompetenciasService.InativarAsync]
+    J -->|Sucesso| K[MessageBoxService.ShowSuccess]
+    J -->|Erro| L[MessageBoxService.ShowError]
+    
+    B -->|Exportar| M[ExportFileService.GenerateExcelSubCompetenciasAsync]
+    M --> N[Download do Arquivo Excel]
+    
+    D -->|Alterar| E
+    D -->|Inativar| J
+    D -->|Exportar| M
+    
+    H --> O[Recarrega Lista]
+    K --> O
+    O --> D
+
+
+## Benefícios da Migração
+
+1. **Separação de Responsabilidades**: Lógica de negócio separada da UI
+2. **Reutilização**: Serviços podem ser utilizados em outros componentes
+3. **Testabilidade**: Serviços podem ser testados independentemente
+4. **Manutenibilidade**: Código mais organizado e fácil de manter
+5. **Performance**: Entity Framework Core com otimizações (AsNoTracking)
+6. **Telemetria**: Rastreamento de eventos e exceções
+7. **Configuração**: Uso do appsettings.json para configurações
+
+## Próximos Passos
+
+1. Criar o componente Blazor `SubCompetencias.razor`
+2. Implementar o code-behind `SubCompetencias.razor.cs`
+3. Configurar roteamento
+4. Implementar testes unitários
+5. Validar migração com dados reais
+
+## Considerações Técnicas
+
+- **Entity Framework**: Utiliza AsNoTracking para consultas de leitura
+- **Telemetria**: Application Insights para monitoramento
+- **Tratamento de Exceções**: Logs estruturados e mensagens amigáveis
+- **Validação**: Validação tanto no cliente quanto no servidor
+- **Exportação**: EPPlus para geração de arquivos Excel
+- **Sessão**: Compatibilidade mantida para migração gradual


### PR DESCRIPTION
Este PR implementa a camada de serviços para SubCompetências, incluindo interface, implementação com EF Core, modelo de entidade, modelo específico para exportação, serviço de exportação reutilizável em Services/Common e documentação detalhada em docs. Segue as diretrizes de centralização de serviços reutilizáveis em Services/Common e documentação técnica em docs, com fluxo mermaid de alto nível. Também inclui o registro dos serviços no Program.cs para DI.