### PR TITLE
Componentização e centralização de serviços reutilizáveis para AutoAvaliacao

### DIFF
--- a/Components/AutoAvaliacao/AutoAvaliacaoCompetencia.razor
+++ b/Components/AutoAvaliacao/AutoAvaliacaoCompetencia.razor
@@ -1,0 +1,413 @@
+@page "/autoavaliacao-competencia"
+@using Peers.Moderno.Services.AutoAvaliacao
+@using Peers.Moderno.Services.AutoAvaliacao.Common
+@using Peers.Moderno.Services.Common
+@using Peers.Moderno.Models.AutoAvaliacao
+@inject IAutoAvaliacaoService AutoAvaliacaoService
+@inject IValidationHelper ValidationHelper
+@inject IMessageBoxService MessageBoxService
+@inject NavigationManager Navigation
+@inject IConfiguration Configuration
+
+<PageTitle>Auto Avaliação - Competência</PageTitle>
+
+<MessageBox @ref="messageBox" />
+
+<!-- Breadcrumb -->
+<div class="page-breadcrumb border-bottom" style="position:fixed;z-index:1;width:100%">
+    <div class="row">
+        <div class="col-lg-3 col-md-4 col-xs-12 align-self-center">
+            <h5 class="font-medium text-uppercase mb-0">Auto Avaliação</h5>
+        </div>
+        <div class="col-lg-9 col-md-8 col-xs-12 align-self-center">
+            <nav aria-label="breadcrumb" class="mt-2 float-md-right float-left">
+                <ol class="breadcrumb mb-0 justify-content-end p-0">
+                    <li class="breadcrumb-item"><a href="/">Peers</a></li>
+                    <li class="breadcrumb-item"><a href="/">Avaliação / Auto Avaliação</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">Competência</li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+</div>
+
+<!-- Container Principal -->
+<div style="overflow:initial !important" class="page-content container-fluid">
+    
+    <!-- Card Título -->
+    <div class="card col-md-10" style="position:fixed;z-index:1; margin-top:21px;border-color:rgba(0, 0, 0, .25);border-width:1px">
+        <div class="card-body">
+            
+            <!-- Detalhes da Avaliação -->
+            <div class="accordion" id="accordionDetalhes">
+                <div class="card">
+                    <div class="card-header" id="headingDetalhes">
+                        <h5 class="mb-0">
+                            <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#Detalhes" aria-expanded="true" aria-controls="Detalhes">
+                                Detalhes da avaliação
+                                <i class="fa fa-angle-right"></i>
+                            </button>
+                        </h5>
+                    </div>
+                    <div id="Detalhes" class="collapse" aria-labelledby="headingDetalhes" data-parent="#accordionDetalhes">
+                        <div class="col-md-5">
+                            <div class="text-left">
+                                <button type="button" class="btn btn-facebook" disabled>Competência</button>
+                                <button class="btn btn-danger" @onclick="IrParaPerformance">Performance</button>
+                                <button class="btn btn-info" @onclick="IrParaFinalizacao">Ir para Finalização</button>
+                                <p></p>
+                            </div>
+                        </div>
+                        <div class="col-sm">
+                            <div class="row">
+                                <div class="col-md-2"><label><b>Avaliado</b></label></div>
+                                <div class="col-md-4"><label>@avaliacaoData?.NomeAssociado</label></div>
+                                <div class="col-md-2"><label><b>Período</b></label></div>
+                                <div class="col-md-4"><label>@avaliacaoData?.Periodo</label></div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-2"><label><b>Tempo de Cargo:</b></label></div>
+                                <div class="col-md-4"><label>@avaliacaoData?.TempoCargo</label></div>
+                                <div class="col-md-2"><label><b>Tempo de Peers</b></label></div>
+                                <div class="col-md-4"><label>@avaliacaoData?.TempoPeers</label></div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-1"><label><b>Projeto</b></label></div>
+                                <div class="col-md-3"><label>@avaliacaoData?.NomeProjeto</label></div>
+                                <div class="col-md-1"><label><b>Cliente</b></label></div>
+                                <div class="col-md-3"><label>@avaliacaoData?.NomeCliente</label></div>
+                                <div class="col-md-2"><label><b>Tempo restante</b></label></div>
+                                <div class="col-md-2"><label>@avaliacaoData?.TempoRestante</label></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Descrições Nível Atual e Próximo -->
+            <div class="accordion" id="accordionCabecalho">
+                <div class="card">
+                    <div class="card-header" id="headingCabecalho">
+                        <h5 class="mb-0">
+                            <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#Cabecalho" aria-expanded="true" aria-controls="Cabecalho">
+                                Descrições nível atual e próximo nível
+                                <i class="fa fa-angle-right"></i>
+                            </button>
+                        </h5>
+                    </div>
+                    <div id="Cabecalho" class="collapse" aria-labelledby="headingCabecalho" data-parent="#accordionCabecalho">
+                        @if (cabecalhoData != null)
+                        {
+                            <table class="table table-striped border" style="width:100%;table-layout:fixed">
+                                <thead>
+                                    <tr>
+                                        <th colspan="1"></th>
+                                        <th colspan="2">Cargo</th>
+                                        <th colspan="2">Função</th>
+                                        <th colspan="2">Autonomia</th>
+                                        <th colspan="2">Escopo de Atuação</th>
+                                        <th colspan="2">Nível de interlocução principal no cliente</th>
+                                        @foreach (var titulo in cabecalhoData.TitulosCompetencias)
+                                        {
+                                            <th colspan="2">@titulo</th>
+                                        }
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td colspan="1">Nível atual</td>
+                                        <td colspan="2">@cabecalhoData.CargoAtual</td>
+                                        <td colspan="2">@cabecalhoData.FuncaoAtual</td>
+                                        <td colspan="2">@cabecalhoData.AutonomiaAtual</td>
+                                        <td colspan="2">@cabecalhoData.EscopoAtual</td>
+                                        <td colspan="2">@cabecalhoData.InterlocucaoAtual</td>
+                                        @foreach (var desc in cabecalhoData.DescricoesCompetenciasAtual)
+                                        {
+                                            <th colspan="2" style="font-weight:normal;">@desc</th>
+                                        }
+                                    </tr>
+                                    <tr>
+                                        <td colspan="1">Próximo nível</td>
+                                        <td colspan="2">@cabecalhoData.CargoProximo</td>
+                                        <td colspan="2">@cabecalhoData.FuncaoProximo</td>
+                                        <td colspan="2">@cabecalhoData.AutonomiaProximo</td>
+                                        <td colspan="2">@cabecalhoData.EscopoProximo</td>
+                                        <td colspan="2">@cabecalhoData.InterlocucaoProximo</td>
+                                        @foreach (var desc in cabecalhoData.DescricoesCompetenciasProximo)
+                                        {
+                                            <th colspan="2" style="font-weight:normal;">@desc</th>
+                                        }
+                                    </tr>
+                                </tbody>
+                            </table>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Card Competências -->
+    <div class="card col-md-12" style="margin-top:220px">
+        <div class="card-body">
+            
+            <!-- Botão Salvar Superior -->
+            <div class="form-body">
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="text-right">
+                            <button class="btn btn-dark" @onclick="SalvarAvaliacao" disabled="@(!podeEditar)">Salvar Avaliação</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Tabela de Competências -->
+            <CompetenciaTable @ref="competenciaTable" 
+                             Competencias="@competencias" 
+                             PodeEditar="@podeEditar"
+                             OnCompetenciaChanged="OnCompetenciaChanged" />
+
+            <!-- Botão Salvar Inferior -->
+            <div class="form-body">
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="text-right">
+                            <button class="btn btn-dark" @onclick="SalvarAvaliacao" disabled="@(!podeEditar)">Salvar Avaliação</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Botões Adicionais -->
+        <div class="card">
+            <div class="card-body">
+                <div class="col-md-5">
+                    <div class="text-left">
+                        <button type="button" class="btn btn-facebook" disabled>Competência</button>
+                        <button class="btn btn-danger" @onclick="IrParaPerformance">Performance</button>
+                        <button class="btn btn-info" @onclick="IrParaFinalizacao">Ir para Finalização</button>
+                        <p></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Auto-save Script -->
+<script>
+    window.autoSaveInterval = null;
+    
+    window.startAutoSave = (dotNetRef) => {
+        if (window.autoSaveInterval) {
+            clearInterval(window.autoSaveInterval);
+        }
+        
+        window.autoSaveInterval = setInterval(() => {
+            dotNetRef.invokeMethodAsync('AutoSave');
+        }, 900000); // 15 minutos
+    };
+    
+    window.stopAutoSave = () => {
+        if (window.autoSaveInterval) {
+            clearInterval(window.autoSaveInterval);
+            window.autoSaveInterval = null;
+        }
+    };
+</script>
+
+@code {
+    [Parameter, SupplyParameterFromQuery] public int? IdProjeto { get; set; }
+    [Parameter, SupplyParameterFromQuery] public int? IdAssociado { get; set; }
+    [Parameter, SupplyParameterFromQuery] public int? IdPeriodo { get; set; }
+    [Parameter, SupplyParameterFromQuery] public string? TipoAvaliacao { get; set; }
+    [Parameter, SupplyParameterFromQuery] public string? Escopo { get; set; }
+    [Parameter, SupplyParameterFromQuery] public int? IdGestor { get; set; }
+
+    private MessageBox messageBox = default!;
+    private CompetenciaTable competenciaTable = default!;
+    private DotNetObjectReference<AutoAvaliacaoCompetencia>? dotNetRef;
+
+    private AvaliacaoDataModel? avaliacaoData;
+    private CabecalhoDataModel? cabecalhoData;
+    private List<CompetenciaAvaliacaoModel> competencias = new();
+    private bool podeEditar = true;
+    private bool isLoading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        dotNetRef = DotNetObjectReference.Create(this);
+        await CarregarDados();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && podeEditar)
+        {
+            await InvokeAsync(async () =>
+            {
+                await Task.Delay(1000);
+                await JSRuntime.InvokeVoidAsync("startAutoSave", dotNetRef);
+            });
+        }
+    }
+
+    private async Task CarregarDados()
+    {
+        try
+        {
+            isLoading = true;
+            StateHasChanged();
+
+            var parametros = new AvaliacaoParametrosModel
+            {
+                IdProjeto = IdProjeto,
+                IdAssociado = IdAssociado,
+                IdPeriodo = IdPeriodo,
+                TipoAvaliacao = TipoAvaliacao,
+                Escopo = Escopo,
+                IdGestor = IdGestor
+            };
+
+            var resultado = await AutoAvaliacaoService.CarregarDadosAvaliacaoAsync(parametros);
+            
+            if (resultado.Sucesso)
+            {
+                avaliacaoData = resultado.AvaliacaoData;
+                cabecalhoData = resultado.CabecalhoData;
+                competencias = resultado.Competencias;
+                podeEditar = resultado.PodeEditar;
+            }
+            else
+            {
+                messageBox.Show(resultado.MensagemErro, MessageBoxType.Error);
+                if (resultado.DeveRedirecionarParaIndex)
+                {
+                    Navigation.NavigateTo("/");
+                    return;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            messageBox.Show("Erro interno ao carregar dados da avaliação.", MessageBoxType.Error);
+        }
+        finally
+        {
+            isLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task SalvarAvaliacao()
+    {
+        try
+        {
+            if (!await ValidarAvaliacao())
+                return;
+
+            var resultado = await AutoAvaliacaoService.SalvarAvaliacaoAsync(competencias, false);
+            
+            if (resultado.Sucesso)
+            {
+                messageBox.Show("Avaliação Salva com Sucesso.", MessageBoxType.Success);
+            }
+            else
+            {
+                messageBox.Show(resultado.MensagemErro, MessageBoxType.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            messageBox.Show("Erro interno ao salvar avaliação.", MessageBoxType.Error);
+        }
+    }
+
+    [JSInvokable]
+    public async Task AutoSave()
+    {
+        if (podeEditar && competencias.Any())
+        {
+            try
+            {
+                await AutoAvaliacaoService.SalvarAvaliacaoAsync(competencias, false);
+                messageBox.Show("SALVANDO!!", MessageBoxType.Info, "ATENÇÃO!");
+            }
+            catch
+            {
+                // Falha silenciosa no auto-save
+            }
+        }
+    }
+
+    private async Task<bool> ValidarAvaliacao()
+    {
+        try
+        {
+            var resultado = await ValidationHelper.ValidarAvaliacaoCompetenciasAsync(competencias);
+            
+            if (!resultado.IsValid)
+            {
+                messageBox.Show(resultado.ErrorMessage, MessageBoxType.Error);
+                
+                // Destacar campos com erro
+                if (competenciaTable != null)
+                {
+                    await competenciaTable.HighlightErrors(resultado.CompetenciasComErro);
+                }
+                
+                return false;
+            }
+            
+            return true;
+        }
+        catch (Exception ex)
+        {
+            messageBox.Show("Erro interno na validação.", MessageBoxType.Error);
+            return false;
+        }
+    }
+
+    private void OnCompetenciaChanged(CompetenciaAvaliacaoModel competencia)
+    {
+        var index = competencias.FindIndex(c => c.IdCompetencia == competencia.IdCompetencia);
+        if (index >= 0)
+        {
+            competencias[index] = competencia;
+        }
+    }
+
+    private async Task IrParaPerformance()
+    {
+        if (await ValidarAvaliacao())
+        {
+            await SalvarAvaliacao();
+            Navigation.NavigateTo("/autoavaliacao-performance");
+        }
+    }
+
+    private async Task IrParaFinalizacao()
+    {
+        if (await ValidarAvaliacao())
+        {
+            await SalvarAvaliacao();
+            var baseUrl = "/autoavaliacao";
+            var queryParams = new List<string>();
+            
+            if (IdProjeto.HasValue) queryParams.Add($"IdProjeto={IdProjeto}");
+            if (IdAssociado.HasValue) queryParams.Add($"IdAssociado={IdAssociado}");
+            if (IdPeriodo.HasValue) queryParams.Add($"IdPeriodo={IdPeriodo}");
+            
+            var url = queryParams.Any() ? $"{baseUrl}?{string.Join("&", queryParams)}" : baseUrl;
+            Navigation.NavigateTo(url);
+        }
+    }
+
+    public void Dispose()
+    {
+        dotNetRef?.Dispose();
+        InvokeAsync(async () => await JSRuntime.InvokeVoidAsync("stopAutoSave"));
+    }
+}

--- a/Components/AutoAvaliacao/MessageBox.razor
+++ b/Components/AutoAvaliacao/MessageBox.razor
@@ -1,0 +1,108 @@
+@using Peers.Moderno.Services.Common
+@inject IMessageBoxService MessageBoxService
+@implements IDisposable
+
+@if (IsVisible)
+{
+    <div class="alert @GetAlertClass() alert-dismissible fade show" role="alert">
+        <div class="d-flex align-items-center">
+            <i class="@GetIconClass() me-2"></i>
+            <div class="flex-grow-1">
+                <strong>@Title</strong>
+                @if (!string.IsNullOrEmpty(Message))
+                {
+                    <div class="mt-1">
+                        @((MarkupString)Message)
+                    </div>
+                }
+            </div>
+        </div>
+        <button type="button" class="btn-close" @onclick="Hide" aria-label="Close"></button>
+    </div>
+}
+
+@code {
+    [Parameter] public string Title { get; set; } = "ATENÇÃO!";
+    [Parameter] public string Message { get; set; } = string.Empty;
+    [Parameter] public MessageBoxType Type { get; set; } = MessageBoxType.Info;
+    [Parameter] public bool IsVisible { get; set; } = false;
+    [Parameter] public int AutoHideDelay { get; set; } = 0;
+    [Parameter] public EventCallback OnHidden { get; set; }
+
+    private Timer? _autoHideTimer;
+
+    protected override void OnInitialized()
+    {
+        MessageBoxService.OnMessageReceived += HandleMessage;
+    }
+
+    private void HandleMessage(MessageBoxEventArgs args)
+    {
+        Message = args.Message;
+        Type = args.Type;
+        Show();
+    }
+
+    public void Show()
+    {
+        IsVisible = true;
+        StateHasChanged();
+
+        if (AutoHideDelay > 0)
+        {
+            _autoHideTimer?.Dispose();
+            _autoHideTimer = new Timer(async _ => await HideWithCallback(), null, AutoHideDelay, Timeout.Infinite);
+        }
+    }
+
+    public void Show(string message, MessageBoxType type = MessageBoxType.Info, string title = "ATENÇÃO!")
+    {
+        Message = message;
+        Type = type;
+        Title = title;
+        Show();
+    }
+
+    public void Hide()
+    {
+        IsVisible = false;
+        _autoHideTimer?.Dispose();
+        StateHasChanged();
+    }
+
+    private async Task HideWithCallback()
+    {
+        Hide();
+        await OnHidden.InvokeAsync();
+    }
+
+    private string GetAlertClass()
+    {
+        return Type switch
+        {
+            MessageBoxType.Success => "alert-success",
+            MessageBoxType.Error => "alert-danger",
+            MessageBoxType.Warning => "alert-warning",
+            MessageBoxType.Info => "alert-info",
+            _ => "alert-info"
+        };
+    }
+
+    private string GetIconClass()
+    {
+        return Type switch
+        {
+            MessageBoxType.Success => "fas fa-check-circle text-success",
+            MessageBoxType.Error => "fas fa-exclamation-triangle text-danger",
+            MessageBoxType.Warning => "fas fa-exclamation-triangle text-warning",
+            MessageBoxType.Info => "fas fa-info-circle text-info",
+            _ => "fas fa-info-circle text-info"
+        };
+    }
+
+    public void Dispose()
+    {
+        MessageBoxService.OnMessageReceived -= HandleMessage;
+        _autoHideTimer?.Dispose();
+    }
+}

--- a/Components/AutoAvaliacao/NotaSelect.razor
+++ b/Components/AutoAvaliacao/NotaSelect.razor
@@ -1,0 +1,105 @@
+@using Peers.Moderno.Services.Common
+@using Peers.Moderno.Services.AutoAvaliacao.Common
+@inject INotaHelper NotaHelper
+
+<div class="@CssClass">
+    @if (IsReadOnly)
+    {
+        <label class="form-control p-0" style="width: 100%; height: 100%; background-color:#E9ECEF">
+            @SelectedText
+        </label>
+    }
+    else
+    {
+        <select @bind="SelectedValue" @onchange="OnValueChanged" class="form-control p-0 select2" style="width: 100%" disabled="@IsDisabled">
+            @if (ShowDefaultOption)
+            {
+                <option value="0" disabled>@DefaultOptionText</option>
+            }
+            @foreach (var nota in Notas)
+            {
+                <option value="@nota.IdNota">@nota.CodigoNota</option>
+            }
+        </select>
+    }
+</div>
+
+@code {
+    [Parameter] public int SelectedValue { get; set; }
+    [Parameter] public EventCallback<int> SelectedValueChanged { get; set; }
+    [Parameter] public bool IsDisabled { get; set; }
+    [Parameter] public bool IsReadOnly { get; set; }
+    [Parameter] public string SelectedText { get; set; } = string.Empty;
+    [Parameter] public string CssClass { get; set; } = string.Empty;
+    [Parameter] public bool ShowDefaultOption { get; set; } = true;
+    [Parameter] public string DefaultOptionText { get; set; } = "[Selecionar]";
+    [Parameter] public bool EnableAllOptions { get; set; } = false;
+    [Parameter] public EventCallback<int> OnSelectionChanged { get; set; }
+
+    private List<NotaModel> Notas { get; set; } = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadNotas();
+    }
+
+    private async Task LoadNotas()
+    {
+        try
+        {
+            Notas = await NotaHelper.ObterNotasCompetenciasAsync(false, EnableAllOptions);
+        }
+        catch (Exception ex)
+        {
+            Notas = new List<NotaModel>();
+        }
+    }
+
+    private async Task OnValueChanged(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out int newValue))
+        {
+            SelectedValue = newValue;
+            await SelectedValueChanged.InvokeAsync(SelectedValue);
+            await OnSelectionChanged.InvokeAsync(SelectedValue);
+        }
+    }
+
+    public async Task RefreshNotas(bool enableAllOptions)
+    {
+        EnableAllOptions = enableAllOptions;
+        await LoadNotas();
+        StateHasChanged();
+    }
+
+    public void SetReadOnly(bool isReadOnly, string selectedText = "")
+    {
+        IsReadOnly = isReadOnly;
+        SelectedText = selectedText;
+        StateHasChanged();
+    }
+
+    public void SetDisabled(bool isDisabled)
+    {
+        IsDisabled = isDisabled;
+        StateHasChanged();
+    }
+
+    public void RemoveDefaultOption()
+    {
+        ShowDefaultOption = false;
+        StateHasChanged();
+    }
+
+    public void SetBackgroundColor(string color)
+    {
+        CssClass = $"background-color: {color}";
+        StateHasChanged();
+    }
+
+    public void ClearBackgroundColor()
+    {
+        CssClass = string.Empty;
+        StateHasChanged();
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -39,6 +39,8 @@ using Peers.Moderno.Services.Projetos.Common;
 using Peers.Moderno.Services.SubCompetencias;
 using Peers.Moderno.Services.SubCompetencias.Common;
 using Peers.Moderno.Services.Common.Avaliacoes;
+using Peers.Moderno.Services.AutoAvaliacao;
+using Peers.Moderno.Services.AutoAvaliacao.Common;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.AI;
@@ -223,6 +225,11 @@ builder.Services.AddScoped<IWorkflowUtils, WorkflowUtils>();
 
 // AutoAvaliacao Services - Novos serviços para migração de Web Forms
 builder.Services.AddScoped<IAutoAvaliacaoService, AutoAvaliacaoService>();
+
+// AutoAvaliacao Common Services - Novos serviços reutilizáveis (passo 12)
+builder.Services.AddScoped<INotaHelper, NotaHelper>();
+builder.Services.AddScoped<IValidationHelper, ValidationHelper>();
+builder.Services.AddScoped<IAccordionHelper, AccordionHelper>();
 
 // AI Services for AutoAvaliacao - Preparação para integração futura
 builder.Services.AddScoped<IAvaliacaoIAService, AvaliacaoIAService>();

--- a/appsettings.json
+++ b/appsettings.json
@@ -35,17 +35,39 @@
     "RequireAllCompetenciasPreenchidas": true,
     "RequireAllPerformancesPreenchidas": true,
     "EnableNotificacaoFinalizacao": true,
+    "AutoSaveIntervalMinutes": 15,
+    "EnableAutoSave": true,
+    "MaxCompetenciaLength": 70,
+    "ShowVerMaisTexto": true,
+    "VerMaisTexto": "Ver+",
     "ValidationMessages": {
-      "ProjetoObrigatorio": "Selecione o projeto",
-      "PeriodoObrigatorio": "Selecione o período",
+      "ProjetoObrigatorio": "É obrigatório a seleção de um Projeto.",
+      "AssociadoObrigatorio": "É obrigatório a seleção de um Associado.",
+      "PeriodoObrigatorio": "É obrigatório a seleção de um Período.",
+      "GestorObrigatorio": "É obrigatório a seleção de um Gestor.",
+      "TipoAvaliacaoObrigatorio": "É obrigatório a seleção de um tipo de avaliação.",
+      "EscopoObrigatorio": "É obrigatório a seleção de um escopo.",
       "CompetenciasNaoPreenchidas": "É obrigatório digitar todas as notas da Avaliação Competência antes de finalizar a Avaliação",
       "PerformancesNaoPreenchidas": "É obrigatório digitar todas as notas da Avaliação Performance antes de finalizar a Avaliação",
       "CompetenciasNaoParametrizadas": "Não existem Competências parametrizadas para este cargo. Não é possível dar andamento na avaliação !!",
       "PerformancesNaoParametrizadas": "Não existem Performances parametrizadas para este cargo ou você ainda não iniciou o preenchimento das Performances. Não é possível dar andamento na avaliação !!",
+      "NotasInconsistentes": "Existem Avaliações de Competências inconsistentes. A nota do nível 2 (próximo nível) não pode ser maior que a nota do nível 1 (nível atual).",
+      "NotaNaoSeAplicaInconsistente": "ATENÇÃO ! Avaliação de Competência com inconsistência. (Detalhe: quando a nota de Competência do Nivel Atual for = Não Se Aplica, o Próximo Nivel deve ser Não Se Aplica). O Sistema ajustou sua avaliação. Favor revalidar sua avaliação !!",
+      "NotasObrigatorias": "É obrigatório selecionar uma nota para cada nível.",
+      "PilarVazio": "Cada pilar precisa receber ao mínimo 1 nota mensurável em cada nível (diferente de não se aplica)",
       "SucessoFinalizacao": "Avaliação Finalizada com Sucesso",
       "ErroFinalizacao": "Erro ao finalizar avaliação",
+      "SucessoSalvamento": "Avaliação Salva com Sucesso.",
+      "ErroSalvamento": "Falha ao Incluir Competência da Avaliação.",
       "AvaliacaoNaoEncontrada": "Avaliação não encontrada",
-      "PermissaoNegada": "Você não tem permissão para esta operação"
+      "PermissaoNegada": "Você não tem permissão para esta operação",
+      "ErroInterno": "Erro interno do sistema",
+      "ProjetoNaoEncontrado": "Projeto Não Encontrado",
+      "AssociadoNaoEncontrado": "Associado Não Encontrado",
+      "PeriodoNaoEncontrado": "Período Não Encontrado",
+      "GestorNaoEncontrado": "Gestor Não Encontrado",
+      "TipoAvaliacaoNaoEncontrado": "Tipo de avaliação Não Encontrado",
+      "EscopoNaoEncontrado": "Escopo Não Encontrado"
     },
     "StatusOptions": {
       "NaoIniciado": "Não iniciado",
@@ -62,6 +84,29 @@
       "AvaliacaoMentor": "Em Cons. Mentor",
       "Finalizada": "Finalizada"
     },
+    "NotasPadrao": {
+      "IdNotaNaoSeAplica": 5,
+      "IdNotaSelecionar": 0
+    },
+    "ComponenteConfig": {
+      "MessageBox": {
+        "DefaultTitle": "ATENÇÃO!",
+        "AutoHideDelay": 5000,
+        "ShowCloseButton": true
+      },
+      "NotaSelect": {
+        "DefaultOptionText": "[Selecionar]",
+        "ShowDefaultOption": true,
+        "EnableAllOptionsWhenFinalized": true
+      },
+      "CompetenciaTable": {
+        "EnableAccordions": true,
+        "TruncateTextLength": 70,
+        "ShowExpandButton": true,
+        "ExpandButtonText": "Ver+",
+        "EnableStickyHeaders": true
+      }
+    },
     "Features": {
       "EnableAuditLog": true,
       "EnableNotifications": true,
@@ -69,7 +114,10 @@
       "EnableIntegrations": false,
       "EnableBulkOperations": false,
       "EnableAdvancedSearch": true,
-      "EnableAIIntegration": false
+      "EnableAIIntegration": false,
+      "EnableAutoSave": true,
+      "EnableRealTimeValidation": true,
+      "EnableProgressTracking": true
     }
   },
   "SubCompetencias": {
@@ -439,7 +487,8 @@
       "Peers.Moderno.Services.Premissas": "Debug",
       "Peers.Moderno.Services.Projetos": "Debug",
       "Peers.Moderno.Services.SubCompetencias": "Debug",
-      "Peers.Moderno.Services.Avaliacoes": "Debug"
+      "Peers.Moderno.Services.Avaliacoes": "Debug",
+      "Peers.Moderno.Services.AutoAvaliacao": "Debug"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
Este PR cria componentes Blazor reutilizáveis para a autoavaliação de competências (NotaSelect, MessageBox, AutoAvaliacaoCompetencia), centraliza serviços auxiliares em Services/Common e Services/AutoAvaliacao/Common, atualiza configurações no appsettings.json e registra os serviços no Program.cs. Segue a premissa de criar pastas 'Common' para todo código potencialmente reutilizável e prepara o sistema para reuso e manutenção facilitada. Inclui documentação detalhada em docs/ explicando o funcionamento, integração e fluxo de alto nível dos novos componentes e serviços.