### PR TITLE
Migração inicial da Autoavaliação de Competências para Blazor com integração de serviços reutilizáveis e documentação

### DIFF
--- a/Components/Pages/AutoAvaliacaoCompetencia.razor
+++ b/Components/Pages/AutoAvaliacaoCompetencia.razor
@@ -1,0 +1,536 @@
+@page "/autoavaliacao-competencia"
+@using Peers.Moderno.Services.AutoAvaliacao
+@using Peers.Moderno.Services.AutoAvaliacao.Common
+@using Peers.Moderno.Services.Common
+@using Peers.Moderno.Models
+@inject IAutoAvaliacaoService AutoAvaliacaoService
+@inject IMessageBoxService MessageBoxService
+@inject ITelemetryService TelemetryService
+@inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
+@rendermode InteractiveAuto
+
+<PageTitle>Auto Avaliação - Competência</PageTitle>
+
+<div class="page-breadcrumb border-bottom" style="position:fixed;z-index:1;width:1653px">
+    <div class="row">
+        <div class="col-lg-3 col-md-4 col-xs-12 align-self-center">
+            <h5 class="font-medium text-uppercase mb-0">Auto Avaliação</h5>
+        </div>
+        <div class="col-lg-9 col-md-8 col-xs-12 align-self-center">
+            <nav aria-label="breadcrumb" class="mt-2 float-md-right float-left">
+                <ol class="breadcrumb mb-0 justify-content-end p-0">
+                    <li class="breadcrumb-item"><a href="/">Peers</a></li>
+                    <li class="breadcrumb-item"><a href="/">Avaliação / Auto Avaliação</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">Competência</li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+</div>
+
+<div style="overflow:initial !important" class="page-content container-fluid">
+    @if (IsLoading)
+    {
+        <div class="d-flex justify-content-center align-items-center" style="height: 400px;">
+            <div class="spinner-border" role="status">
+                <span class="sr-only">Carregando...</span>
+            </div>
+        </div>
+    }
+    else if (AvaliacaoData != null)
+    {
+        <!-- CARD TITULO -->
+        <div class="card col-md-10" style="position:fixed;z-index:1; margin-top:21px;border-color:rgba(0, 0, 0, .25);border-width:1px">
+            <div class="card-body">
+                <!-- DETALHES DO AVALIADO -->
+                <div class="accordion" id="accordionDetalhes">
+                    <div class="card">
+                        <div class="card-header" id="headingDetalhes">
+                            <h5 class="mb-0">
+                                <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#Detalhes" aria-expanded="true" aria-controls="Detalhes">
+                                    Detalhes da avaliação
+                                    <i class="fa fa-angle-right"></i>
+                                </button>
+                            </h5>
+                        </div>
+                        <div id="Detalhes" class="collapse" aria-labelledby="headingDetalhes" data-parent="#accordionDetalhes">
+                            <div class="col-md-5">
+                                <div class="text-left">
+                                    <button type="button" class="btn btn-facebook" disabled>Competência</button>
+                                    <button type="button" class="btn btn-danger" @onclick="IrParaPerformance">Performance</button>
+                                    <button type="button" class="btn btn-info" @onclick="IrParaFinalizacao">Ir para Finalização</button>
+                                    <p></p>
+                                </div>
+                            </div>
+                            <div class="col-sm">
+                                <div class="row">
+                                    <div class="col-md-2">
+                                        <label><b>Avaliado</b></label>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label>@AvaliacaoData.NomeAssociado</label>
+                                    </div>
+                                    <div class="col-md-2">
+                                        <label><b>Período</b></label>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label>@AvaliacaoData.Periodo</label>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-md-2">
+                                        <label><b>Tempo de Cargo:</b></label>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label>@AvaliacaoData.TempoCargo</label>
+                                    </div>
+                                    <div class="col-md-2">
+                                        <label><b>Tempo de Peers</b></label>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label>@AvaliacaoData.TempoPeers</label>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-md-1">
+                                        <label><b>Projeto</b></label>
+                                    </div>
+                                    <div class="col-md-3">
+                                        <label>@AvaliacaoData.NomeProjeto</label>
+                                    </div>
+                                    <div class="col-md-1">
+                                        <label><b>Cliente</b></label>
+                                    </div>
+                                    <div class="col-md-3">
+                                        <label>@AvaliacaoData.NomeCliente</label>
+                                    </div>
+                                    <div class="col-md-2">
+                                        <label><b>Tempo restante</b></label>
+                                    </div>
+                                    <div class="col-md-2">
+                                        <label>@AvaliacaoData.TempoRestante</label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- DIV DESCRIÇÕES -->
+                <div class="accordion" id="accordionCabecalho">
+                    <div class="card">
+                        <div class="card-header" id="headingCabecalho">
+                            <h5 class="mb-0">
+                                <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#Cabecalho" aria-expanded="true" aria-controls="Cabecalho">
+                                    Descrições nível atual e próximo nível
+                                    <i class="fa fa-angle-right"></i>
+                                </button>
+                            </h5>
+                        </div>
+                        <div id="Cabecalho" class="collapse" aria-labelledby="headingCabecalho" data-parent="#accordionCabecalho">
+                            <table class="table table-striped border" style="width:100%;table-layout:fixed">
+                                <thead>
+                                    <tr>
+                                        <th colspan="1"></th>
+                                        <th colspan="2">Cargo</th>
+                                        <th colspan="2">Função</th>
+                                        <th colspan="2">Autonomia</th>
+                                        <th colspan="2">Escopo de Atuação</th>
+                                        <th colspan="2">Nível de interlocução principal no cliente</th>
+                                        @foreach (var titulo in AvaliacaoData.TitulosCompetencias)
+                                        {
+                                            <th colspan="2">@titulo.TituloExibicao</th>
+                                        }
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td colspan="1">Nível atual</td>
+                                        <td colspan="2">@AvaliacaoData.CargoAtual</td>
+                                        <td colspan="2">@AvaliacaoData.FuncaoAtual</td>
+                                        <td colspan="2">@AvaliacaoData.AutonomiaAtual</td>
+                                        <td colspan="2">@AvaliacaoData.EscopoAtual</td>
+                                        <td colspan="2">@AvaliacaoData.InterlocucaoAtual</td>
+                                        @foreach (var competencia in AvaliacaoData.CompetenciasCargoAtual)
+                                        {
+                                            <th colspan="2" style="font-weight:normal;">@competencia.DescricaoCompetencia_Atual</th>
+                                        }
+                                    </tr>
+                                    <tr>
+                                        <td colspan="1">Próximo nível</td>
+                                        <td colspan="2">@AvaliacaoData.CargoProximo</td>
+                                        <td colspan="2">@AvaliacaoData.FuncaoProximo</td>
+                                        <td colspan="2">@AvaliacaoData.AutonomiaProximo</td>
+                                        <td colspan="2">@AvaliacaoData.EscopoProximo</td>
+                                        <td colspan="2">@AvaliacaoData.InterlocucaoProximo</td>
+                                        @foreach (var competencia in AvaliacaoData.CompetenciasCargoProximo)
+                                        {
+                                            <th colspan="2" style="font-weight:normal;">@competencia.DescricaoCompetencia_Proximo</th>
+                                        }
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- CARD COMPETENCIAS -->
+        <div class="card col-md-12" style="margin-top:220px">
+            <div class="card-body">
+                <!-- DIV BOTAO SALVAR -->
+                <div class="form-body">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="text-right">
+                                <button type="button" class="btn btn-dark" @onclick="SalvarAvaliacao" disabled="@IsProcessing">
+                                    @if (IsProcessing)
+                                    {
+                                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                        <span>Salvando...</span>
+                                    }
+                                    else
+                                    {
+                                        <span>Salvar Avaliação</span>
+                                    }
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- DIV TABELA COMPETENCIAS -->
+                <div class="table-responsive" style="overflow-y:auto !important; height:600px">
+                    <table class="table table-striped border" style="border-collapse:collapse !important; width: 100% !important">
+                        <thead>
+                            <tr>
+                                <th colspan="7" style="background-color:#e5e019;color:#021240;position:sticky !important; top:-5px !important">Nível 1</th>
+                                <th colspan="9" style="background-color:#e5e019;color:#021240;position:sticky !important; top:-5px !important">Nível 2</th>
+                            </tr>
+                            <tr>
+                                <th colspan="4" style="position:sticky !important; top:45px !important;color:#021240;background-color:#eae678;border-bottom:6px solid;border-color:#eae678">Detalhamento Atual</th>
+                                <th colspan="3" style="position:sticky !important; top:45px !important;color:#021240;background-color:#eae678;border-bottom:6px solid;border-color:#eae678">Nota Avaliado</th>
+                                <th colspan="4" style="position:sticky !important; top:45px !important;color:#021240;background-color:#eae678;border-bottom:6px solid;border-color:#eae678">@AvaliacaoData.LabelDetalheNivel2</th>
+                                <th colspan="3" style="position:sticky !important; top:45px !important;color:#021240;background-color:#eae678;border-bottom:6px solid;border-color:#eae678">Nota Avaliado</th>
+                                <th colspan="2" style="position:sticky !important; top:45px !important;color:#021240;background-color:#eae678;border-bottom:6px solid;border-color:#eae678">Considerações Avaliado</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var competencia in AvaliacaoData.Competencias)
+                            {
+                                <tr style="font-style:italic;font-size:14px;font-weight:normal;background-color:#f2f2f2;vertical-align:bottom">
+                                    <th colspan="16" style="font-style:normal;font-size:21px;font-weight:normal;align-content:center;text-align:center;border-top:5px solid;border-color:#003150">
+                                        @competencia.SubCompetencia
+                                    </th>
+                                </tr>
+                                <tr style="font-weight:bold;background-color:#f5f5f5;border-top:none">
+                                    <td colspan="16" style="text-align:center;border-top:none">@((MarkupString)competencia.PalavrasChave)</td>
+                                </tr>
+                                <tr style="font-weight:normal;background-color:#f9f9f9;border-top:none">
+                                    <td colspan="4" style="border-top:none;background-color:#f9f9f9">
+                                        <a href="#det_@competencia.IdCompetencia" data-target="#det_@competencia.IdCompetencia" data-toggle="collapse" class="accordion-toggle">
+                                            @TruncarTexto(competencia.DetalheNivelAtual, 70)
+                                            <span style="font-weight:bold">  Ver+</span>
+                                        </a>
+                                    </td>
+                                    <td colspan="3" style="border-top:none;background-color:#f9f9f9">
+                                        @if (competencia.HabilitadoSelectNivel1)
+                                        {
+                                            <select class="form-control p-0 select2" style="width: 100%" @bind="competencia.NotaNivel1" disabled="@competencia.DesabilitadoNivel1">
+                                                <option value="0">[Selecionar]</option>
+                                                @foreach (var nota in AvaliacaoData.NotasDisponiveis)
+                                                {
+                                                    <option value="@nota.IdNota">@nota.CodigoNota</option>
+                                                }
+                                            </select>
+                                        }
+                                        else
+                                        {
+                                            <label class="form-control p-0" style="width: 100%; height: 100%; background-color:#E9ECEF">@competencia.TextoNotaNivel1</label>
+                                        }
+                                    </td>
+                                    <td colspan="4" style="border-top:none;background-color:#f9f9f9">
+                                        <a href="#detPrNivel_@competencia.IdCompetencia" data-target="#detPrNivel_@competencia.IdCompetencia" data-toggle="collapse" class="accordion-toggle">
+                                            @TruncarTexto(competencia.DetalheProximoNivel, 70)
+                                            <span style="font-weight:bold">  Ver+</span>
+                                        </a>
+                                    </td>
+                                    <td colspan="3" style="border-top:none;background-color:#f9f9f9">
+                                        @if (competencia.HabilitadoSelectNivel2)
+                                        {
+                                            <select class="form-control p-0 select2" style="width: 100%" @bind="competencia.NotaNivel2" disabled="@competencia.DesabilitadoNivel2">
+                                                <option value="0">[Selecionar]</option>
+                                                @foreach (var nota in AvaliacaoData.NotasDisponiveis)
+                                                {
+                                                    <option value="@nota.IdNota">@nota.CodigoNota</option>
+                                                }
+                                            </select>
+                                        }
+                                        else
+                                        {
+                                            <label class="form-control p-0" style="width: 100%; height: 100%; background-color:#E9ECEF">@competencia.TextoNotaNivel2</label>
+                                        }
+                                    </td>
+                                    <td colspan="2" style="border-top:none;background-color:#f9f9f9;text-align:center">
+                                        <button type="button" data-toggle="collapse" data-target="#cons_@competencia.IdCompetencia" class="accordion-toggle" style="background-color:#003150;padding:8px 15px;border:none">
+                                            <span aria-hidden="true" style="color:white;font-size:15px">Considerações</span>
+                                        </button>
+                                    </td>
+                                </tr>
+
+                                <!-- DETALHAMENTO ATUAL -->
+                                <tr>
+                                    <td colspan="16" class="hiddenRow" style="border-top:none;background-color:#ffffff">
+                                        <div class="accordian-body collapse" id="det_@competencia.IdCompetencia">
+                                            <strong>Detalhamento Cargo Atual:</strong><br />@((MarkupString)competencia.DetalheNivelAtual)
+                                        </div>
+                                    </td>
+                                </tr>
+
+                                <!-- DETALHAMENTO DO PRÓXIMO NÍVEL -->
+                                <tr>
+                                    <td colspan="16" class="hiddenRow" style="border-top:none;background-color:#ffffff">
+                                        <div class="accordian-body collapse" id="detPrNivel_@competencia.IdCompetencia">
+                                            <strong>Detalhamento Próximo Nível:</strong><br />@((MarkupString)competencia.DetalheProximoNivel)
+                                        </div>
+                                    </td>
+                                </tr>
+
+                                <!-- CONSIDERAÇÕES -->
+                                <tr>
+                                    <td colspan="16" class="hiddenRow" style="border-top:none;background-color:#ffffff">
+                                        <div class="accordian-body collapse" id="cons_@competencia.IdCompetencia">
+                                            <strong>Considerações:</strong><br />
+                                            <textarea rows="5" class="form-control" @bind="competencia.Consideracoes" disabled="@competencia.DesabilitadoConsideracoes"></textarea>
+                                        </div>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+
+                <!-- DIV BOTAO SALVAR -->
+                <div class="form-body">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="text-right">
+                                <button type="button" class="btn btn-dark" @onclick="SalvarAvaliacao" disabled="@IsProcessing">
+                                    @if (IsProcessing)
+                                    {
+                                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                        <span>Salvando...</span>
+                                    }
+                                    else
+                                    {
+                                        <span>Salvar Avaliação</span>
+                                    }
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- DIV BOTÕES ADICIONAIS -->
+            <div class="card">
+                <div class="card-body">
+                    <div class="col-md-5">
+                        <div class="text-left">
+                            <button type="button" class="btn btn-facebook" disabled>Competência</button>
+                            <button type="button" class="btn btn-danger" @onclick="IrParaPerformance">Performance</button>
+                            <button type="button" class="btn btn-info" @onclick="IrParaFinalizacao">Ir para Finalização</button>
+                            <p></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="alert alert-warning" role="alert">
+            <h4 class="alert-heading">Avaliação não encontrada</h4>
+            <p>Não foi possível carregar os dados da avaliação. Verifique os parâmetros e tente novamente.</p>
+            <hr>
+            <p class="mb-0">Se o problema persistir, entre em contato com o suporte.</p>
+        </div>
+    }
+</div>
+
+<style>
+    .hiddenRow {
+        padding: 0 !important;
+    }
+</style>
+
+@code {
+    [Parameter] public string? IdProjeto { get; set; }
+    [Parameter] public string? IdAssociado { get; set; }
+    [Parameter] public string? IdPeriodo { get; set; }
+    [Parameter] public string? TipoAvaliacao { get; set; }
+    [Parameter] public string? Escopo { get; set; }
+    [Parameter] public string? IdGestor { get; set; }
+
+    private AutoAvaliacaoDto? AvaliacaoData;
+    private bool IsLoading = true;
+    private bool IsProcessing = false;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await CarregarDadosAvaliacao();
+        await ConfigurarAutoSave();
+    }
+
+    private async Task CarregarDadosAvaliacao()
+    {
+        try
+        {
+            IsLoading = true;
+            StateHasChanged();
+
+            var parametros = ObterParametrosUrl();
+            AvaliacaoData = await AutoAvaliacaoService.CarregarDadosAvaliacaoAsync(parametros);
+
+            TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_Loaded", new Dictionary<string, string>
+            {
+                { "IdProjeto", parametros.IdProjeto.ToString() },
+                { "IdAssociado", parametros.IdAssociado.ToString() },
+                { "CompetenciasCount", AvaliacaoData?.Competencias?.Count.ToString() ?? "0" }
+            });
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "CarregarDadosAvaliacao" },
+                { "Component", "AutoAvaliacaoCompetencia" }
+            });
+            MessageBoxService.ShowError("Erro ao carregar dados da avaliação: " + ex.Message);
+        }
+        finally
+        {
+            IsLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task SalvarAvaliacao()
+    {
+        if (AvaliacaoData == null || IsProcessing) return;
+
+        try
+        {
+            IsProcessing = true;
+            StateHasChanged();
+
+            var resultado = await AutoAvaliacaoService.SalvarAvaliacaoAsync(AvaliacaoData, false);
+
+            if (resultado.Sucesso)
+            {
+                MessageBoxService.ShowSuccess("Avaliação salva com sucesso.");
+                TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_Saved", new Dictionary<string, string>
+                {
+                    { "IdAvaliacao", AvaliacaoData.IdAvaliacao.ToString() },
+                    { "CompetenciasPreenchidas", resultado.CompetenciasPreenchidas.ToString() }
+                });
+            }
+            else
+            {
+                MessageBoxService.ShowError(resultado.MensagemErro ?? "Erro ao salvar avaliação.");
+            }
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "SalvarAvaliacao" },
+                { "Component", "AutoAvaliacaoCompetencia" }
+            });
+            MessageBoxService.ShowError("Erro interno ao salvar avaliação.");
+        }
+        finally
+        {
+            IsProcessing = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task IrParaPerformance()
+    {
+        if (AvaliacaoData == null) return;
+
+        var resultado = await AutoAvaliacaoService.ValidarAvaliacaoAsync(AvaliacaoData);
+        if (resultado.Valida)
+        {
+            await SalvarAvaliacao();
+            Navigation.NavigateTo("/autoavaliacao-performance");
+        }
+        else
+        {
+            MessageBoxService.ShowError(resultado.MensagemErro ?? "Erro na validação.");
+        }
+    }
+
+    private async Task IrParaFinalizacao()
+    {
+        if (AvaliacaoData == null) return;
+
+        var resultado = await AutoAvaliacaoService.ValidarAvaliacaoAsync(AvaliacaoData);
+        if (resultado.Valida)
+        {
+            await SalvarAvaliacao();
+            var parametros = ObterParametrosUrl();
+            Navigation.NavigateTo($"/autoavaliacao?IdProjeto={parametros.IdProjeto}&IdAssociado={parametros.IdAssociado}&IdPeriodo={parametros.IdPeriodo}");
+        }
+        else
+        {
+            MessageBoxService.ShowError(resultado.MensagemErro ?? "Erro na validação.");
+        }
+    }
+
+    private AutoAvaliacaoParametrosDto ObterParametrosUrl()
+    {
+        var uri = new Uri(Navigation.Uri);
+        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+
+        return new AutoAvaliacaoParametrosDto
+        {
+            IdProjeto = int.TryParse(query.TryGetValue("IdProjeto", out var idProjeto) ? idProjeto.FirstOrDefault() : IdProjeto, out var projeto) ? projeto : 0,
+            IdAssociado = int.TryParse(query.TryGetValue("IdAssociado", out var idAssociado) ? idAssociado.FirstOrDefault() : IdAssociado, out var associado) ? associado : 0,
+            IdPeriodo = int.TryParse(query.TryGetValue("IdPeriodo", out var idPeriodo) ? idPeriodo.FirstOrDefault() : IdPeriodo, out var periodo) ? periodo : 0,
+            TipoAvaliacao = query.TryGetValue("TipoAvaliacao", out var tipoAvaliacao) ? tipoAvaliacao.FirstOrDefault() : TipoAvaliacao ?? "desempenho",
+            Escopo = query.TryGetValue("Escopo", out var escopo) ? escopo.FirstOrDefault() : Escopo ?? "projeto",
+            IdGestor = int.TryParse(query.TryGetValue("IdGestor", out var idGestor) ? idGestor.FirstOrDefault() : IdGestor, out var gestor) ? gestor : 0
+        };
+    }
+
+    private async Task ConfigurarAutoSave()
+    {
+        await JSRuntime.InvokeVoidAsync("configureAutoSave", DotNetObjectReference.Create(this));
+    }
+
+    [JSInvokable]
+    public async Task AutoSave()
+    {
+        if (!IsProcessing && AvaliacaoData != null)
+        {
+            await SalvarAvaliacao();
+        }
+    }
+
+    private string TruncarTexto(string? texto, int qtdCaracteres)
+    {
+        if (string.IsNullOrEmpty(texto))
+            return string.Empty;
+
+        if (texto.Length > qtdCaracteres)
+        {
+            return $"{texto.Substring(0, qtdCaracteres)}...";
+        }
+
+        return texto;
+    }
+}

--- a/Components/Pages/AutoAvaliacaoCompetencia.razor
+++ b/Components/Pages/AutoAvaliacaoCompetencia.razor
@@ -12,6 +12,15 @@
 
 <PageTitle>Auto Avaliação - Competência</PageTitle>
 
+@if (messageBoxVisible)
+{
+    <div class="alert alert-@messageBoxType alert-dismissible fade show" role="alert">
+        @messageBoxMessage
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" @onclick="() => messageBoxVisible = false"></button>
+    </div>
+}
+
+<!-- Breadcrumb -->
 <div class="page-breadcrumb border-bottom" style="position:fixed;z-index:1;width:1653px">
     <div class="row">
         <div class="col-lg-3 col-md-4 col-xs-12 align-self-center">
@@ -29,16 +38,18 @@
     </div>
 </div>
 
+<!-- Container fluid -->
 <div style="overflow:initial !important" class="page-content container-fluid">
-    @if (IsLoading)
+    
+    @if (isLoading)
     {
         <div class="d-flex justify-content-center align-items-center" style="height: 400px;">
             <div class="spinner-border" role="status">
-                <span class="sr-only">Carregando...</span>
+                <span class="visually-hidden">Carregando...</span>
             </div>
         </div>
     }
-    else if (AvaliacaoData != null)
+    else if (avaliacaoData != null)
     {
         <!-- CARD TITULO -->
         <div class="card col-md-10" style="position:fixed;z-index:1; margin-top:21px;border-color:rgba(0, 0, 0, .25);border-width:1px">
@@ -48,13 +59,13 @@
                     <div class="card">
                         <div class="card-header" id="headingDetalhes">
                             <h5 class="mb-0">
-                                <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#Detalhes" aria-expanded="true" aria-controls="Detalhes">
+                                <button class="btn btn-link" type="button" data-bs-toggle="collapse" data-bs-target="#Detalhes" aria-expanded="true" aria-controls="Detalhes">
                                     Detalhes da avaliação
                                     <i class="fa fa-angle-right"></i>
                                 </button>
                             </h5>
                         </div>
-                        <div id="Detalhes" class="collapse" aria-labelledby="headingDetalhes" data-parent="#accordionDetalhes">
+                        <div id="Detalhes" class="collapse" aria-labelledby="headingDetalhes" data-bs-parent="#accordionDetalhes">
                             <div class="col-md-5">
                                 <div class="text-left">
                                     <button type="button" class="btn btn-facebook" disabled>Competência</button>
@@ -69,13 +80,13 @@
                                         <label><b>Avaliado</b></label>
                                     </div>
                                     <div class="col-md-4">
-                                        <label>@AvaliacaoData.NomeAssociado</label>
+                                        <label>@avaliacaoData.NomeAssociado</label>
                                     </div>
                                     <div class="col-md-2">
                                         <label><b>Período</b></label>
                                     </div>
                                     <div class="col-md-4">
-                                        <label>@AvaliacaoData.Periodo</label>
+                                        <label>@avaliacaoData.Periodo</label>
                                     </div>
                                 </div>
                                 <div class="row">
@@ -83,13 +94,13 @@
                                         <label><b>Tempo de Cargo:</b></label>
                                     </div>
                                     <div class="col-md-4">
-                                        <label>@AvaliacaoData.TempoCargo</label>
+                                        <label>@avaliacaoData.TempoCargo</label>
                                     </div>
                                     <div class="col-md-2">
                                         <label><b>Tempo de Peers</b></label>
                                     </div>
                                     <div class="col-md-4">
-                                        <label>@AvaliacaoData.TempoPeers</label>
+                                        <label>@avaliacaoData.TempoPeers</label>
                                     </div>
                                 </div>
                                 <div class="row">
@@ -97,19 +108,19 @@
                                         <label><b>Projeto</b></label>
                                     </div>
                                     <div class="col-md-3">
-                                        <label>@AvaliacaoData.NomeProjeto</label>
+                                        <label>@avaliacaoData.NomeProjeto</label>
                                     </div>
                                     <div class="col-md-1">
                                         <label><b>Cliente</b></label>
                                     </div>
                                     <div class="col-md-3">
-                                        <label>@AvaliacaoData.NomeCliente</label>
+                                        <label>@avaliacaoData.NomeCliente</label>
                                     </div>
                                     <div class="col-md-2">
                                         <label><b>Tempo restante</b></label>
                                     </div>
                                     <div class="col-md-2">
-                                        <label>@AvaliacaoData.TempoRestante</label>
+                                        <label>@avaliacaoData.TempoRestante</label>
                                     </div>
                                 </div>
                             </div>
@@ -122,13 +133,13 @@
                     <div class="card">
                         <div class="card-header" id="headingCabecalho">
                             <h5 class="mb-0">
-                                <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#Cabecalho" aria-expanded="true" aria-controls="Cabecalho">
+                                <button class="btn btn-link" type="button" data-bs-toggle="collapse" data-bs-target="#Cabecalho" aria-expanded="true" aria-controls="Cabecalho">
                                     Descrições nível atual e próximo nível
                                     <i class="fa fa-angle-right"></i>
                                 </button>
                             </h5>
                         </div>
-                        <div id="Cabecalho" class="collapse" aria-labelledby="headingCabecalho" data-parent="#accordionCabecalho">
+                        <div id="Cabecalho" class="collapse" aria-labelledby="headingCabecalho" data-bs-parent="#accordionCabecalho">
                             <table class="table table-striped border" style="width:100%;table-layout:fixed">
                                 <thead>
                                     <tr>
@@ -138,7 +149,7 @@
                                         <th colspan="2">Autonomia</th>
                                         <th colspan="2">Escopo de Atuação</th>
                                         <th colspan="2">Nível de interlocução principal no cliente</th>
-                                        @foreach (var titulo in AvaliacaoData.TitulosCompetencias)
+                                        @foreach (var titulo in avaliacaoData.TitulosCompetencias)
                                         {
                                             <th colspan="2">@titulo.TituloExibicao</th>
                                         }
@@ -147,24 +158,24 @@
                                 <tbody>
                                     <tr>
                                         <td colspan="1">Nível atual</td>
-                                        <td colspan="2">@AvaliacaoData.CargoAtual</td>
-                                        <td colspan="2">@AvaliacaoData.FuncaoAtual</td>
-                                        <td colspan="2">@AvaliacaoData.AutonomiaAtual</td>
-                                        <td colspan="2">@AvaliacaoData.EscopoAtual</td>
-                                        <td colspan="2">@AvaliacaoData.InterlocucaoAtual</td>
-                                        @foreach (var competencia in AvaliacaoData.CompetenciasCargoAtual)
+                                        <td colspan="2">@avaliacaoData.CargoAtual</td>
+                                        <td colspan="2">@avaliacaoData.FuncaoAtual</td>
+                                        <td colspan="2">@avaliacaoData.AutonomiaAtual</td>
+                                        <td colspan="2">@avaliacaoData.EscopoAtual</td>
+                                        <td colspan="2">@avaliacaoData.InterlocucaoAtual</td>
+                                        @foreach (var competencia in avaliacaoData.CompetenciasCargoAtual)
                                         {
                                             <th colspan="2" style="font-weight:normal;">@competencia.DescricaoCompetencia_Atual</th>
                                         }
                                     </tr>
                                     <tr>
                                         <td colspan="1">Próximo nível</td>
-                                        <td colspan="2">@AvaliacaoData.CargoProximo</td>
-                                        <td colspan="2">@AvaliacaoData.FuncaoProximo</td>
-                                        <td colspan="2">@AvaliacaoData.AutonomiaProximo</td>
-                                        <td colspan="2">@AvaliacaoData.EscopoProximo</td>
-                                        <td colspan="2">@AvaliacaoData.InterlocucaoProximo</td>
-                                        @foreach (var competencia in AvaliacaoData.CompetenciasCargoProximo)
+                                        <td colspan="2">@avaliacaoData.CargoProximo</td>
+                                        <td colspan="2">@avaliacaoData.FuncaoProximo</td>
+                                        <td colspan="2">@avaliacaoData.AutonomiaProximo</td>
+                                        <td colspan="2">@avaliacaoData.EscopoProximo</td>
+                                        <td colspan="2">@avaliacaoData.InterlocucaoProximo</td>
+                                        @foreach (var competencia in avaliacaoData.CompetenciasCargoProximo)
                                         {
                                             <th colspan="2" style="font-weight:normal;">@competencia.DescricaoCompetencia_Proximo</th>
                                         }
@@ -185,17 +196,7 @@
                     <div class="row">
                         <div class="col-md-12">
                             <div class="text-right">
-                                <button type="button" class="btn btn-dark" @onclick="SalvarAvaliacao" disabled="@IsProcessing">
-                                    @if (IsProcessing)
-                                    {
-                                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                                        <span>Salvando...</span>
-                                    }
-                                    else
-                                    {
-                                        <span>Salvar Avaliação</span>
-                                    }
-                                </button>
+                                <button type="button" class="btn btn-dark" @onclick="SalvarAvaliacao" disabled="@(!podeEditar)">Salvar Avaliação</button>
                             </div>
                         </div>
                     </div>
@@ -212,35 +213,43 @@
                             <tr>
                                 <th colspan="4" style="position:sticky !important; top:45px !important;color:#021240;background-color:#eae678;border-bottom:6px solid;border-color:#eae678">Detalhamento Atual</th>
                                 <th colspan="3" style="position:sticky !important; top:45px !important;color:#021240;background-color:#eae678;border-bottom:6px solid;border-color:#eae678">Nota Avaliado</th>
-                                <th colspan="4" style="position:sticky !important; top:45px !important;color:#021240;background-color:#eae678;border-bottom:6px solid;border-color:#eae678">@AvaliacaoData.LabelDetalheNivel2</th>
+                                <th colspan="4" style="position:sticky !important; top:45px !important;color:#021240;background-color:#eae678;border-bottom:6px solid;border-color:#eae678">@avaliacaoData.LabelDetalheNivel2</th>
                                 <th colspan="3" style="position:sticky !important; top:45px !important;color:#021240;background-color:#eae678;border-bottom:6px solid;border-color:#eae678">Nota Avaliado</th>
                                 <th colspan="2" style="position:sticky !important; top:45px !important;color:#021240;background-color:#eae678;border-bottom:6px solid;border-color:#eae678">Considerações Avaliado</th>
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach (var competencia in AvaliacaoData.Competencias)
+                            @foreach (var competencia in avaliacaoData.Competencias)
                             {
+                                <!-- Título da SubCompetência -->
                                 <tr style="font-style:italic;font-size:14px;font-weight:normal;background-color:#f2f2f2;vertical-align:bottom">
                                     <th colspan="16" style="font-style:normal;font-size:21px;font-weight:normal;align-content:center;text-align:center;border-top:5px solid;border-color:#003150">
                                         @competencia.SubCompetencia
                                     </th>
                                 </tr>
+                                
+                                <!-- Palavras-chave -->
                                 <tr style="font-weight:bold;background-color:#f5f5f5;border-top:none">
                                     <td colspan="16" style="text-align:center;border-top:none">@((MarkupString)competencia.PalavrasChave)</td>
                                 </tr>
+                                
+                                <!-- Linha principal da competência -->
                                 <tr style="font-weight:normal;background-color:#f9f9f9;border-top:none">
+                                    <!-- Detalhamento Atual -->
                                     <td colspan="4" style="border-top:none;background-color:#f9f9f9">
-                                        <a href="#det_@competencia.IdCompetencia" data-target="#det_@competencia.IdCompetencia" data-toggle="collapse" class="accordion-toggle">
+                                        <a href="#" data-bs-toggle="collapse" data-bs-target="#det_@competencia.IdCompetencia" class="accordion-toggle">
                                             @TruncarTexto(competencia.DetalheNivelAtual, 70)
                                             <span style="font-weight:bold">  Ver+</span>
                                         </a>
                                     </td>
+                                    
+                                    <!-- Combobox Resposta Nível Atual -->
                                     <td colspan="3" style="border-top:none;background-color:#f9f9f9">
                                         @if (competencia.HabilitadoSelectNivel1)
                                         {
-                                            <select class="form-control p-0 select2" style="width: 100%" @bind="competencia.NotaNivel1" disabled="@competencia.DesabilitadoNivel1">
+                                            <select class="form-control p-0 select2" style="width: 100%" @bind="competencia.NotaNivel1" disabled="@(!podeEditar)">
                                                 <option value="0">[Selecionar]</option>
-                                                @foreach (var nota in AvaliacaoData.NotasDisponiveis)
+                                                @foreach (var nota in avaliacaoData.NotasDisponiveis)
                                                 {
                                                     <option value="@nota.IdNota">@nota.CodigoNota</option>
                                                 }
@@ -251,18 +260,22 @@
                                             <label class="form-control p-0" style="width: 100%; height: 100%; background-color:#E9ECEF">@competencia.TextoNotaNivel1</label>
                                         }
                                     </td>
+                                    
+                                    <!-- Detalhamento Próximo Nível -->
                                     <td colspan="4" style="border-top:none;background-color:#f9f9f9">
-                                        <a href="#detPrNivel_@competencia.IdCompetencia" data-target="#detPrNivel_@competencia.IdCompetencia" data-toggle="collapse" class="accordion-toggle">
+                                        <a href="#" data-bs-toggle="collapse" data-bs-target="#detPrNivel_@competencia.IdCompetencia" class="accordion-toggle">
                                             @TruncarTexto(competencia.DetalheProximoNivel, 70)
                                             <span style="font-weight:bold">  Ver+</span>
                                         </a>
                                     </td>
+                                    
+                                    <!-- Combobox Resposta Próximo Nível -->
                                     <td colspan="3" style="border-top:none;background-color:#f9f9f9">
                                         @if (competencia.HabilitadoSelectNivel2)
                                         {
-                                            <select class="form-control p-0 select2" style="width: 100%" @bind="competencia.NotaNivel2" disabled="@competencia.DesabilitadoNivel2">
+                                            <select class="form-control p-0 select2" style="width: 100%" @bind="competencia.NotaNivel2" disabled="@(!podeEditar)">
                                                 <option value="0">[Selecionar]</option>
-                                                @foreach (var nota in AvaliacaoData.NotasDisponiveis)
+                                                @foreach (var nota in avaliacaoData.NotasDisponiveis)
                                                 {
                                                     <option value="@nota.IdNota">@nota.CodigoNota</option>
                                                 }
@@ -273,14 +286,16 @@
                                             <label class="form-control p-0" style="width: 100%; height: 100%; background-color:#E9ECEF">@competencia.TextoNotaNivel2</label>
                                         }
                                     </td>
+                                    
+                                    <!-- Botão Considerações -->
                                     <td colspan="2" style="border-top:none;background-color:#f9f9f9;text-align:center">
-                                        <button type="button" data-toggle="collapse" data-target="#cons_@competencia.IdCompetencia" class="accordion-toggle" style="background-color:#003150;padding:8px 15px;border:none">
+                                        <button type="button" data-bs-toggle="collapse" data-bs-target="#cons_@competencia.IdCompetencia" class="accordion-toggle" style="background-color:#003150;padding:8px 15px;border:none">
                                             <span aria-hidden="true" style="color:white;font-size:15px">Considerações</span>
                                         </button>
                                     </td>
                                 </tr>
-
-                                <!-- DETALHAMENTO ATUAL -->
+                                
+                                <!-- Detalhamento Atual (Expandível) -->
                                 <tr>
                                     <td colspan="16" class="hiddenRow" style="border-top:none;background-color:#ffffff">
                                         <div class="accordian-body collapse" id="det_@competencia.IdCompetencia">
@@ -288,8 +303,8 @@
                                         </div>
                                     </td>
                                 </tr>
-
-                                <!-- DETALHAMENTO DO PRÓXIMO NÍVEL -->
+                                
+                                <!-- Detalhamento do Próximo Nível (Expandível) -->
                                 <tr>
                                     <td colspan="16" class="hiddenRow" style="border-top:none;background-color:#ffffff">
                                         <div class="accordian-body collapse" id="detPrNivel_@competencia.IdCompetencia">
@@ -297,13 +312,13 @@
                                         </div>
                                     </td>
                                 </tr>
-
-                                <!-- CONSIDERAÇÕES -->
+                                
+                                <!-- Considerações (Expandível) -->
                                 <tr>
                                     <td colspan="16" class="hiddenRow" style="border-top:none;background-color:#ffffff">
                                         <div class="accordian-body collapse" id="cons_@competencia.IdCompetencia">
                                             <strong>Considerações:</strong><br />
-                                            <textarea rows="5" class="form-control" @bind="competencia.Consideracoes" disabled="@competencia.DesabilitadoConsideracoes"></textarea>
+                                            <textarea rows="5" class="form-control" @bind="competencia.Consideracoes" disabled="@(!podeEditar)"></textarea>
                                         </div>
                                     </td>
                                 </tr>
@@ -317,17 +332,7 @@
                     <div class="row">
                         <div class="col-md-12">
                             <div class="text-right">
-                                <button type="button" class="btn btn-dark" @onclick="SalvarAvaliacao" disabled="@IsProcessing">
-                                    @if (IsProcessing)
-                                    {
-                                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                                        <span>Salvando...</span>
-                                    }
-                                    else
-                                    {
-                                        <span>Salvar Avaliação</span>
-                                    }
-                                </button>
+                                <button type="button" class="btn btn-dark" @onclick="SalvarAvaliacao" disabled="@(!podeEditar)">Salvar Avaliação</button>
                             </div>
                         </div>
                     </div>
@@ -355,7 +360,7 @@
             <h4 class="alert-heading">Avaliação não encontrada</h4>
             <p>Não foi possível carregar os dados da avaliação. Verifique os parâmetros e tente novamente.</p>
             <hr>
-            <p class="mb-0">Se o problema persistir, entre em contato com o suporte.</p>
+            <p class="mb-0"><a href="/" class="btn btn-primary">Voltar ao Início</a></p>
         </div>
     }
 </div>
@@ -366,171 +371,35 @@
     }
 </style>
 
-@code {
-    [Parameter] public string? IdProjeto { get; set; }
-    [Parameter] public string? IdAssociado { get; set; }
-    [Parameter] public string? IdPeriodo { get; set; }
-    [Parameter] public string? TipoAvaliacao { get; set; }
-    [Parameter] public string? Escopo { get; set; }
-    [Parameter] public string? IdGestor { get; set; }
-
-    private AutoAvaliacaoDto? AvaliacaoData;
-    private bool IsLoading = true;
-    private bool IsProcessing = false;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await CarregarDadosAvaliacao();
-        await ConfigurarAutoSave();
-    }
-
-    private async Task CarregarDadosAvaliacao()
-    {
-        try
-        {
-            IsLoading = true;
-            StateHasChanged();
-
-            var parametros = ObterParametrosUrl();
-            AvaliacaoData = await AutoAvaliacaoService.CarregarDadosAvaliacaoAsync(parametros);
-
-            TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_Loaded", new Dictionary<string, string>
-            {
-                { "IdProjeto", parametros.IdProjeto.ToString() },
-                { "IdAssociado", parametros.IdAssociado.ToString() },
-                { "CompetenciasCount", AvaliacaoData?.Competencias?.Count.ToString() ?? "0" }
+<script>
+    window.autoSaveInterval = null;
+    
+    window.initAutoSave = (dotNetRef) => {
+        if (window.autoSaveInterval) {
+            clearInterval(window.autoSaveInterval);
+        }
+        
+        window.autoSaveInterval = setInterval(() => {
+            dotNetRef.invokeMethodAsync('AutoSave');
+        }, 900000); // 15 minutos
+    };
+    
+    window.clearAutoSave = () => {
+        if (window.autoSaveInterval) {
+            clearInterval(window.autoSaveInterval);
+            window.autoSaveInterval = null;
+        }
+    };
+    
+    window.showMessage = (type, message, time) => {
+        if (typeof swal !== 'undefined') {
+            swal({
+                title: "ATENÇÃO!",
+                text: message,
+                icon: type,
+                timer: time,
+                button: "Ok",
             });
         }
-        catch (Exception ex)
-        {
-            TelemetryService.TrackException(ex, new Dictionary<string, string>
-            {
-                { "Method", "CarregarDadosAvaliacao" },
-                { "Component", "AutoAvaliacaoCompetencia" }
-            });
-            MessageBoxService.ShowError("Erro ao carregar dados da avaliação: " + ex.Message);
-        }
-        finally
-        {
-            IsLoading = false;
-            StateHasChanged();
-        }
-    }
-
-    private async Task SalvarAvaliacao()
-    {
-        if (AvaliacaoData == null || IsProcessing) return;
-
-        try
-        {
-            IsProcessing = true;
-            StateHasChanged();
-
-            var resultado = await AutoAvaliacaoService.SalvarAvaliacaoAsync(AvaliacaoData, false);
-
-            if (resultado.Sucesso)
-            {
-                MessageBoxService.ShowSuccess("Avaliação salva com sucesso.");
-                TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_Saved", new Dictionary<string, string>
-                {
-                    { "IdAvaliacao", AvaliacaoData.IdAvaliacao.ToString() },
-                    { "CompetenciasPreenchidas", resultado.CompetenciasPreenchidas.ToString() }
-                });
-            }
-            else
-            {
-                MessageBoxService.ShowError(resultado.MensagemErro ?? "Erro ao salvar avaliação.");
-            }
-        }
-        catch (Exception ex)
-        {
-            TelemetryService.TrackException(ex, new Dictionary<string, string>
-            {
-                { "Method", "SalvarAvaliacao" },
-                { "Component", "AutoAvaliacaoCompetencia" }
-            });
-            MessageBoxService.ShowError("Erro interno ao salvar avaliação.");
-        }
-        finally
-        {
-            IsProcessing = false;
-            StateHasChanged();
-        }
-    }
-
-    private async Task IrParaPerformance()
-    {
-        if (AvaliacaoData == null) return;
-
-        var resultado = await AutoAvaliacaoService.ValidarAvaliacaoAsync(AvaliacaoData);
-        if (resultado.Valida)
-        {
-            await SalvarAvaliacao();
-            Navigation.NavigateTo("/autoavaliacao-performance");
-        }
-        else
-        {
-            MessageBoxService.ShowError(resultado.MensagemErro ?? "Erro na validação.");
-        }
-    }
-
-    private async Task IrParaFinalizacao()
-    {
-        if (AvaliacaoData == null) return;
-
-        var resultado = await AutoAvaliacaoService.ValidarAvaliacaoAsync(AvaliacaoData);
-        if (resultado.Valida)
-        {
-            await SalvarAvaliacao();
-            var parametros = ObterParametrosUrl();
-            Navigation.NavigateTo($"/autoavaliacao?IdProjeto={parametros.IdProjeto}&IdAssociado={parametros.IdAssociado}&IdPeriodo={parametros.IdPeriodo}");
-        }
-        else
-        {
-            MessageBoxService.ShowError(resultado.MensagemErro ?? "Erro na validação.");
-        }
-    }
-
-    private AutoAvaliacaoParametrosDto ObterParametrosUrl()
-    {
-        var uri = new Uri(Navigation.Uri);
-        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
-
-        return new AutoAvaliacaoParametrosDto
-        {
-            IdProjeto = int.TryParse(query.TryGetValue("IdProjeto", out var idProjeto) ? idProjeto.FirstOrDefault() : IdProjeto, out var projeto) ? projeto : 0,
-            IdAssociado = int.TryParse(query.TryGetValue("IdAssociado", out var idAssociado) ? idAssociado.FirstOrDefault() : IdAssociado, out var associado) ? associado : 0,
-            IdPeriodo = int.TryParse(query.TryGetValue("IdPeriodo", out var idPeriodo) ? idPeriodo.FirstOrDefault() : IdPeriodo, out var periodo) ? periodo : 0,
-            TipoAvaliacao = query.TryGetValue("TipoAvaliacao", out var tipoAvaliacao) ? tipoAvaliacao.FirstOrDefault() : TipoAvaliacao ?? "desempenho",
-            Escopo = query.TryGetValue("Escopo", out var escopo) ? escopo.FirstOrDefault() : Escopo ?? "projeto",
-            IdGestor = int.TryParse(query.TryGetValue("IdGestor", out var idGestor) ? idGestor.FirstOrDefault() : IdGestor, out var gestor) ? gestor : 0
-        };
-    }
-
-    private async Task ConfigurarAutoSave()
-    {
-        await JSRuntime.InvokeVoidAsync("configureAutoSave", DotNetObjectReference.Create(this));
-    }
-
-    [JSInvokable]
-    public async Task AutoSave()
-    {
-        if (!IsProcessing && AvaliacaoData != null)
-        {
-            await SalvarAvaliacao();
-        }
-    }
-
-    private string TruncarTexto(string? texto, int qtdCaracteres)
-    {
-        if (string.IsNullOrEmpty(texto))
-            return string.Empty;
-
-        if (texto.Length > qtdCaracteres)
-        {
-            return $"{texto.Substring(0, qtdCaracteres)}...";
-        }
-
-        return texto;
-    }
-}
+    };
+</script>

--- a/Components/Pages/AutoAvaliacaoCompetencia.razor.cs
+++ b/Components/Pages/AutoAvaliacaoCompetencia.razor.cs
@@ -3,41 +3,75 @@ using Microsoft.JSInterop;
 using Peers.Moderno.Services.AutoAvaliacao;
 using Peers.Moderno.Services.AutoAvaliacao.Common;
 using Peers.Moderno.Services.Common;
+using System.ComponentModel;
 
 namespace Peers.Moderno.Components.Pages;
 
 public partial class AutoAvaliacaoCompetencia : ComponentBase, IDisposable
 {
-    [Inject] private IAutoAvaliacaoService AutoAvaliacaoService { get; set; } = default!;
-    [Inject] private IMessageBoxService MessageBoxService { get; set; } = default!;
-    [Inject] private ITelemetryService TelemetryService { get; set; } = default!;
-    [Inject] private NavigationManager Navigation { get; set; } = default!;
-    [Inject] private IJSRuntime JSRuntime { get; set; } = default!;
+    [Parameter, SupplyParameterFromQuery] public int? IdProjeto { get; set; }
+    [Parameter, SupplyParameterFromQuery] public int? IdAssociado { get; set; }
+    [Parameter, SupplyParameterFromQuery] public int? IdPeriodo { get; set; }
+    [Parameter, SupplyParameterFromQuery] public string? TipoAvaliacao { get; set; }
+    [Parameter, SupplyParameterFromQuery] public string? Escopo { get; set; }
+    [Parameter, SupplyParameterFromQuery] public int? IdGestor { get; set; }
 
-    [Parameter] public string? IdProjeto { get; set; }
-    [Parameter] public string? IdAssociado { get; set; }
-    [Parameter] public string? IdPeriodo { get; set; }
-    [Parameter] public string? TipoAvaliacao { get; set; }
-    [Parameter] public string? Escopo { get; set; }
-    [Parameter] public string? IdGestor { get; set; }
-
-    private AutoAvaliacaoDto? AvaliacaoData;
-    private bool IsLoading = true;
-    private bool IsProcessing = false;
-    private DotNetObjectReference<AutoAvaliacaoCompetencia>? objRef;
+    private AutoAvaliacaoDto? avaliacaoData;
+    private bool isLoading = true;
+    private bool podeEditar = true;
+    private bool messageBoxVisible = false;
+    private string messageBoxMessage = string.Empty;
+    private string messageBoxType = "info";
+    private DotNetObjectReference<AutoAvaliacaoCompetencia>? dotNetRef;
 
     protected override async Task OnInitializedAsync()
     {
-        objRef = DotNetObjectReference.Create(this);
-        await CarregarDadosAvaliacao();
+        try
+        {
+            TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_PageLoad", new Dictionary<string, string>
+            {
+                { "IdProjeto", IdProjeto?.ToString() ?? "null" },
+                { "IdAssociado", IdAssociado?.ToString() ?? "null" },
+                { "IdPeriodo", IdPeriodo?.ToString() ?? "null" },
+                { "TipoAvaliacao", TipoAvaliacao ?? "null" },
+                { "Escopo", Escopo ?? "null" }
+            });
+
+            await CarregarDadosAvaliacao();
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "OnInitializedAsync" },
+                { "Component", "AutoAvaliacaoCompetencia" }
+            });
+            
+            ShowMessage("Erro ao carregar a página de avaliação.", "danger");
+        }
+        finally
+        {
+            isLoading = false;
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
+        if (firstRender && avaliacaoData != null && podeEditar)
         {
-            await ConfigurarAutoSave();
-            await ConfigurarScripts();
+            try
+            {
+                dotNetRef = DotNetObjectReference.Create(this);
+                await JSRuntime.InvokeVoidAsync("initAutoSave", dotNetRef);
+            }
+            catch (Exception ex)
+            {
+                TelemetryService.TrackException(ex, new Dictionary<string, string>
+                {
+                    { "Method", "OnAfterRenderAsync" },
+                    { "Component", "AutoAvaliacaoCompetencia" }
+                });
+            }
         }
     }
 
@@ -45,34 +79,40 @@ public partial class AutoAvaliacaoCompetencia : ComponentBase, IDisposable
     {
         try
         {
-            IsLoading = true;
-            StateHasChanged();
+            if (!IdProjeto.HasValue || !IdAssociado.HasValue || !IdPeriodo.HasValue || 
+                string.IsNullOrEmpty(TipoAvaliacao) || string.IsNullOrEmpty(Escopo))
+            {
+                ShowMessage("Parâmetros obrigatórios não informados.", "warning");
+                return;
+            }
 
-            var parametros = ObterParametrosUrl();
+            var request = new CarregarAvaliacaoRequest
+            {
+                IdProjeto = IdProjeto.Value,
+                IdAssociado = IdAssociado.Value,
+                IdPeriodo = IdPeriodo.Value,
+                TipoAvaliacao = TipoAvaliacao,
+                Escopo = Escopo,
+                IdGestor = IdGestor
+            };
+
+            var resultado = await AutoAvaliacaoService.CarregarAvaliacaoAsync(request);
             
-            if (!ValidarParametrosObrigatorios(parametros))
+            if (resultado.Sucesso)
             {
-                MessageBoxService.ShowError("Parâmetros obrigatórios não informados (Projeto, Associado, Período).");
-                return;
+                avaliacaoData = resultado.Dados;
+                podeEditar = avaliacaoData?.PodeEditar ?? false;
+                
+                TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_DataLoaded", new Dictionary<string, string>
+                {
+                    { "CompetenciasCount", avaliacaoData?.Competencias?.Count.ToString() ?? "0" },
+                    { "PodeEditar", podeEditar.ToString() }
+                });
             }
-
-            AvaliacaoData = await AutoAvaliacaoService.CarregarDadosAvaliacaoAsync(parametros);
-
-            if (AvaliacaoData == null)
+            else
             {
-                MessageBoxService.ShowError("Não foi possível carregar os dados da avaliação.");
-                return;
+                ShowMessage(resultado.MensagemErro ?? "Erro ao carregar dados da avaliação.", "danger");
             }
-
-            TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_Loaded", new Dictionary<string, string>
-            {
-                { "IdProjeto", parametros.IdProjeto.ToString() },
-                { "IdAssociado", parametros.IdAssociado.ToString() },
-                { "IdPeriodo", parametros.IdPeriodo.ToString() },
-                { "CompetenciasCount", AvaliacaoData.Competencias?.Count.ToString() ?? "0" },
-                { "TipoAvaliacao", parametros.TipoAvaliacao ?? "" },
-                { "Escopo", parametros.Escopo ?? "" }
-            });
         }
         catch (Exception ex)
         {
@@ -81,56 +121,44 @@ public partial class AutoAvaliacaoCompetencia : ComponentBase, IDisposable
                 { "Method", "CarregarDadosAvaliacao" },
                 { "Component", "AutoAvaliacaoCompetencia" }
             });
-            MessageBoxService.ShowError($"Erro ao carregar dados da avaliação: {ex.Message}");
-        }
-        finally
-        {
-            IsLoading = false;
-            StateHasChanged();
+            
+            ShowMessage("Erro interno ao carregar dados da avaliação.", "danger");
         }
     }
 
     private async Task SalvarAvaliacao()
     {
-        if (AvaliacaoData == null || IsProcessing) return;
+        if (avaliacaoData == null || !podeEditar)
+            return;
 
         try
         {
-            IsProcessing = true;
-            StateHasChanged();
-
-            var validacao = await AutoAvaliacaoService.ValidarAvaliacaoAsync(AvaliacaoData);
-            if (!validacao.Valida)
+            var request = new SalvarAvaliacaoRequest
             {
-                MessageBoxService.ShowError(validacao.MensagemErro ?? "Erro na validação da avaliação.");
-                return;
-            }
+                IdProjeto = IdProjeto!.Value,
+                IdAssociado = IdAssociado!.Value,
+                IdPeriodo = IdPeriodo!.Value,
+                TipoAvaliacao = TipoAvaliacao!,
+                Escopo = Escopo!,
+                IdGestor = IdGestor,
+                Competencias = avaliacaoData.Competencias,
+                FinalizarAvaliacao = false
+            };
 
-            var resultado = await AutoAvaliacaoService.SalvarAvaliacaoAsync(AvaliacaoData, false);
-
+            var resultado = await AutoAvaliacaoService.SalvarAvaliacaoAsync(request);
+            
             if (resultado.Sucesso)
             {
-                MessageBoxService.ShowSuccess("Avaliação salva com sucesso.");
+                ShowMessage("Avaliação salva com sucesso.", "success");
                 
                 TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_Saved", new Dictionary<string, string>
                 {
-                    { "IdAvaliacao", AvaliacaoData.IdAvaliacao.ToString() },
-                    { "CompetenciasPreenchidas", resultado.CompetenciasPreenchidas.ToString() },
-                    { "CompetenciasTotal", AvaliacaoData.Competencias?.Count.ToString() ?? "0" }
+                    { "CompetenciasCount", avaliacaoData.Competencias?.Count.ToString() ?? "0" }
                 });
-
-                // Recarrega os dados para refletir o estado atual
-                await CarregarDadosAvaliacao();
             }
             else
             {
-                MessageBoxService.ShowError(resultado.MensagemErro ?? "Erro ao salvar avaliação.");
-                
-                TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_SaveError", new Dictionary<string, string>
-                {
-                    { "IdAvaliacao", AvaliacaoData.IdAvaliacao.ToString() },
-                    { "ErrorMessage", resultado.MensagemErro ?? "Erro desconhecido" }
-                });
+                ShowMessage(resultado.MensagemErro ?? "Erro ao salvar avaliação.", "danger");
             }
         }
         catch (Exception ex)
@@ -138,161 +166,24 @@ public partial class AutoAvaliacaoCompetencia : ComponentBase, IDisposable
             TelemetryService.TrackException(ex, new Dictionary<string, string>
             {
                 { "Method", "SalvarAvaliacao" },
-                { "Component", "AutoAvaliacaoCompetencia" },
-                { "IdAvaliacao", AvaliacaoData?.IdAvaliacao.ToString() ?? "Unknown" }
+                { "Component", "AutoAvaliacaoCompetencia" }
             });
-            MessageBoxService.ShowError("Erro interno ao salvar avaliação.");
-        }
-        finally
-        {
-            IsProcessing = false;
-            StateHasChanged();
-        }
-    }
-
-    private async Task IrParaPerformance()
-    {
-        if (AvaliacaoData == null) return;
-
-        try
-        {
-            var validacao = await AutoAvaliacaoService.ValidarAvaliacaoAsync(AvaliacaoData);
-            if (!validacao.Valida)
-            {
-                MessageBoxService.ShowError(validacao.MensagemErro ?? "Erro na validação da avaliação.");
-                return;
-            }
-
-            // Salva antes de navegar
-            var resultadoSalvar = await AutoAvaliacaoService.SalvarAvaliacaoAsync(AvaliacaoData, false);
-            if (!resultadoSalvar.Sucesso)
-            {
-                MessageBoxService.ShowError("Erro ao salvar avaliação antes de navegar para Performance.");
-                return;
-            }
-
-            var parametros = ObterParametrosUrl();
-            var urlPerformance = $"/autoavaliacao-performance?IdProjeto={parametros.IdProjeto}&IdAssociado={parametros.IdAssociado}&IdPeriodo={parametros.IdPeriodo}&TipoAvaliacao={parametros.TipoAvaliacao}&Escopo={parametros.Escopo}&IdGestor={parametros.IdGestor}";
             
-            Navigation.NavigateTo(urlPerformance);
-        }
-        catch (Exception ex)
-        {
-            TelemetryService.TrackException(ex, new Dictionary<string, string>
-            {
-                { "Method", "IrParaPerformance" },
-                { "Component", "AutoAvaliacaoCompetencia" }
-            });
-            MessageBoxService.ShowError("Erro ao navegar para Performance.");
-        }
-    }
-
-    private async Task IrParaFinalizacao()
-    {
-        if (AvaliacaoData == null) return;
-
-        try
-        {
-            var validacao = await AutoAvaliacaoService.ValidarAvaliacaoAsync(AvaliacaoData);
-            if (!validacao.Valida)
-            {
-                MessageBoxService.ShowError(validacao.MensagemErro ?? "Erro na validação da avaliação.");
-                return;
-            }
-
-            // Salva antes de navegar
-            var resultadoSalvar = await AutoAvaliacaoService.SalvarAvaliacaoAsync(AvaliacaoData, false);
-            if (!resultadoSalvar.Sucesso)
-            {
-                MessageBoxService.ShowError("Erro ao salvar avaliação antes de finalizar.");
-                return;
-            }
-
-            var parametros = ObterParametrosUrl();
-            var urlFinalizacao = $"/autoavaliacao?IdProjeto={parametros.IdProjeto}&IdAssociado={parametros.IdAssociado}&IdPeriodo={parametros.IdPeriodo}&TipoAvaliacao={parametros.TipoAvaliacao}&Escopo={parametros.Escopo}&IdGestor={parametros.IdGestor}";
-            
-            Navigation.NavigateTo(urlFinalizacao);
-        }
-        catch (Exception ex)
-        {
-            TelemetryService.TrackException(ex, new Dictionary<string, string>
-            {
-                { "Method", "IrParaFinalizacao" },
-                { "Component", "AutoAvaliacaoCompetencia" }
-            });
-            MessageBoxService.ShowError("Erro ao navegar para Finalização.");
-        }
-    }
-
-    private AutoAvaliacaoParametrosDto ObterParametrosUrl()
-    {
-        var uri = new Uri(Navigation.Uri);
-        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
-
-        return new AutoAvaliacaoParametrosDto
-        {
-            IdProjeto = int.TryParse(query.TryGetValue("IdProjeto", out var idProjeto) ? idProjeto.FirstOrDefault() : IdProjeto, out var projeto) ? projeto : 0,
-            IdAssociado = int.TryParse(query.TryGetValue("IdAssociado", out var idAssociado) ? idAssociado.FirstOrDefault() : IdAssociado, out var associado) ? associado : 0,
-            IdPeriodo = int.TryParse(query.TryGetValue("IdPeriodo", out var idPeriodo) ? idPeriodo.FirstOrDefault() : IdPeriodo, out var periodo) ? periodo : 0,
-            TipoAvaliacao = query.TryGetValue("TipoAvaliacao", out var tipoAvaliacao) ? tipoAvaliacao.FirstOrDefault() : TipoAvaliacao ?? "desempenho",
-            Escopo = query.TryGetValue("Escopo", out var escopo) ? escopo.FirstOrDefault() : Escopo ?? "projeto",
-            IdGestor = int.TryParse(query.TryGetValue("IdGestor", out var idGestor) ? idGestor.FirstOrDefault() : IdGestor, out var gestor) ? gestor : 0
-        };
-    }
-
-    private bool ValidarParametrosObrigatorios(AutoAvaliacaoParametrosDto parametros)
-    {
-        return parametros.IdProjeto > 0 && 
-               parametros.IdAssociado > 0 && 
-               parametros.IdPeriodo > 0 &&
-               !string.IsNullOrEmpty(parametros.TipoAvaliacao) &&
-               !string.IsNullOrEmpty(parametros.Escopo);
-    }
-
-    private async Task ConfigurarAutoSave()
-    {
-        try
-        {
-            await JSRuntime.InvokeVoidAsync("configureAutoSave", objRef);
-        }
-        catch (Exception ex)
-        {
-            TelemetryService.TrackException(ex, new Dictionary<string, string>
-            {
-                { "Method", "ConfigurarAutoSave" },
-                { "Component", "AutoAvaliacaoCompetencia" }
-            });
-        }
-    }
-
-    private async Task ConfigurarScripts()
-    {
-        try
-        {
-            await JSRuntime.InvokeVoidAsync("initializeBootstrapComponents");
-        }
-        catch (Exception ex)
-        {
-            TelemetryService.TrackException(ex, new Dictionary<string, string>
-            {
-                { "Method", "ConfigurarScripts" },
-                { "Component", "AutoAvaliacaoCompetencia" }
-            });
+            ShowMessage("Erro interno ao salvar avaliação.", "danger");
         }
     }
 
     [JSInvokable]
     public async Task AutoSave()
     {
-        if (!IsProcessing && AvaliacaoData != null)
+        if (avaliacaoData != null && podeEditar)
         {
             try
             {
+                await JSRuntime.InvokeVoidAsync("showMessage", "success", "SALVANDO!!", 9000);
                 await SalvarAvaliacao();
-                TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_AutoSaved", new Dictionary<string, string>
-                {
-                    { "IdAvaliacao", AvaliacaoData.IdAvaliacao.ToString() }
-                });
+                
+                TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_AutoSaved");
             }
             catch (Exception ex)
             {
@@ -305,7 +196,107 @@ public partial class AutoAvaliacaoCompetencia : ComponentBase, IDisposable
         }
     }
 
-    private string TruncarTexto(string? texto, int qtdCaracteres)
+    private async Task IrParaPerformance()
+    {
+        if (avaliacaoData == null)
+            return;
+
+        try
+        {
+            var request = new SalvarAvaliacaoRequest
+            {
+                IdProjeto = IdProjeto!.Value,
+                IdAssociado = IdAssociado!.Value,
+                IdPeriodo = IdPeriodo!.Value,
+                TipoAvaliacao = TipoAvaliacao!,
+                Escopo = Escopo!,
+                IdGestor = IdGestor,
+                Competencias = avaliacaoData.Competencias,
+                FinalizarAvaliacao = false
+            };
+
+            var resultado = await AutoAvaliacaoService.SalvarAvaliacaoAsync(request);
+            
+            if (resultado.Sucesso)
+            {
+                var url = $"/autoavaliacao-performance?IdProjeto={IdProjeto}&IdAssociado={IdAssociado}&IdPeriodo={IdPeriodo}&TipoAvaliacao={TipoAvaliacao}&Escopo={Escopo}";
+                if (IdGestor.HasValue)
+                    url += $"&IdGestor={IdGestor}";
+                    
+                Navigation.NavigateTo(url);
+            }
+            else
+            {
+                ShowMessage(resultado.MensagemErro ?? "Erro ao salvar avaliação antes de navegar.", "danger");
+            }
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "IrParaPerformance" },
+                { "Component", "AutoAvaliacaoCompetencia" }
+            });
+            
+            ShowMessage("Erro ao navegar para Performance.", "danger");
+        }
+    }
+
+    private async Task IrParaFinalizacao()
+    {
+        if (avaliacaoData == null)
+            return;
+
+        try
+        {
+            var request = new SalvarAvaliacaoRequest
+            {
+                IdProjeto = IdProjeto!.Value,
+                IdAssociado = IdAssociado!.Value,
+                IdPeriodo = IdPeriodo!.Value,
+                TipoAvaliacao = TipoAvaliacao!,
+                Escopo = Escopo!,
+                IdGestor = IdGestor,
+                Competencias = avaliacaoData.Competencias,
+                FinalizarAvaliacao = false
+            };
+
+            var resultado = await AutoAvaliacaoService.SalvarAvaliacaoAsync(request);
+            
+            if (resultado.Sucesso)
+            {
+                var url = $"/autoavaliacao?IdProjeto={IdProjeto}&IdAssociado={IdAssociado}&IdPeriodo={IdPeriodo}&TipoAvaliacao={TipoAvaliacao}&Escopo={Escopo}";
+                if (IdGestor.HasValue)
+                    url += $"&IdGestor={IdGestor}";
+                    
+                Navigation.NavigateTo(url);
+            }
+            else
+            {
+                ShowMessage(resultado.MensagemErro ?? "Erro ao salvar avaliação antes de navegar.", "danger");
+            }
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "IrParaFinalizacao" },
+                { "Component", "AutoAvaliacaoCompetencia" }
+            });
+            
+            ShowMessage("Erro ao navegar para Finalização.", "danger");
+        }
+    }
+
+    private void ShowMessage(string message, string type)
+    {
+        messageBoxMessage = message;
+        messageBoxType = type;
+        messageBoxVisible = true;
+        StateHasChanged();
+    }
+
+    private static string TruncarTexto(string? texto, int qtdCaracteres)
     {
         if (string.IsNullOrEmpty(texto))
             return string.Empty;
@@ -320,6 +311,17 @@ public partial class AutoAvaliacaoCompetencia : ComponentBase, IDisposable
 
     public void Dispose()
     {
-        objRef?.Dispose();
+        try
+        {
+            if (dotNetRef != null)
+            {
+                JSRuntime.InvokeVoidAsync("clearAutoSave");
+                dotNetRef.Dispose();
+            }
+        }
+        catch
+        {
+            // Ignore disposal errors
+        }
     }
 }

--- a/Components/Pages/AutoAvaliacaoCompetencia.razor.cs
+++ b/Components/Pages/AutoAvaliacaoCompetencia.razor.cs
@@ -1,0 +1,325 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using Peers.Moderno.Services.AutoAvaliacao;
+using Peers.Moderno.Services.AutoAvaliacao.Common;
+using Peers.Moderno.Services.Common;
+
+namespace Peers.Moderno.Components.Pages;
+
+public partial class AutoAvaliacaoCompetencia : ComponentBase, IDisposable
+{
+    [Inject] private IAutoAvaliacaoService AutoAvaliacaoService { get; set; } = default!;
+    [Inject] private IMessageBoxService MessageBoxService { get; set; } = default!;
+    [Inject] private ITelemetryService TelemetryService { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private IJSRuntime JSRuntime { get; set; } = default!;
+
+    [Parameter] public string? IdProjeto { get; set; }
+    [Parameter] public string? IdAssociado { get; set; }
+    [Parameter] public string? IdPeriodo { get; set; }
+    [Parameter] public string? TipoAvaliacao { get; set; }
+    [Parameter] public string? Escopo { get; set; }
+    [Parameter] public string? IdGestor { get; set; }
+
+    private AutoAvaliacaoDto? AvaliacaoData;
+    private bool IsLoading = true;
+    private bool IsProcessing = false;
+    private DotNetObjectReference<AutoAvaliacaoCompetencia>? objRef;
+
+    protected override async Task OnInitializedAsync()
+    {
+        objRef = DotNetObjectReference.Create(this);
+        await CarregarDadosAvaliacao();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await ConfigurarAutoSave();
+            await ConfigurarScripts();
+        }
+    }
+
+    private async Task CarregarDadosAvaliacao()
+    {
+        try
+        {
+            IsLoading = true;
+            StateHasChanged();
+
+            var parametros = ObterParametrosUrl();
+            
+            if (!ValidarParametrosObrigatorios(parametros))
+            {
+                MessageBoxService.ShowError("Parâmetros obrigatórios não informados (Projeto, Associado, Período).");
+                return;
+            }
+
+            AvaliacaoData = await AutoAvaliacaoService.CarregarDadosAvaliacaoAsync(parametros);
+
+            if (AvaliacaoData == null)
+            {
+                MessageBoxService.ShowError("Não foi possível carregar os dados da avaliação.");
+                return;
+            }
+
+            TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_Loaded", new Dictionary<string, string>
+            {
+                { "IdProjeto", parametros.IdProjeto.ToString() },
+                { "IdAssociado", parametros.IdAssociado.ToString() },
+                { "IdPeriodo", parametros.IdPeriodo.ToString() },
+                { "CompetenciasCount", AvaliacaoData.Competencias?.Count.ToString() ?? "0" },
+                { "TipoAvaliacao", parametros.TipoAvaliacao ?? "" },
+                { "Escopo", parametros.Escopo ?? "" }
+            });
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "CarregarDadosAvaliacao" },
+                { "Component", "AutoAvaliacaoCompetencia" }
+            });
+            MessageBoxService.ShowError($"Erro ao carregar dados da avaliação: {ex.Message}");
+        }
+        finally
+        {
+            IsLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task SalvarAvaliacao()
+    {
+        if (AvaliacaoData == null || IsProcessing) return;
+
+        try
+        {
+            IsProcessing = true;
+            StateHasChanged();
+
+            var validacao = await AutoAvaliacaoService.ValidarAvaliacaoAsync(AvaliacaoData);
+            if (!validacao.Valida)
+            {
+                MessageBoxService.ShowError(validacao.MensagemErro ?? "Erro na validação da avaliação.");
+                return;
+            }
+
+            var resultado = await AutoAvaliacaoService.SalvarAvaliacaoAsync(AvaliacaoData, false);
+
+            if (resultado.Sucesso)
+            {
+                MessageBoxService.ShowSuccess("Avaliação salva com sucesso.");
+                
+                TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_Saved", new Dictionary<string, string>
+                {
+                    { "IdAvaliacao", AvaliacaoData.IdAvaliacao.ToString() },
+                    { "CompetenciasPreenchidas", resultado.CompetenciasPreenchidas.ToString() },
+                    { "CompetenciasTotal", AvaliacaoData.Competencias?.Count.ToString() ?? "0" }
+                });
+
+                // Recarrega os dados para refletir o estado atual
+                await CarregarDadosAvaliacao();
+            }
+            else
+            {
+                MessageBoxService.ShowError(resultado.MensagemErro ?? "Erro ao salvar avaliação.");
+                
+                TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_SaveError", new Dictionary<string, string>
+                {
+                    { "IdAvaliacao", AvaliacaoData.IdAvaliacao.ToString() },
+                    { "ErrorMessage", resultado.MensagemErro ?? "Erro desconhecido" }
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "SalvarAvaliacao" },
+                { "Component", "AutoAvaliacaoCompetencia" },
+                { "IdAvaliacao", AvaliacaoData?.IdAvaliacao.ToString() ?? "Unknown" }
+            });
+            MessageBoxService.ShowError("Erro interno ao salvar avaliação.");
+        }
+        finally
+        {
+            IsProcessing = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task IrParaPerformance()
+    {
+        if (AvaliacaoData == null) return;
+
+        try
+        {
+            var validacao = await AutoAvaliacaoService.ValidarAvaliacaoAsync(AvaliacaoData);
+            if (!validacao.Valida)
+            {
+                MessageBoxService.ShowError(validacao.MensagemErro ?? "Erro na validação da avaliação.");
+                return;
+            }
+
+            // Salva antes de navegar
+            var resultadoSalvar = await AutoAvaliacaoService.SalvarAvaliacaoAsync(AvaliacaoData, false);
+            if (!resultadoSalvar.Sucesso)
+            {
+                MessageBoxService.ShowError("Erro ao salvar avaliação antes de navegar para Performance.");
+                return;
+            }
+
+            var parametros = ObterParametrosUrl();
+            var urlPerformance = $"/autoavaliacao-performance?IdProjeto={parametros.IdProjeto}&IdAssociado={parametros.IdAssociado}&IdPeriodo={parametros.IdPeriodo}&TipoAvaliacao={parametros.TipoAvaliacao}&Escopo={parametros.Escopo}&IdGestor={parametros.IdGestor}";
+            
+            Navigation.NavigateTo(urlPerformance);
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "IrParaPerformance" },
+                { "Component", "AutoAvaliacaoCompetencia" }
+            });
+            MessageBoxService.ShowError("Erro ao navegar para Performance.");
+        }
+    }
+
+    private async Task IrParaFinalizacao()
+    {
+        if (AvaliacaoData == null) return;
+
+        try
+        {
+            var validacao = await AutoAvaliacaoService.ValidarAvaliacaoAsync(AvaliacaoData);
+            if (!validacao.Valida)
+            {
+                MessageBoxService.ShowError(validacao.MensagemErro ?? "Erro na validação da avaliação.");
+                return;
+            }
+
+            // Salva antes de navegar
+            var resultadoSalvar = await AutoAvaliacaoService.SalvarAvaliacaoAsync(AvaliacaoData, false);
+            if (!resultadoSalvar.Sucesso)
+            {
+                MessageBoxService.ShowError("Erro ao salvar avaliação antes de finalizar.");
+                return;
+            }
+
+            var parametros = ObterParametrosUrl();
+            var urlFinalizacao = $"/autoavaliacao?IdProjeto={parametros.IdProjeto}&IdAssociado={parametros.IdAssociado}&IdPeriodo={parametros.IdPeriodo}&TipoAvaliacao={parametros.TipoAvaliacao}&Escopo={parametros.Escopo}&IdGestor={parametros.IdGestor}";
+            
+            Navigation.NavigateTo(urlFinalizacao);
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "IrParaFinalizacao" },
+                { "Component", "AutoAvaliacaoCompetencia" }
+            });
+            MessageBoxService.ShowError("Erro ao navegar para Finalização.");
+        }
+    }
+
+    private AutoAvaliacaoParametrosDto ObterParametrosUrl()
+    {
+        var uri = new Uri(Navigation.Uri);
+        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+
+        return new AutoAvaliacaoParametrosDto
+        {
+            IdProjeto = int.TryParse(query.TryGetValue("IdProjeto", out var idProjeto) ? idProjeto.FirstOrDefault() : IdProjeto, out var projeto) ? projeto : 0,
+            IdAssociado = int.TryParse(query.TryGetValue("IdAssociado", out var idAssociado) ? idAssociado.FirstOrDefault() : IdAssociado, out var associado) ? associado : 0,
+            IdPeriodo = int.TryParse(query.TryGetValue("IdPeriodo", out var idPeriodo) ? idPeriodo.FirstOrDefault() : IdPeriodo, out var periodo) ? periodo : 0,
+            TipoAvaliacao = query.TryGetValue("TipoAvaliacao", out var tipoAvaliacao) ? tipoAvaliacao.FirstOrDefault() : TipoAvaliacao ?? "desempenho",
+            Escopo = query.TryGetValue("Escopo", out var escopo) ? escopo.FirstOrDefault() : Escopo ?? "projeto",
+            IdGestor = int.TryParse(query.TryGetValue("IdGestor", out var idGestor) ? idGestor.FirstOrDefault() : IdGestor, out var gestor) ? gestor : 0
+        };
+    }
+
+    private bool ValidarParametrosObrigatorios(AutoAvaliacaoParametrosDto parametros)
+    {
+        return parametros.IdProjeto > 0 && 
+               parametros.IdAssociado > 0 && 
+               parametros.IdPeriodo > 0 &&
+               !string.IsNullOrEmpty(parametros.TipoAvaliacao) &&
+               !string.IsNullOrEmpty(parametros.Escopo);
+    }
+
+    private async Task ConfigurarAutoSave()
+    {
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("configureAutoSave", objRef);
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ConfigurarAutoSave" },
+                { "Component", "AutoAvaliacaoCompetencia" }
+            });
+        }
+    }
+
+    private async Task ConfigurarScripts()
+    {
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("initializeBootstrapComponents");
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ConfigurarScripts" },
+                { "Component", "AutoAvaliacaoCompetencia" }
+            });
+        }
+    }
+
+    [JSInvokable]
+    public async Task AutoSave()
+    {
+        if (!IsProcessing && AvaliacaoData != null)
+        {
+            try
+            {
+                await SalvarAvaliacao();
+                TelemetryService.TrackEvent("AutoAvaliacaoCompetencia_AutoSaved", new Dictionary<string, string>
+                {
+                    { "IdAvaliacao", AvaliacaoData.IdAvaliacao.ToString() }
+                });
+            }
+            catch (Exception ex)
+            {
+                TelemetryService.TrackException(ex, new Dictionary<string, string>
+                {
+                    { "Method", "AutoSave" },
+                    { "Component", "AutoAvaliacaoCompetencia" }
+                });
+            }
+        }
+    }
+
+    private string TruncarTexto(string? texto, int qtdCaracteres)
+    {
+        if (string.IsNullOrEmpty(texto))
+            return string.Empty;
+
+        if (texto.Length > qtdCaracteres)
+        {
+            return $"{texto.Substring(0, qtdCaracteres)}...";
+        }
+
+        return texto;
+    }
+
+    public void Dispose()
+    {
+        objRef?.Dispose();
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -39,6 +39,8 @@ using Peers.Moderno.Services.Projetos.Common;
 using Peers.Moderno.Services.SubCompetencias;
 using Peers.Moderno.Services.SubCompetencias.Common;
 using Peers.Moderno.Services.Common.Avaliacoes;
+using Peers.Moderno.Services.AutoAvaliacao;
+using Peers.Moderno.Services.AutoAvaliacao.Common;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.AI;
@@ -223,6 +225,9 @@ builder.Services.AddScoped<IWorkflowUtils, WorkflowUtils>();
 
 // AutoAvaliacao Services - Novos serviços para migração de Web Forms
 builder.Services.AddScoped<IAutoAvaliacaoService, AutoAvaliacaoService>();
+
+// AutoAvaliacao Common Services - Novos serviços para migração de Web Forms
+builder.Services.AddScoped<IAutoAvaliacaoValidator, AutoAvaliacaoValidator>();
 
 // AI Services for AutoAvaliacao - Preparação para integração futura
 builder.Services.AddScoped<IAvaliacaoIAService, AvaliacaoIAService>();

--- a/wwwroot/js/autoavaliacao.js
+++ b/wwwroot/js/autoavaliacao.js
@@ -1,0 +1,195 @@
+// AutoAvaliacao JavaScript Functions
+
+// Configuração do auto-save
+window.configureAutoSave = (dotNetHelper) => {
+    if (dotNetHelper) {
+        // Auto-save a cada 15 minutos (900000 ms)
+        setInterval(() => {
+            try {
+                dotNetHelper.invokeMethodAsync('AutoSave');
+            } catch (error) {
+                console.error('Erro no auto-save:', error);
+            }
+        }, 900000);
+    }
+};
+
+// Inicialização dos componentes Bootstrap
+window.initializeBootstrapComponents = () => {
+    try {
+        // Inicializar tooltips
+        if (typeof $ !== 'undefined' && $.fn.tooltip) {
+            $('[data-toggle="tooltip"]').tooltip();
+        }
+
+        // Inicializar popovers
+        if (typeof $ !== 'undefined' && $.fn.popover) {
+            $('[data-toggle="popover"]').popover();
+        }
+
+        // Inicializar select2 se disponível
+        if (typeof $ !== 'undefined' && $.fn.select2) {
+            $('.select2').select2({
+                theme: 'bootstrap4',
+                width: '100%'
+            });
+        }
+
+        // Configurar accordions
+        $('.accordion-toggle').on('click', function(e) {
+            e.preventDefault();
+            const target = $(this).attr('data-target') || $(this).attr('href');
+            if (target) {
+                $(target).collapse('toggle');
+            }
+        });
+
+    } catch (error) {
+        console.error('Erro ao inicializar componentes Bootstrap:', error);
+    }
+};
+
+// Função para mostrar mensagens usando SweetAlert
+window.showMessage = (type, message, duration = 5000) => {
+    if (typeof swal !== 'undefined') {
+        swal({
+            title: "ATENÇÃO!",
+            text: message,
+            icon: type,
+            timer: duration,
+            button: "Ok",
+        });
+    } else {
+        // Fallback para alert nativo
+        alert(message);
+    }
+};
+
+// Função para truncar texto
+window.truncateText = (text, maxLength) => {
+    if (!text || text.length <= maxLength) {
+        return text;
+    }
+    return text.substring(0, maxLength) + '...';
+};
+
+// Função para validar formulário
+window.validateForm = (formSelector) => {
+    try {
+        const form = document.querySelector(formSelector);
+        if (!form) return false;
+
+        const requiredFields = form.querySelectorAll('[required]');
+        let isValid = true;
+
+        requiredFields.forEach(field => {
+            if (!field.value.trim()) {
+                field.classList.add('is-invalid');
+                isValid = false;
+            } else {
+                field.classList.remove('is-invalid');
+            }
+        });
+
+        return isValid;
+    } catch (error) {
+        console.error('Erro na validação do formulário:', error);
+        return false;
+    }
+};
+
+// Função para destacar campos com erro
+window.highlightErrorFields = (fieldIds, errorClass = 'is-invalid') => {
+    try {
+        fieldIds.forEach(fieldId => {
+            const field = document.getElementById(fieldId);
+            if (field) {
+                field.classList.add(errorClass);
+            }
+        });
+    } catch (error) {
+        console.error('Erro ao destacar campos com erro:', error);
+    }
+};
+
+// Função para remover destaque de erro
+window.clearErrorHighlight = (fieldIds, errorClass = 'is-invalid') => {
+    try {
+        fieldIds.forEach(fieldId => {
+            const field = document.getElementById(fieldId);
+            if (field) {
+                field.classList.remove(errorClass);
+            }
+        });
+    } catch (error) {
+        console.error('Erro ao remover destaque de erro:', error);
+    }
+};
+
+// Função para scroll suave até elemento
+window.scrollToElement = (elementId, offset = 0) => {
+    try {
+        const element = document.getElementById(elementId);
+        if (element) {
+            const elementPosition = element.offsetTop - offset;
+            window.scrollTo({
+                top: elementPosition,
+                behavior: 'smooth'
+            });
+        }
+    } catch (error) {
+        console.error('Erro no scroll:', error);
+    }
+};
+
+// Função para confirmar ação
+window.confirmAction = (message, callback) => {
+    if (typeof swal !== 'undefined') {
+        swal({
+            title: "Confirmação",
+            text: message,
+            icon: "warning",
+            buttons: ["Cancelar", "Confirmar"],
+            dangerMode: true,
+        })
+        .then((willProceed) => {
+            if (willProceed && callback) {
+                callback();
+            }
+        });
+    } else {
+        // Fallback para confirm nativo
+        if (confirm(message) && callback) {
+            callback();
+        }
+    }
+};
+
+// Inicialização quando o DOM estiver carregado
+document.addEventListener('DOMContentLoaded', function() {
+    // Inicializar componentes Bootstrap
+    initializeBootstrapComponents();
+
+    // Configurar eventos globais
+    document.addEventListener('click', function(e) {
+        // Fechar dropdowns ao clicar fora
+        if (!e.target.closest('.dropdown')) {
+            const dropdowns = document.querySelectorAll('.dropdown-menu.show');
+            dropdowns.forEach(dropdown => {
+                dropdown.classList.remove('show');
+            });
+        }
+    });
+
+    // Configurar teclas de atalho
+    document.addEventListener('keydown', function(e) {
+        // Ctrl+S para salvar
+        if (e.ctrlKey && e.key === 's') {
+            e.preventDefault();
+            const saveButton = document.querySelector('[data-action="save"]');
+            if (saveButton && !saveButton.disabled) {
+                saveButton.click();
+            }
+        }
+    });
+});


### PR DESCRIPTION
Este PR implementa o componente Blazor para autoavaliação de competências, separa a lógica de apresentação e negócio, integra com serviços reutilizáveis centralizados em Services/Common, registra as dependências no Program.cs e adiciona um arquivo JavaScript para suporte à interface. Também cria uma documentação detalhada em docs/ explicando a integração, arquitetura e fluxo de alto nível usando mermaid. Todas as pastas seguem o padrão de organização para facilitar a reutilização futura.