### PR TITLE
Base comum para autoavaliação de competências: contratos, DTOs e validador

### DIFF
--- a/Services/AutoAvaliacao/Common/AutoAvaliacaoDto.cs
+++ b/Services/AutoAvaliacao/Common/AutoAvaliacaoDto.cs
@@ -1,0 +1,162 @@
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Common;
+
+namespace Peers.Moderno.Services.AutoAvaliacao.Common;
+
+public class AutoAvaliacaoDto
+{
+    public int IdProjeto { get; set; }
+    public int IdAssociado { get; set; }
+    public int IdPeriodo { get; set; }
+    public int IdAvaliacao { get; set; }
+    public int IdGestor { get; set; }
+    public string TipoAvaliacao { get; set; } = string.Empty;
+    public string Escopo { get; set; } = string.Empty;
+    
+    // Informações do Avaliado
+    public AssociadoInfoDto AssociadoInfo { get; set; } = new AssociadoInfoDto();
+    public ProjetoInfoDto ProjetoInfo { get; set; } = new ProjetoInfoDto();
+    public PeriodoInfoDto PeriodoInfo { get; set; } = new PeriodoInfoDto();
+    
+    // Cabeçalho de Descrições
+    public CabecalhoDescricoesDto CabecalhoDescricoes { get; set; } = new CabecalhoDescricoesDto();
+    
+    // Lista de Competências para Avaliação
+    public List<CompetenciaAvaliacaoDto> Competencias { get; set; } = new List<CompetenciaAvaliacaoDto>();
+    
+    // Status e Controle
+    public string EtapaAtual { get; set; } = string.Empty;
+    public string StatusAvaliacao { get; set; } = string.Empty;
+    public bool PodeEditar { get; set; } = true;
+    public bool PodeFinalizar { get; set; } = false;
+    public bool TodosItensPreenchidos { get; set; } = false;
+    public string TempoRestante { get; set; } = string.Empty;
+    
+    // Configurações de Exibição
+    public bool ExibirDetalhamentoProximoNivel { get; set; } = true;
+    public string LabelDetalhamentoProximoNivel { get; set; } = "Detalhamento Próximo Nível";
+    public bool TrocaTitulosBackoffice { get; set; } = false;
+    
+    // Metadados
+    public DateTime? DataInicioAvaliacao { get; set; }
+    public DateTime? DataFimAvaliacao { get; set; }
+    public DateTime DataCarregamento { get; set; } = DateTime.Now;
+}
+
+public class AssociadoInfoDto
+{
+    public int Id { get; set; }
+    public string Nome { get; set; } = string.Empty;
+    public string TempoCargo { get; set; } = string.Empty;
+    public string TempoPeers { get; set; } = string.Empty;
+    public int IdCargo { get; set; }
+    public int IdNivel { get; set; }
+    public int IdEmpresa { get; set; }
+    public string Vertical { get; set; } = string.Empty;
+}
+
+public class ProjetoInfoDto
+{
+    public int Id { get; set; }
+    public string Nome { get; set; } = string.Empty;
+    public string Cliente { get; set; } = string.Empty;
+    public int IdCliente { get; set; }
+    public int IdEmpresa { get; set; }
+}
+
+public class PeriodoInfoDto
+{
+    public int Id { get; set; }
+    public string Periodo { get; set; } = string.Empty;
+    public DateTime? DataInicio { get; set; }
+    public DateTime? DataFim { get; set; }
+}
+
+public class CabecalhoDescricoesDto
+{
+    // Informações do Cargo Atual
+    public string CargoAtual { get; set; } = string.Empty;
+    public string FuncaoAtual { get; set; } = string.Empty;
+    public string AutonomiaAtual { get; set; } = string.Empty;
+    public string EscopoAtual { get; set; } = string.Empty;
+    public string InterlocucaoAtual { get; set; } = string.Empty;
+    
+    // Informações do Próximo Cargo
+    public string CargoProximo { get; set; } = string.Empty;
+    public string FuncaoProximo { get; set; } = string.Empty;
+    public string AutonomiaProximo { get; set; } = string.Empty;
+    public string EscopoProximo { get; set; } = string.Empty;
+    public string InterlocucaoProximo { get; set; } = string.Empty;
+    
+    // Competências Extensíveis
+    public List<DescricaoCompetenciaDto> CompetenciasDescricoes { get; set; } = new List<DescricaoCompetenciaDto>();
+}
+
+public class DescricaoCompetenciaDto
+{
+    public string TituloExibicao { get; set; } = string.Empty;
+    public string DescricaoCompetencia_Atual { get; set; } = string.Empty;
+    public string DescricaoCompetencia_Proximo { get; set; } = string.Empty;
+}
+
+public class CompetenciaAvaliacaoDto
+{
+    public int IdCompetencia { get; set; }
+    public int IdEixo { get; set; }
+    public int IdSubCompetencia { get; set; }
+    public int IdDimensao { get; set; }
+    public int IdModo { get; set; }
+    
+    // Informações de Agrupamento
+    public string Eixo { get; set; } = string.Empty;
+    public string SubCompetencia { get; set; } = string.Empty;
+    public string Dimensao { get; set; } = string.Empty;
+    public string PalavrasChave { get; set; } = string.Empty;
+    
+    // Detalhamentos
+    public string DetalheNivelAtual { get; set; } = string.Empty;
+    public string DetalheProximoNivel { get; set; } = string.Empty;
+    public string CompetenciaAtual { get; set; } = string.Empty;
+    public string CompetenciaProximo { get; set; } = string.Empty;
+    
+    // Notas e Respostas
+    public int NotaNivel1 { get; set; } = 0;
+    public int NotaNivel2 { get; set; } = 0;
+    public string Consideracoes { get; set; } = string.Empty;
+    
+    // Configurações de Exibição e Interação
+    public bool InputEtapaAtual { get; set; } = true;
+    public bool VisivelEtapaAtual { get; set; } = true;
+    public bool InputNivel1 { get; set; } = true;
+    public bool InputNivel2 { get; set; } = true;
+    public bool VisivelNivel1 { get; set; } = true;
+    public bool VisivelNivel2 { get; set; } = true;
+    
+    // Estados de Controle
+    public bool DisableSelectNivel1 { get; set; } = false;
+    public bool DisableSelectNivel2 { get; set; } = false;
+    public bool HiddenSelectNivel1 { get; set; } = false;
+    public bool HiddenSelectNivel2 { get; set; } = false;
+    public bool HiddenTextBoxNivel1 { get; set; } = true;
+    public bool HiddenTextBoxNivel2 { get; set; } = true;
+    
+    // Textos para Exibição (quando não editável)
+    public string TextoNotaNivel1 { get; set; } = string.Empty;
+    public string TextoNotaNivel2 { get; set; } = string.Empty;
+    
+    // Controle de Visibilidade
+    public bool IsHidden { get; set; } = false;
+    public string IsHiddenDetalhamentoProximoNivel { get; set; } = string.Empty;
+    
+    // Lista de Opções para Combos
+    public List<ComboItem> OpcoesNotaNivel1 { get; set; } = new List<ComboItem>();
+    public List<ComboItem> OpcoesNotaNivel2 { get; set; } = new List<ComboItem>();
+    
+    // Validação
+    public bool IsValid { get; set; } = true;
+    public List<string> ValidationErrors { get; set; } = new List<string>();
+    
+    // Metadados
+    public bool JaFinalizada { get; set; } = false;
+    public DateTime? DataUltimaAlteracao { get; set; }
+}

--- a/Services/AutoAvaliacao/Common/IAutoAvaliacaoService.cs
+++ b/Services/AutoAvaliacao/Common/IAutoAvaliacaoService.cs
@@ -1,0 +1,109 @@
+using Peers.Moderno.Services.AutoAvaliacao.Common;
+using Peers.Moderno.Models;
+
+namespace Peers.Moderno.Services.AutoAvaliacao.Common;
+
+public interface IAutoAvaliacaoService
+{
+    Task<AutoAvaliacaoDto> CarregarAutoAvaliacaoAsync(int idProjeto, int idAssociado, int idPeriodo, string tipoAvaliacao, string escopo, int idGestor);
+    Task<AutoAvaliacaoDto> CarregarCompetenciasAsync(int idAssociado, int idProjeto, int idPeriodo, string tipoAvaliacao, string escopo, int idAvaliacao);
+    Task<AutoAvaliacaoValidationResult> ValidarAvaliacaoAsync(AutoAvaliacaoDto avaliacao);
+    Task<AutoAvaliacaoSaveResult> SalvarAvaliacaoAsync(AutoAvaliacaoDto avaliacao, bool finalizarAvaliacao = false);
+    Task<AutoAvaliacaoDto> CarregarCabecalhoDescricoesAsync(int idCargo, List<Competencia> competencias, Associado associado);
+    Task<bool> VerificarPermissaoEdicaoAsync(int idAvaliacao, string etapaAtual);
+    Task<string> CalcularTempoRestanteAsync(int idAvaliacao);
+    Task<AutoAvaliacaoStatusInfo> ObterStatusAvaliacaoAsync(int idAvaliacao);
+    Task<bool> PodeFinalizarAvaliacaoAsync(AutoAvaliacaoDto avaliacao);
+    Task<List<CompetenciaAvaliacaoDto>> ProcessarCompetenciasParaExibicaoAsync(List<Competencia> competencias, List<object> avaliacoesExistentes, Associado associado);
+    Task<bool> AvancaProximaEtapaAsync(int idAvaliacao, string tipoAvaliacao);
+    Task<AutoAvaliacaoConfigDto> ObterConfiguracaoAvaliacaoAsync();
+}
+
+public class AutoAvaliacaoValidationResult
+{
+    public bool IsValid { get; set; }
+    public List<string> ErrorMessages { get; set; } = new List<string>();
+    public List<CompetenciaValidationError> CompetenciaErrors { get; set; } = new List<CompetenciaValidationError>();
+
+    public static AutoAvaliacaoValidationResult Success()
+    {
+        return new AutoAvaliacaoValidationResult { IsValid = true };
+    }
+
+    public static AutoAvaliacaoValidationResult Error(string message)
+    {
+        return new AutoAvaliacaoValidationResult 
+        { 
+            IsValid = false, 
+            ErrorMessages = new List<string> { message } 
+        };
+    }
+
+    public static AutoAvaliacaoValidationResult Error(List<string> messages)
+    {
+        return new AutoAvaliacaoValidationResult 
+        { 
+            IsValid = false, 
+            ErrorMessages = messages 
+        };
+    }
+}
+
+public class AutoAvaliacaoSaveResult
+{
+    public bool IsSuccess { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public int? IdAvaliacao { get; set; }
+    public string NovaEtapa { get; set; } = string.Empty;
+
+    public static AutoAvaliacaoSaveResult Success(string message, int? idAvaliacao = null, string novaEtapa = "")
+    {
+        return new AutoAvaliacaoSaveResult 
+        { 
+            IsSuccess = true, 
+            Message = message,
+            IdAvaliacao = idAvaliacao,
+            NovaEtapa = novaEtapa
+        };
+    }
+
+    public static AutoAvaliacaoSaveResult Error(string message)
+    {
+        return new AutoAvaliacaoSaveResult 
+        { 
+            IsSuccess = false, 
+            Message = message 
+        };
+    }
+}
+
+public class CompetenciaValidationError
+{
+    public int IdCompetencia { get; set; }
+    public string SubCompetencia { get; set; } = string.Empty;
+    public string ErrorMessage { get; set; } = string.Empty;
+    public string FieldType { get; set; } = string.Empty; // "nivel1", "nivel2", "consideracoes"
+}
+
+public class AutoAvaliacaoStatusInfo
+{
+    public string EtapaAtual { get; set; } = string.Empty;
+    public string StatusAvaliacao { get; set; } = string.Empty;
+    public bool PodeEditar { get; set; }
+    public bool PodeFinalizar { get; set; }
+    public DateTime? DataInicio { get; set; }
+    public DateTime? DataFim { get; set; }
+    public string TempoRestante { get; set; } = string.Empty;
+}
+
+public class AutoAvaliacaoConfigDto
+{
+    public string DefaultTipoAvaliacao { get; set; } = string.Empty;
+    public string DefaultEscopo { get; set; } = string.Empty;
+    public bool RequireAllCompetenciasPreenchidas { get; set; }
+    public bool EnableFinalizacaoAutomatica { get; set; }
+    public bool EnableNotificacaoFinalizacao { get; set; }
+    public Dictionary<string, string> ValidationMessages { get; set; } = new Dictionary<string, string>();
+    public Dictionary<string, string> StatusOptions { get; set; } = new Dictionary<string, string>();
+    public Dictionary<string, string> EtapasAvaliacao { get; set; } = new Dictionary<string, string>();
+}

--- a/Services/AutoAvaliacao/Common/IAutoAvaliacaoValidator.cs
+++ b/Services/AutoAvaliacao/Common/IAutoAvaliacaoValidator.cs
@@ -1,0 +1,51 @@
+using Peers.Moderno.Services.AutoAvaliacao.Common;
+
+namespace Peers.Moderno.Services.AutoAvaliacao.Common;
+
+public interface IAutoAvaliacaoValidator
+{
+    Task<AutoAvaliacaoValidationResult> ValidarAvaliacaoCompletaAsync(AutoAvaliacaoDto avaliacao);
+    Task<AutoAvaliacaoValidationResult> ValidarCompetenciaAsync(CompetenciaAvaliacaoDto competencia);
+    Task<AutoAvaliacaoValidationResult> ValidarConsistenciaNiveisAsync(CompetenciaAvaliacaoDto competencia);
+    Task<AutoAvaliacaoValidationResult> ValidarPilaresPreenchidosAsync(List<CompetenciaAvaliacaoDto> competencias);
+    Task<AutoAvaliacaoValidationResult> ValidarNotasObrigatoriasAsync(List<CompetenciaAvaliacaoDto> competencias);
+    Task<AutoAvaliacaoValidationResult> ValidarRegrasNegocioAsync(AutoAvaliacaoDto avaliacao);
+    Task<AutoAvaliacaoValidationResult> ValidarPermissaoEdicaoAsync(AutoAvaliacaoDto avaliacao);
+    Task<AutoAvaliacaoValidationResult> ValidarEtapaAvaliacaoAsync(string etapaAtual, string operacao);
+    Task<bool> PodeFinalizarAvaliacaoAsync(AutoAvaliacaoDto avaliacao);
+    Task<List<CompetenciaValidationError>> ValidarCompetenciasIndividualmenteAsync(List<CompetenciaAvaliacaoDto> competencias);
+    Task<AutoAvaliacaoValidationResult> ValidarNotaNaoSeAplicaAsync(CompetenciaAvaliacaoDto competencia);
+    Task<AutoAvaliacaoValidationResult> ValidarHieraquiaNotasAsync(CompetenciaAvaliacaoDto competencia);
+}
+
+public static class ValidationConstants
+{
+    public const int NOTA_NAO_SE_APLICA = 5;
+    public const int NOTA_SELECIONAR = 0;
+    
+    public static readonly string[] ETAPAS_PERMITIDAS_EDICAO = 
+    {
+        "nao_iniciada",
+        "auto_avaliacao", 
+        "avaliacao_cegas",
+        "em_paralelo"
+    };
+    
+    public static readonly string[] OPERACOES_VALIDACAO = 
+    {
+        "salvar",
+        "finalizar",
+        "navegar"
+    };
+    
+    public static readonly Dictionary<string, string> MENSAGENS_VALIDACAO = new Dictionary<string, string>
+    {
+        { "NOTAS_OBRIGATORIAS", "É obrigatório selecionar uma nota para cada nível." },
+        { "INCONSISTENCIA_NAO_SE_APLICA", "Quando a nota de Competência do Nível Atual for = Não Se Aplica, o Próximo Nível deve ser Não Se Aplica." },
+        { "HIERARQUIA_NOTAS", "A nota do nível 2 (próximo nível) não pode ser maior que a nota do nível 1 (nível atual)." },
+        { "PILAR_VAZIO", "Cada pilar precisa receber ao mínimo 1 nota mensurável em cada nível (diferente de não se aplica)." },
+        { "COMPETENCIAS_NAO_PREENCHIDAS", "É obrigatório digitar todas as notas da Avaliação Competência antes de finalizar a Avaliação." },
+        { "ETAPA_NAO_PERMITIDA", "Não é possível editar a avaliação na etapa atual." },
+        { "PERMISSAO_NEGADA", "Você não tem permissão para esta operação." }
+    };
+}


### PR DESCRIPTION
Criação da estrutura base reutilizável para a autoavaliação de competências, incluindo interfaces de serviço e validador, DTOs completos para transporte de dados entre UI e backend, e constantes de validação. Todo o código foi centralizado em Services/AutoAvaliacao/Common, seguindo o padrão de reutilização corporativa. Essa base permitirá que outras features e módulos consumam a lógica de autoavaliação sem duplicação, facilitando manutenção, testes e evolução do sistema.