### PR TITLE
Migração e padronização do TotalizadorAvaliacao para Blazor com arquitetura reutilizável

### DIFF
--- a/Components/Pages/TotalizadorAvaliacao.razor
+++ b/Components/Pages/TotalizadorAvaliacao.razor
@@ -1,0 +1,130 @@
+@page "/totalizador-avaliacao"
+@rendermode InteractiveAuto
+@using Peers.Moderno.Models
+@using Peers.Moderno.Services.Common
+@inject IMessageBoxService MessageBoxService
+@inject NavigationManager Navigation
+
+<PageTitle>Totalizador das Avaliações</PageTitle>
+
+<div class="page-breadcrumb border-bottom">
+    <div class="row">
+        <div class="col-lg-3 col-md-4 col-xs-12 align-self-center">
+            <h5 class="font-medium text-uppercase mb-0">Totalizador das Avaliações</h5>
+        </div>
+        <div class="col-lg-9 col-md-8 col-xs-12 align-self-center">
+            <nav aria-label="breadcrumb" class="mt-2 float-md-right float-left">
+                <ol class="breadcrumb mb-0 justify-content-end p-0">
+                    <li class="breadcrumb-item"><a href="/">Peers</a></li>
+                    <li class="breadcrumb-item active">Totalizador das Avaliações</li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+</div>
+
+<div class="page-content container-fluid">
+    <div class="card">
+        <div class="card-body">
+            <h4 class="card-title">Dados do Associado</h4>
+            <div class="form-body">
+                <div class="row">
+                    <div class="col-md-6">
+                        <div class="form-group">
+                            <label>Nome</label>
+                            <InputText @bind-Value="@associado.Nome" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="form-group">
+                            <label>Mentor</label>
+                            <InputSelect @bind-Value="@associado.IdMentor" class="form-control p-0 select2" style="width: 100%">
+                                @foreach (var mentor in mentoresCombo)
+                                {
+                                    <option value="@mentor.Value">@mentor.Text</option>
+                                }
+                            </InputSelect>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-4">
+                        <div class="form-group">
+                            <label>E-mail</label>
+                            <InputText @bind-Value="@associado.Email" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="form-group">
+                            <label>Senha</label>
+                            <InputText @bind-Value="@associado.Senha" type="password" class="form-control" />
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-4">
+                        <div class="form-group">
+                            <label>Cargo</label>
+                            <InputSelect @bind-Value="@associado.IdCargo" class="form-control p-0 select2" style="width: 100%">
+                                @foreach (var cargo in cargosCombo)
+                                {
+                                    <option value="@cargo.Value">@cargo.Text</option>
+                                }
+                            </InputSelect>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="form-group">
+                            <label>Perfil de acesso</label>
+                            <InputSelect @bind-Value="@associado.IdPerfil" class="form-control p-0 select2" style="width: 100%">
+                                @foreach (var perfil in perfisCombo)
+                                {
+                                    <option value="@perfil.Value">@perfil.Text</option>
+                                }
+                            </InputSelect>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="form-group">
+                            <label>Status</label>
+                            <InputSelect @bind-Value="@statusSelecionado" class="form-control p-0 select2" style="width: 100%">
+                                @foreach (var status in statusCombo)
+                                {
+                                    <option value="@status.Value">@status.Text</option>
+                                }
+                            </InputSelect>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="form-actions">
+                    <div class="text-right">
+                        <button @onclick="CadastrarSalvar" class="btn btn-info" disabled="@isProcessing">
+                            @if (isProcessing)
+                            {
+                                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                <text> Processando...</text>
+                            }
+                            else
+                            {
+                                <text>Cadastrar/Salvar</text>
+                            }
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if (showMessageBox)
+{
+    <div class="alert @GetAlertClass() alert-dismissible fade show" role="alert">
+        @messageBoxText
+        <button type="button" class="close" @onclick="() => showMessageBox = false" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+}

--- a/Components/Pages/TotalizadorAvaliacao.razor.cs
+++ b/Components/Pages/TotalizadorAvaliacao.razor.cs
@@ -1,0 +1,201 @@
+using Microsoft.AspNetCore.Components;
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Common;
+using Peers.Moderno.Services.Associados;
+
+namespace Peers.Moderno.Components.Pages;
+
+public partial class TotalizadorAvaliacao : ComponentBase
+{
+    [Inject] private IAssociadosService AssociadosService { get; set; } = default!;
+    [Inject] private IMessageBoxService MessageBoxService { get; set; } = default!;
+    [Inject] private ITelemetryService TelemetryService { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+
+    private Associado associado = new();
+    private List<ComboItem> mentoresCombo = new();
+    private List<ComboItem> cargosCombo = new();
+    private List<ComboItem> perfisCombo = new();
+    private List<ComboItem> statusCombo = new();
+    private string statusSelecionado = "1";
+    private bool isProcessing = false;
+    private bool showMessageBox = false;
+    private string messageBoxText = string.Empty;
+    private MessageBoxType messageBoxType = MessageBoxType.Info;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            await CarregarCombosAsync();
+            MessageBoxService.OnMessageReceived += HandleMessageReceived;
+            
+            TelemetryService.TrackPageView("TotalizadorAvaliacao", new Dictionary<string, string>
+            {
+                { "Component", "TotalizadorAvaliacao" },
+                { "Action", "PageLoad" }
+            });
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "OnInitializedAsync" },
+                { "Component", "TotalizadorAvaliacao" }
+            });
+            ShowMessage("Erro ao carregar a página", MessageBoxType.Error);
+        }
+    }
+
+    private async Task CarregarCombosAsync()
+    {
+        try
+        {
+            var mentores = await AssociadosService.ObterMentoresAsync();
+            mentoresCombo = ComboHelper.CreateComboFromList(
+                mentores, 
+                m => m.Id.ToString(), 
+                m => m.Nome, 
+                includeSelecionar: true
+            );
+
+            var cargos = await AssociadosService.ObterCargosAsync();
+            cargosCombo = ComboHelper.CreateComboFromList(
+                cargos, 
+                c => c.IdCargo.ToString(), 
+                c => c.Nome, 
+                includeSelecionar: true
+            );
+
+            var perfis = await AssociadosService.ObterPerfisAsync();
+            perfisCombo = ComboHelper.CreateComboFromList(
+                perfis, 
+                p => p.Id.ToString(), 
+                p => p.Nome, 
+                includeSelecionar: true
+            );
+
+            statusCombo = ComboHelper.GetStatusItems();
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "CarregarCombosAsync" },
+                { "Component", "TotalizadorAvaliacao" }
+            });
+            throw;
+        }
+    }
+
+    private async Task CadastrarSalvar()
+    {
+        if (isProcessing) return;
+
+        try
+        {
+            isProcessing = true;
+            StateHasChanged();
+
+            var validationResult = ValidationHelper.ValidateAssociado(associado, statusSelecionado);
+            if (!validationResult.IsValid)
+            {
+                ShowMessage(validationResult.ErrorMessage, MessageBoxType.Error);
+                return;
+            }
+
+            associado.Ativo = statusSelecionado == "1";
+
+            bool success;
+            if (associado.Id > 0)
+            {
+                success = await AssociadosService.AlterarAssociadoAsync(associado);
+                if (success)
+                {
+                    ShowMessage("Associado alterado com sucesso!", MessageBoxType.Success);
+                    TelemetryService.TrackEvent("AssociadoAlterado", new Dictionary<string, string>
+                    {
+                        { "AssociadoId", associado.Id.ToString() },
+                        { "Component", "TotalizadorAvaliacao" }
+                    });
+                }
+                else
+                {
+                    ShowMessage("Erro ao alterar associado", MessageBoxType.Error);
+                }
+            }
+            else
+            {
+                success = await AssociadosService.InserirAssociadoAsync(associado);
+                if (success)
+                {
+                    ShowMessage("Associado cadastrado com sucesso!", MessageBoxType.Success);
+                    LimparFormulario();
+                    TelemetryService.TrackEvent("AssociadoCadastrado", new Dictionary<string, string>
+                    {
+                        { "Component", "TotalizadorAvaliacao" }
+                    });
+                }
+                else
+                {
+                    ShowMessage("Erro ao cadastrar associado", MessageBoxType.Error);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "CadastrarSalvar" },
+                { "Component", "TotalizadorAvaliacao" },
+                { "AssociadoId", associado?.Id.ToString() ?? "0" }
+            });
+            ShowMessage("Erro interno ao processar solicitação", MessageBoxType.Error);
+        }
+        finally
+        {
+            isProcessing = false;
+            StateHasChanged();
+        }
+    }
+
+    private void LimparFormulario()
+    {
+        associado = new Associado();
+        statusSelecionado = "1";
+        StateHasChanged();
+    }
+
+    private void HandleMessageReceived(MessageBoxEventArgs args)
+    {
+        ShowMessage(args.Message, args.Type);
+    }
+
+    private void ShowMessage(string message, MessageBoxType type)
+    {
+        messageBoxText = message;
+        messageBoxType = type;
+        showMessageBox = true;
+        StateHasChanged();
+    }
+
+    private string GetAlertClass()
+    {
+        return messageBoxType switch
+        {
+            MessageBoxType.Success => "alert-success",
+            MessageBoxType.Error => "alert-danger",
+            MessageBoxType.Warning => "alert-warning",
+            MessageBoxType.Info => "alert-info",
+            _ => "alert-info"
+        };
+    }
+
+    public void Dispose()
+    {
+        if (MessageBoxService != null)
+        {
+            MessageBoxService.OnMessageReceived -= HandleMessageReceived;
+        }
+    }
+}

--- a/Services/Common/ValidationHelper.cs
+++ b/Services/Common/ValidationHelper.cs
@@ -1,0 +1,249 @@
+using Peers.Moderno.Models;
+
+namespace Peers.Moderno.Services.Common;
+
+public static class ValidationHelper
+{
+    public static ValidationResult ValidateAssociado(Associado associado, string status)
+    {
+        if (associado == null)
+        {
+            return ValidationResult.Error("Dados do associado são obrigatórios");
+        }
+
+        if (string.IsNullOrWhiteSpace(associado.Nome))
+        {
+            return ValidationResult.Error("Nome é obrigatório");
+        }
+
+        if (string.IsNullOrWhiteSpace(associado.Email))
+        {
+            return ValidationResult.Error("E-mail é obrigatório");
+        }
+
+        if (!IsValidEmail(associado.Email))
+        {
+            return ValidationResult.Error("E-mail inválido");
+        }
+
+        if (string.IsNullOrWhiteSpace(associado.Senha))
+        {
+            return ValidationResult.Error("Senha é obrigatória");
+        }
+
+        if (associado.Senha.Length < 6)
+        {
+            return ValidationResult.Error("Senha deve ter pelo menos 6 caracteres");
+        }
+
+        if (associado.IdCargo <= 0)
+        {
+            return ValidationResult.Error("Selecione um cargo");
+        }
+
+        if (associado.IdPerfil <= 0)
+        {
+            return ValidationResult.Error("Selecione um perfil de acesso");
+        }
+
+        if (string.IsNullOrWhiteSpace(status))
+        {
+            return ValidationResult.Error("Selecione o status");
+        }
+
+        return ValidationResult.Success();
+    }
+
+    public static ValidationResult ValidateRequired(string value, string fieldName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ValidationResult.Error($"{fieldName} é obrigatório");
+        }
+        return ValidationResult.Success();
+    }
+
+    public static ValidationResult ValidateEmail(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return ValidationResult.Error("E-mail é obrigatório");
+        }
+
+        if (!IsValidEmail(email))
+        {
+            return ValidationResult.Error("E-mail inválido");
+        }
+
+        return ValidationResult.Success();
+    }
+
+    public static ValidationResult ValidatePassword(string password)
+    {
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            return ValidationResult.Error("Senha é obrigatória");
+        }
+
+        if (password.Length < 6)
+        {
+            return ValidationResult.Error("Senha deve ter pelo menos 6 caracteres");
+        }
+
+        return ValidationResult.Success();
+    }
+
+    public static ValidationResult ValidateNumericRange(int value, int min, int max, string fieldName)
+    {
+        if (value < min || value > max)
+        {
+            return ValidationResult.Error($"{fieldName} deve estar entre {min} e {max}");
+        }
+        return ValidationResult.Success();
+    }
+
+    public static ValidationResult ValidateStringLength(string value, int maxLength, string fieldName)
+    {
+        if (!string.IsNullOrEmpty(value) && value.Length > maxLength)
+        {
+            return ValidationResult.Error($"{fieldName} deve ter no máximo {maxLength} caracteres");
+        }
+        return ValidationResult.Success();
+    }
+
+    public static ValidationResult ValidateSelection(int selectedValue, string fieldName)
+    {
+        if (selectedValue <= 0)
+        {
+            return ValidationResult.Error($"Selecione {fieldName}");
+        }
+        return ValidationResult.Success();
+    }
+
+    public static ValidationResult ValidateSelectionString(string selectedValue, string fieldName)
+    {
+        if (string.IsNullOrWhiteSpace(selectedValue) || selectedValue == "" || selectedValue == "0")
+        {
+            return ValidationResult.Error($"Selecione {fieldName}");
+        }
+        return ValidationResult.Success();
+    }
+
+    public static bool IsValidEmail(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+            return false;
+
+        try
+        {
+            var addr = new System.Net.Mail.MailAddress(email);
+            return addr.Address == email;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public static bool IsValidCPF(string cpf)
+    {
+        if (string.IsNullOrWhiteSpace(cpf))
+            return false;
+
+        cpf = cpf.Replace(".", "").Replace("-", "");
+
+        if (cpf.Length != 11)
+            return false;
+
+        if (cpf.All(c => c == cpf[0]))
+            return false;
+
+        var sum = 0;
+        for (int i = 0; i < 9; i++)
+            sum += int.Parse(cpf[i].ToString()) * (10 - i);
+
+        var remainder = sum % 11;
+        var digit1 = remainder < 2 ? 0 : 11 - remainder;
+
+        if (int.Parse(cpf[9].ToString()) != digit1)
+            return false;
+
+        sum = 0;
+        for (int i = 0; i < 10; i++)
+            sum += int.Parse(cpf[i].ToString()) * (11 - i);
+
+        remainder = sum % 11;
+        var digit2 = remainder < 2 ? 0 : 11 - remainder;
+
+        return int.Parse(cpf[10].ToString()) == digit2;
+    }
+
+    public static ValidationResult ValidateCPF(string cpf, string fieldName = "CPF")
+    {
+        if (!IsValidCPF(cpf))
+        {
+            return ValidationResult.Error($"{fieldName} inválido");
+        }
+        return ValidationResult.Success();
+    }
+
+    public static ValidationResult ValidateMultiple(params ValidationResult[] validations)
+    {
+        var errors = validations.Where(v => !v.IsValid).Select(v => v.ErrorMessage).ToList();
+        
+        if (errors.Any())
+        {
+            return ValidationResult.Error(string.Join("; ", errors));
+        }
+        
+        return ValidationResult.Success();
+    }
+}
+
+public class ValidationResult
+{
+    public bool IsValid { get; private set; }
+    public string ErrorMessage { get; private set; } = string.Empty;
+    public List<string> ErrorMessages { get; private set; } = new List<string>();
+
+    private ValidationResult() { }
+
+    public static ValidationResult Success()
+    {
+        return new ValidationResult { IsValid = true };
+    }
+
+    public static ValidationResult Error(string errorMessage)
+    {
+        return new ValidationResult
+        {
+            IsValid = false,
+            ErrorMessage = errorMessage,
+            ErrorMessages = new List<string> { errorMessage }
+        };
+    }
+
+    public static ValidationResult Error(List<string> errorMessages)
+    {
+        return new ValidationResult
+        {
+            IsValid = false,
+            ErrorMessage = string.Join("; ", errorMessages),
+            ErrorMessages = errorMessages
+        };
+    }
+
+    public ValidationResult AddError(string errorMessage)
+    {
+        if (IsValid)
+        {
+            IsValid = false;
+            ErrorMessages = new List<string>();
+        }
+        
+        ErrorMessages.Add(errorMessage);
+        ErrorMessage = string.Join("; ", ErrorMessages);
+        
+        return this;
+    }
+}

--- a/docs/TotalizadorAvaliacao.md
+++ b/docs/TotalizadorAvaliacao.md
@@ -1,0 +1,205 @@
+# TotalizadorAvaliacao - Migração Web Forms para Blazor
+
+## Visão Geral
+
+Este documento descreve a migração da página `TotalizadorAvaliacao.aspx` (Web Forms) para um componente Blazor moderno utilizando .NET 9 e renderização híbrida.
+
+## Arquitetura da Solução
+
+### Componentes Principais
+
+1. **TotalizadorAvaliacao.razor** - Interface do usuário em Blazor
+2. **TotalizadorAvaliacao.razor.cs** - Code-behind com lógica de negócio
+3. **ValidationHelper.cs** - Helper genérico para validações
+4. **ComboHelper.cs** - Helper para criação de combos reutilizáveis
+5. **IAssociadosService** - Serviço de negócio para operações com associados
+
+### Tecnologias Utilizadas
+
+- **.NET 9** - Framework principal
+- **Blazor Server/WebAssembly Híbrido** - Renderização automática
+- **Entity Framework Core** - ORM para acesso a dados
+- **Dependency Injection** - Injeção de dependências nativa
+- **Application Insights** - Telemetria e monitoramento
+
+## Funcionalidades Implementadas
+
+### Cadastro de Associados
+- Formulário reativo com binding bidirecional
+- Validação em tempo real
+- Combos dinâmicos para Mentor, Cargo e Perfil
+- Feedback visual durante processamento
+
+### Validações
+- Nome obrigatório
+- E-mail obrigatório e formato válido
+- Senha obrigatória (mínimo 6 caracteres)
+- Seleção obrigatória de Cargo e Perfil
+- Status obrigatório
+
+### Integração com Serviços
+- **IAssociadosService** - CRUD de associados
+- **IMessageBoxService** - Mensagens ao usuário
+- **ITelemetryService** - Rastreamento de eventos
+- **ComboHelper** - Criação padronizada de combos
+- **ValidationHelper** - Validações reutilizáveis
+
+## Fluxo de Alto Nível
+
+mermaid
+flowchart TD
+    A[Usuário acessa /totalizador-avaliacao] --> B[TotalizadorAvaliacao.razor]
+    B --> C[OnInitializedAsync]
+    C --> D[CarregarCombosAsync]
+    D --> E[IAssociadosService]
+    E --> F[ApplicationDbContext]
+    F --> G[SQL Server Database]
+    
+    H[Usuário preenche formulário] --> I[CadastrarSalvar]
+    I --> J[ValidationHelper.ValidateAssociado]
+    J --> K{Validação OK?}
+    K -->|Não| L[ShowMessage - Erro]
+    K -->|Sim| M[IAssociadosService.InserirAssociadoAsync]
+    M --> N[ApplicationDbContext.SaveChanges]
+    N --> O[SQL Server Database]
+    O --> P[ShowMessage - Sucesso]
+    P --> Q[LimparFormulario]
+    
+    R[ITelemetryService] --> S[Application Insights]
+    I --> R
+    C --> R
+    M --> R
+    
+    T[IMessageBoxService] --> U[Alert Component]
+    L --> T
+    P --> T
+
+
+## Estrutura de Arquivos
+
+
+Components/
+  Pages/
+    TotalizadorAvaliacao.razor          # Interface Blazor
+    TotalizadorAvaliacao.razor.cs       # Code-behind
+
+Services/
+  Common/
+    ValidationHelper.cs                 # Validações reutilizáveis
+    ComboHelper.cs                     # Helpers para combos
+    MessageBoxService.cs               # Serviço de mensagens
+  Associados/
+    IAssociadosService.cs              # Interface do serviço
+    AssociadosService.cs               # Implementação do serviço
+
+Models/
+  Associado.cs                         # Modelo de domínio
+  Cargo.cs                            # Modelo de cargo
+  Perfil.cs                           # Modelo de perfil
+
+docs/
+  TotalizadorAvaliacao.md             # Esta documentação
+
+
+## Padrões Implementados
+
+### Injeção de Dependências
+csharp
+[Inject] private IAssociadosService AssociadosService { get; set; } = default!;
+[Inject] private IMessageBoxService MessageBoxService { get; set; } = default!;
+[Inject] private ITelemetryService TelemetryService { get; set; } = default!;
+
+
+### Binding Bidirecional
+razor
+<InputText @bind-Value="@associado.Nome" class="form-control" />
+<InputSelect @bind-Value="@associado.IdCargo" class="form-control">
+
+
+### Validação Centralizada
+csharp
+var validationResult = ValidationHelper.ValidateAssociado(associado, statusSelecionado);
+if (!validationResult.IsValid)
+{
+    ShowMessage(validationResult.ErrorMessage, MessageBoxType.Error);
+    return;
+}
+
+
+### Telemetria
+csharp
+TelemetryService.TrackEvent("AssociadoCadastrado", new Dictionary<string, string>
+{
+    { "Component", "TotalizadorAvaliacao" }
+});
+
+
+## Melhorias Implementadas
+
+### Performance
+- Renderização híbrida (Server + WebAssembly)
+- Lazy loading de combos
+- State management otimizado
+- Binding eficiente
+
+### UX/UI
+- Feedback visual durante processamento
+- Validação em tempo real
+- Mensagens de sucesso/erro padronizadas
+- Interface responsiva
+
+### Manutenibilidade
+- Separação clara de responsabilidades
+- Serviços reutilizáveis
+- Validações centralizadas
+- Logging e telemetria integrados
+
+### Testabilidade
+- Lógica desacoplada da UI
+- Interfaces bem definidas
+- Injeção de dependências
+- Métodos pequenos e focados
+
+## Configuração e Deployment
+
+### Dependências
+- Microsoft.AspNetCore.Components.Web
+- Microsoft.EntityFrameworkCore.SqlServer
+- Microsoft.ApplicationInsights.AspNetCore
+
+### Configuração no Program.cs
+csharp
+builder.Services.AddScoped<IAssociadosService, AssociadosService>();
+builder.Services.AddScoped<IMessageBoxService, MessageBoxService>();
+builder.Services.AddScoped<ITelemetryService, TelemetryService>();
+
+
+### Roteamento
+- URL: `/totalizador-avaliacao`
+- Renderização: InteractiveAuto (Híbrida)
+
+## Considerações de Segurança
+
+- Validação server-side obrigatória
+- Sanitização de inputs
+- Proteção contra XSS via Blazor
+- Autenticação/autorização via middleware
+
+## Monitoramento
+
+- Application Insights para telemetria
+- Logging estruturado
+- Métricas de performance
+- Rastreamento de erros
+
+## Próximos Passos
+
+1. Implementar testes unitários
+2. Adicionar validações avançadas
+3. Implementar cache para combos
+4. Adicionar suporte a upload de foto
+5. Implementar auditoria de alterações
+
+## Conclusão
+
+A migração para Blazor trouxe benefícios significativos em termos de performance, manutenibilidade e experiência do usuário, mantendo a funcionalidade original enquanto moderniza a arquitetura e implementa melhores práticas de desenvolvimento.


### PR DESCRIPTION
Este PR implementa o componente Blazor TotalizadorAvaliacao, seu code-behind desacoplado, um helper de validação centralizado em Services/Common, e documentação detalhada em docs/. Todas as mudanças seguem a premissa de centralizar serviços reutilizáveis em Services/Common e documentar o fluxo de alto nível com Mermaid. O código foi estruturado para facilitar futuras reutilizações e manutenções, conforme as diretrizes do projeto.