### PR TITLE
Criação de helpers reutilizáveis para AutoAvaliacao (Notas, Validações e Accordions) + documentação técnica

### DIFF
--- a/Services/AutoAvaliacao/Common/AccordionHelper.cs
+++ b/Services/AutoAvaliacao/Common/AccordionHelper.cs
@@ -1,0 +1,181 @@
+using Peers.Moderno.Services.Common;
+
+namespace Peers.Moderno.Services.AutoAvaliacao.Common;
+
+public interface IAccordionHelper
+{
+    string TruncarTexto(string texto, int maxLength);
+    string GerarIdAccordion(string prefixo, int id);
+    string GerarLinkAccordion(string texto, string targetId, int maxLength);
+    AccordionConfig GetAccordionConfig();
+    bool ShouldShowExpandButton(string texto, int maxLength);
+    string GetExpandButtonText();
+    string FormatarTextoCompleto(string prefixo, string texto);
+    AccordionItem CriarAccordionItem(string id, string titulo, string conteudo, bool isExpanded = false);
+    List<AccordionItem> CriarAccordionsPerformance(int idPerformance, string abaixo, string esperado, string acima);
+}
+
+public class AccordionHelper : IAccordionHelper
+{
+    private readonly IConfiguration _configuration;
+    private readonly ITelemetryService _telemetryService;
+
+    public AccordionHelper(IConfiguration configuration, ITelemetryService telemetryService)
+    {
+        _configuration = configuration;
+        _telemetryService = telemetryService;
+    }
+
+    public string TruncarTexto(string texto, int maxLength)
+    {
+        if (string.IsNullOrEmpty(texto))
+            return string.Empty;
+
+        if (texto.Length <= maxLength)
+            return texto;
+
+        return texto.Substring(0, maxLength) + "...";
+    }
+
+    public string GerarIdAccordion(string prefixo, int id)
+    {
+        return $"{prefixo}_{id}";
+    }
+
+    public string GerarLinkAccordion(string texto, string targetId, int maxLength)
+    {
+        var textoTruncado = TruncarTexto(texto, maxLength);
+        var showExpandButton = ShouldShowExpandButton(texto, maxLength);
+        
+        if (showExpandButton)
+        {
+            return $"{textoTruncado} <span style='font-weight:bold'>{GetExpandButtonText()}</span>";
+        }
+        
+        return textoTruncado;
+    }
+
+    public AccordionConfig GetAccordionConfig()
+    {
+        return new AccordionConfig
+        {
+            MaxTextLength = _configuration.GetValue("AutoAvaliacao:MaxCompetenciaLength", 70),
+            ShowExpandButton = _configuration.GetValue("AutoAvaliacao:ShowVerMaisTexto", true),
+            ExpandButtonText = _configuration.GetValue("AutoAvaliacao:VerMaisTexto", "Ver+"),
+            EnableAccordions = _configuration.GetValue("AutoAvaliacao:ComponenteConfig:CompetenciaTable:EnableAccordions", true),
+            EnableStickyHeaders = _configuration.GetValue("AutoAvaliacao:ComponenteConfig:CompetenciaTable:EnableStickyHeaders", true)
+        };
+    }
+
+    public bool ShouldShowExpandButton(string texto, int maxLength)
+    {
+        if (string.IsNullOrEmpty(texto))
+            return false;
+            
+        return texto.Length > maxLength && GetAccordionConfig().ShowExpandButton;
+    }
+
+    public string GetExpandButtonText()
+    {
+        return GetAccordionConfig().ExpandButtonText;
+    }
+
+    public string FormatarTextoCompleto(string prefixo, string texto)
+    {
+        if (string.IsNullOrEmpty(prefixo) || string.IsNullOrEmpty(texto))
+            return texto ?? string.Empty;
+            
+        return $"[{prefixo}] {texto}";
+    }
+
+    public AccordionItem CriarAccordionItem(string id, string titulo, string conteudo, bool isExpanded = false)
+    {
+        var config = GetAccordionConfig();
+        
+        return new AccordionItem
+        {
+            Id = id,
+            Titulo = titulo,
+            TituloTruncado = TruncarTexto(titulo, config.MaxTextLength),
+            Conteudo = conteudo,
+            IsExpanded = isExpanded,
+            ShowExpandButton = ShouldShowExpandButton(titulo, config.MaxTextLength),
+            ExpandButtonText = GetExpandButtonText()
+        };
+    }
+
+    public List<AccordionItem> CriarAccordionsPerformance(int idPerformance, string abaixo, string esperado, string acima)
+    {
+        var items = new List<AccordionItem>();
+        var config = GetAccordionConfig();
+
+        if (!string.IsNullOrEmpty(abaixo))
+        {
+            items.Add(new AccordionItem
+            {
+                Id = GerarIdAccordion("abaixo", idPerformance),
+                Titulo = TruncarTexto(abaixo, config.MaxTextLength),
+                Conteudo = FormatarTextoCompleto("Abaixo", abaixo),
+                ShowExpandButton = ShouldShowExpandButton(abaixo, config.MaxTextLength),
+                ExpandButtonText = GetExpandButtonText()
+            });
+        }
+
+        if (!string.IsNullOrEmpty(esperado))
+        {
+            items.Add(new AccordionItem
+            {
+                Id = GerarIdAccordion("esperado", idPerformance),
+                Titulo = TruncarTexto(esperado, config.MaxTextLength),
+                Conteudo = FormatarTextoCompleto("Esperado", esperado),
+                ShowExpandButton = ShouldShowExpandButton(esperado, config.MaxTextLength),
+                ExpandButtonText = GetExpandButtonText()
+            });
+        }
+
+        if (!string.IsNullOrEmpty(acima))
+        {
+            items.Add(new AccordionItem
+            {
+                Id = GerarIdAccordion("acima", idPerformance),
+                Titulo = TruncarTexto(acima, config.MaxTextLength),
+                Conteudo = FormatarTextoCompleto("Acima", acima),
+                ShowExpandButton = ShouldShowExpandButton(acima, config.MaxTextLength),
+                ExpandButtonText = GetExpandButtonText()
+            });
+        }
+
+        _telemetryService.TrackEvent("AccordionItemsCreated", new Dictionary<string, string>
+        {
+            { "IdPerformance", idPerformance.ToString() },
+            { "ItemsCount", items.Count.ToString() }
+        });
+
+        return items;
+    }
+}
+
+public class AccordionConfig
+{
+    public int MaxTextLength { get; set; } = 70;
+    public bool ShowExpandButton { get; set; } = true;
+    public string ExpandButtonText { get; set; } = "Ver+";
+    public bool EnableAccordions { get; set; } = true;
+    public bool EnableStickyHeaders { get; set; } = true;
+}
+
+public class AccordionItem
+{
+    public string Id { get; set; } = string.Empty;
+    public string Titulo { get; set; } = string.Empty;
+    public string TituloTruncado { get; set; } = string.Empty;
+    public string Conteudo { get; set; } = string.Empty;
+    public bool IsExpanded { get; set; } = false;
+    public bool ShowExpandButton { get; set; } = false;
+    public string ExpandButtonText { get; set; } = "Ver+";
+    public string CssClass { get; set; } = string.Empty;
+    public string TargetId => $"#{Id}";
+    public string DataTarget => $"#{Id}";
+    public string AriaExpanded => IsExpanded ? "true" : "false";
+    public string CollapseClass => IsExpanded ? "collapse show" : "collapse";
+}

--- a/Services/AutoAvaliacao/Common/NotaHelper.cs
+++ b/Services/AutoAvaliacao/Common/NotaHelper.cs
@@ -1,0 +1,205 @@
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Common;
+
+namespace Peers.Moderno.Services.AutoAvaliacao.Common;
+
+public interface INotaHelper
+{
+    List<ComboItem> GetNotasPerformanceItems(bool includeSelecionar = true);
+    List<ComboItem> GetNotasCompetenciaItems(bool includeSelecionar = true);
+    bool IsNotaValida(int? nota);
+    bool IsNotaNaoSeAplica(int? nota);
+    bool IsNotaSelecionar(int? nota);
+    string GetNotaTexto(int? nota);
+    string GetNotaCssClass(int? nota);
+    bool ValidarNotaObrigatoria(int? nota, bool isRequired = true);
+    bool ValidarNotasConsistencia(int? notaNivel1, int? notaNivel2);
+    void AjustarNotaNaoSeAplica(ref int? notaNivel1, ref int? notaNivel2);
+    bool HasNotasMensuravelPorPilar(List<int?> notasNivel1, List<int?> notasNivel2);
+    bool ValidarPreenchimentoCompleto(List<int?> notas, bool allowNaoSeAplica = true);
+    int GetNotaPadraoAutoAvaliacao();
+    int GetNotaPadraoAvaliacaoAsCegas();
+    int GetNotaPadraoAvaliacaoGestor();
+    int GetIdNotaNaoSeAplica();
+    int GetIdNotaSelecionar();
+}
+
+public class NotaHelper : INotaHelper
+{
+    private readonly ITelemetryService _telemetryService;
+    private readonly IConfiguration _configuration;
+    
+    private const int ID_NOTA_NAO_SE_APLICA = 5;
+    private const int ID_NOTA_SELECIONAR = 0;
+    private const int NOTA_PADRAO_AUTO_AVALIACAO = 1;
+    private const int NOTA_PADRAO_AVALIACAO_AS_CEGAS = 1;
+    private const int NOTA_PADRAO_AVALIACAO_GESTOR = 1;
+
+    public NotaHelper(ITelemetryService telemetryService, IConfiguration configuration)
+    {
+        _telemetryService = telemetryService;
+        _configuration = configuration;
+    }
+
+    public List<ComboItem> GetNotasPerformanceItems(bool includeSelecionar = true)
+    {
+        var items = new List<ComboItem>();
+        
+        if (includeSelecionar)
+        {
+            items.Add(new ComboItem { Value = "0", Text = "[Selecionar]", IsDisabled = true });
+        }
+        
+        items.AddRange(new List<ComboItem>
+        {
+            new ComboItem { Value = "1", Text = "1" },
+            new ComboItem { Value = "2", Text = "2" },
+            new ComboItem { Value = "3", Text = "3" },
+            new ComboItem { Value = "4", Text = "4" },
+            new ComboItem { Value = "5", Text = "Não se aplica" }
+        });
+        
+        return items;
+    }
+
+    public List<ComboItem> GetNotasCompetenciaItems(bool includeSelecionar = true)
+    {
+        var items = new List<ComboItem>();
+        
+        if (includeSelecionar)
+        {
+            items.Add(new ComboItem { Value = "0", Text = "[Selecionar]", IsDisabled = true });
+        }
+        
+        items.AddRange(new List<ComboItem>
+        {
+            new ComboItem { Value = "1", Text = "1" },
+            new ComboItem { Value = "2", Text = "2" },
+            new ComboItem { Value = "3", Text = "3" },
+            new ComboItem { Value = "4", Text = "4" },
+            new ComboItem { Value = "5", Text = "Não se aplica" }
+        });
+        
+        return items;
+    }
+
+    public bool IsNotaValida(int? nota)
+    {
+        return nota.HasValue && nota.Value >= 1 && nota.Value <= 5;
+    }
+
+    public bool IsNotaNaoSeAplica(int? nota)
+    {
+        return nota.HasValue && nota.Value == ID_NOTA_NAO_SE_APLICA;
+    }
+
+    public bool IsNotaSelecionar(int? nota)
+    {
+        return !nota.HasValue || nota.Value == ID_NOTA_SELECIONAR;
+    }
+
+    public string GetNotaTexto(int? nota)
+    {
+        if (!nota.HasValue || nota.Value == ID_NOTA_SELECIONAR)
+            return "[Selecionar]";
+            
+        return nota.Value == ID_NOTA_NAO_SE_APLICA ? "Não se aplica" : nota.Value.ToString();
+    }
+
+    public string GetNotaCssClass(int? nota)
+    {
+        if (!IsNotaValida(nota))
+            return "text-muted";
+            
+        return nota.Value switch
+        {
+            1 => "text-danger",
+            2 => "text-warning",
+            3 => "text-info",
+            4 => "text-success",
+            5 => "text-secondary",
+            _ => "text-muted"
+        };
+    }
+
+    public bool ValidarNotaObrigatoria(int? nota, bool isRequired = true)
+    {
+        if (!isRequired)
+            return true;
+            
+        return IsNotaValida(nota);
+    }
+
+    public bool ValidarNotasConsistencia(int? notaNivel1, int? notaNivel2)
+    {
+        if (!IsNotaValida(notaNivel1) || !IsNotaValida(notaNivel2))
+            return true;
+            
+        if (IsNotaNaoSeAplica(notaNivel1))
+            return IsNotaNaoSeAplica(notaNivel2);
+            
+        return notaNivel2.Value <= notaNivel1.Value;
+    }
+
+    public void AjustarNotaNaoSeAplica(ref int? notaNivel1, ref int? notaNivel2)
+    {
+        if (IsNotaNaoSeAplica(notaNivel1) && !IsNotaNaoSeAplica(notaNivel2))
+        {
+            notaNivel2 = ID_NOTA_NAO_SE_APLICA;
+            
+            _telemetryService.TrackEvent("NotaAjustadaNaoSeAplica", new Dictionary<string, string>
+            {
+                { "NotaNivel1", notaNivel1.ToString() },
+                { "NotaNivel2Original", notaNivel2.ToString() },
+                { "NotaNivel2Ajustada", ID_NOTA_NAO_SE_APLICA.ToString() }
+            });
+        }
+    }
+
+    public bool HasNotasMensuravelPorPilar(List<int?> notasNivel1, List<int?> notasNivel2)
+    {
+        var notasMensuravelNivel1 = notasNivel1.Count(n => IsNotaValida(n) && !IsNotaNaoSeAplica(n));
+        var notasMensuravelNivel2 = notasNivel2.Count(n => IsNotaValida(n) && !IsNotaNaoSeAplica(n));
+        
+        return notasMensuravelNivel1 > 0 && notasMensuravelNivel2 > 0;
+    }
+
+    public bool ValidarPreenchimentoCompleto(List<int?> notas, bool allowNaoSeAplica = true)
+    {
+        foreach (var nota in notas)
+        {
+            if (IsNotaSelecionar(nota))
+                return false;
+                
+            if (!allowNaoSeAplica && IsNotaNaoSeAplica(nota))
+                return false;
+        }
+        
+        return true;
+    }
+
+    public int GetNotaPadraoAutoAvaliacao()
+    {
+        return _configuration.GetValue("AutoAvaliacao:NotasPadrao:AutoAvaliacao", NOTA_PADRAO_AUTO_AVALIACAO);
+    }
+
+    public int GetNotaPadraoAvaliacaoAsCegas()
+    {
+        return _configuration.GetValue("AutoAvaliacao:NotasPadrao:AvaliacaoAsCegas", NOTA_PADRAO_AVALIACAO_AS_CEGAS);
+    }
+
+    public int GetNotaPadraoAvaliacaoGestor()
+    {
+        return _configuration.GetValue("AutoAvaliacao:NotasPadrao:AvaliacaoGestor", NOTA_PADRAO_AVALIACAO_GESTOR);
+    }
+
+    public int GetIdNotaNaoSeAplica()
+    {
+        return _configuration.GetValue("AutoAvaliacao:NotasPadrao:IdNotaNaoSeAplica", ID_NOTA_NAO_SE_APLICA);
+    }
+
+    public int GetIdNotaSelecionar()
+    {
+        return _configuration.GetValue("AutoAvaliacao:NotasPadrao:IdNotaSelecionar", ID_NOTA_SELECIONAR);
+    }
+}

--- a/Services/AutoAvaliacao/Common/ValidationHelper.cs
+++ b/Services/AutoAvaliacao/Common/ValidationHelper.cs
@@ -1,0 +1,284 @@
+using Peers.Moderno.Services.Common;
+
+namespace Peers.Moderno.Services.AutoAvaliacao.Common;
+
+public interface IValidationHelper
+{
+    ValidationResult ValidarParametrosObrigatorios(int? idProjeto, int? idAssociado, int? idPeriodo);
+    ValidationResult ValidarAvaliacaoCompleta(List<int?> notasCompetencia, List<int?> notasPerformance, bool requireAllFilled = true);
+    ValidationResult ValidarConsistenciaNotas(List<(int? nivel1, int? nivel2)> paresNotas);
+    ValidationResult ValidarPilaresPreenchidos(Dictionary<string, List<int?>> notasPorPilar);
+    ValidationResult ValidarPermissaoEdicao(bool isFinalized, bool hasPermission);
+    ValidationResult ValidarTempoRestante(DateTime? dataLimite);
+    string GetMensagemValidacao(string chave, params object[] parametros);
+    bool IsValidationEnabled();
+}
+
+public class ValidationHelper : IValidationHelper
+{
+    private readonly IConfiguration _configuration;
+    private readonly ITelemetryService _telemetryService;
+    private readonly INotaHelper _notaHelper;
+
+    public ValidationHelper(
+        IConfiguration configuration,
+        ITelemetryService telemetryService,
+        INotaHelper notaHelper)
+    {
+        _configuration = configuration;
+        _telemetryService = telemetryService;
+        _notaHelper = notaHelper;
+    }
+
+    public ValidationResult ValidarParametrosObrigatorios(int? idProjeto, int? idAssociado, int? idPeriodo)
+    {
+        var errors = new List<string>();
+
+        if (!idProjeto.HasValue || idProjeto.Value <= 0)
+        {
+            errors.Add(GetMensagemValidacao("ProjetoObrigatorio"));
+        }
+
+        if (!idAssociado.HasValue || idAssociado.Value <= 0)
+        {
+            errors.Add(GetMensagemValidacao("AssociadoObrigatorio"));
+        }
+
+        if (!idPeriodo.HasValue || idPeriodo.Value <= 0)
+        {
+            errors.Add(GetMensagemValidacao("PeriodoObrigatorio"));
+        }
+
+        if (errors.Any())
+        {
+            _telemetryService.TrackEvent("ValidationError_ParametrosObrigatorios", new Dictionary<string, string>
+            {
+                { "ErrorCount", errors.Count.ToString() },
+                { "IdProjeto", idProjeto?.ToString() ?? "null" },
+                { "IdAssociado", idAssociado?.ToString() ?? "null" },
+                { "IdPeriodo", idPeriodo?.ToString() ?? "null" }
+            });
+
+            return ValidationResult.Error(string.Join("; ", errors));
+        }
+
+        return ValidationResult.Success();
+    }
+
+    public ValidationResult ValidarAvaliacaoCompleta(List<int?> notasCompetencia, List<int?> notasPerformance, bool requireAllFilled = true)
+    {
+        var errors = new List<string>();
+
+        if (requireAllFilled)
+        {
+            if (!_notaHelper.ValidarPreenchimentoCompleto(notasCompetencia, true))
+            {
+                errors.Add(GetMensagemValidacao("CompetenciasNaoPreenchidas"));
+            }
+
+            if (!_notaHelper.ValidarPreenchimentoCompleto(notasPerformance, true))
+            {
+                errors.Add(GetMensagemValidacao("PerformancesNaoPreenchidas"));
+            }
+        }
+
+        if (!notasCompetencia.Any())
+        {
+            errors.Add(GetMensagemValidacao("CompetenciasNaoParametrizadas"));
+        }
+
+        if (!notasPerformance.Any())
+        {
+            errors.Add(GetMensagemValidacao("PerformancesNaoParametrizadas"));
+        }
+
+        if (errors.Any())
+        {
+            _telemetryService.TrackEvent("ValidationError_AvaliacaoIncompleta", new Dictionary<string, string>
+            {
+                { "ErrorCount", errors.Count.ToString() },
+                { "CompetenciasCount", notasCompetencia.Count.ToString() },
+                { "PerformancesCount", notasPerformance.Count.ToString() }
+            });
+
+            return ValidationResult.Error(string.Join("; ", errors));
+        }
+
+        return ValidationResult.Success();
+    }
+
+    public ValidationResult ValidarConsistenciaNotas(List<(int? nivel1, int? nivel2)> paresNotas)
+    {
+        var inconsistencias = new List<string>();
+        var ajustesNecessarios = new List<string>();
+
+        foreach (var (nivel1, nivel2) in paresNotas)
+        {
+            if (!_notaHelper.ValidarNotasConsistencia(nivel1, nivel2))
+            {
+                inconsistencias.Add($"Nota Nível 1: {_notaHelper.GetNotaTexto(nivel1)}, Nível 2: {_notaHelper.GetNotaTexto(nivel2)}");
+            }
+
+            if (_notaHelper.IsNotaNaoSeAplica(nivel1) && !_notaHelper.IsNotaNaoSeAplica(nivel2))
+            {
+                ajustesNecessarios.Add($"Ajuste necessário: Nível 1 = Não se aplica, Nível 2 deve ser Não se aplica");
+            }
+        }
+
+        if (inconsistencias.Any())
+        {
+            _telemetryService.TrackEvent("ValidationError_NotasInconsistentes", new Dictionary<string, string>
+            {
+                { "InconsistenciasCount", inconsistencias.Count.ToString() },
+                { "AjustesCount", ajustesNecessarios.Count.ToString() }
+            });
+
+            var errorMessage = GetMensagemValidacao("NotasInconsistentes");
+            if (ajustesNecessarios.Any())
+            {
+                errorMessage += " " + GetMensagemValidacao("NotaNaoSeAplicaInconsistente");
+            }
+
+            return ValidationResult.Error(errorMessage);
+        }
+
+        return ValidationResult.Success();
+    }
+
+    public ValidationResult ValidarPilaresPreenchidos(Dictionary<string, List<int?>> notasPorPilar)
+    {
+        var pilaresVazios = new List<string>();
+
+        foreach (var pilar in notasPorPilar)
+        {
+            var notasMensuravelNivel1 = pilar.Value.Count(n => _notaHelper.IsNotaValida(n) && !_notaHelper.IsNotaNaoSeAplica(n));
+            
+            if (notasMensuravelNivel1 == 0)
+            {
+                pilaresVazios.Add(pilar.Key);
+            }
+        }
+
+        if (pilaresVazios.Any())
+        {
+            _telemetryService.TrackEvent("ValidationError_PilaresVazios", new Dictionary<string, string>
+            {
+                { "PilaresVaziosCount", pilaresVazios.Count.ToString() },
+                { "PilaresVazios", string.Join(", ", pilaresVazios) }
+            });
+
+            return ValidationResult.Error(GetMensagemValidacao("PilarVazio"));
+        }
+
+        return ValidationResult.Success();
+    }
+
+    public ValidationResult ValidarPermissaoEdicao(bool isFinalized, bool hasPermission)
+    {
+        if (isFinalized)
+        {
+            return ValidationResult.Error("Avaliação já foi finalizada e não pode ser editada.");
+        }
+
+        if (!hasPermission)
+        {
+            return ValidationResult.Error(GetMensagemValidacao("PermissaoNegada"));
+        }
+
+        return ValidationResult.Success();
+    }
+
+    public ValidationResult ValidarTempoRestante(DateTime? dataLimite)
+    {
+        if (!dataLimite.HasValue)
+        {
+            return ValidationResult.Success();
+        }
+
+        if (DateTime.Now > dataLimite.Value)
+        {
+            return ValidationResult.Warning("Prazo da avaliação expirado. Utilize o período de compensação se disponível.");
+        }
+
+        var tempoRestante = dataLimite.Value - DateTime.Now;
+        if (tempoRestante.TotalHours < 24)
+        {
+            return ValidationResult.Warning($"Atenção: Restam apenas {tempoRestante.TotalHours:F1} horas para finalizar a avaliação.");
+        }
+
+        return ValidationResult.Success();
+    }
+
+    public string GetMensagemValidacao(string chave, params object[] parametros)
+    {
+        var mensagem = _configuration[$"AutoAvaliacao:ValidationMessages:{chave}"] ?? chave;
+        
+        if (parametros.Any())
+        {
+            try
+            {
+                return string.Format(mensagem, parametros);
+            }
+            catch
+            {
+                return mensagem;
+            }
+        }
+        
+        return mensagem;
+    }
+
+    public bool IsValidationEnabled()
+    {
+        return _configuration.GetValue("AutoAvaliacao:EnableValidation", true);
+    }
+}
+
+public class ValidationResult
+{
+    public bool IsValid { get; private set; }
+    public bool IsWarning { get; private set; }
+    public string Message { get; private set; } = string.Empty;
+    public List<string> Errors { get; private set; } = new List<string>();
+    public List<string> Warnings { get; private set; } = new List<string>();
+
+    private ValidationResult() { }
+
+    public static ValidationResult Success()
+    {
+        return new ValidationResult { IsValid = true };
+    }
+
+    public static ValidationResult Error(string message)
+    {
+        return new ValidationResult
+        {
+            IsValid = false,
+            Message = message,
+            Errors = new List<string> { message }
+        };
+    }
+
+    public static ValidationResult Warning(string message)
+    {
+        return new ValidationResult
+        {
+            IsValid = true,
+            IsWarning = true,
+            Message = message,
+            Warnings = new List<string> { message }
+        };
+    }
+
+    public static ValidationResult Multiple(List<string> errors, List<string> warnings = null)
+    {
+        return new ValidationResult
+        {
+            IsValid = !errors.Any(),
+            IsWarning = warnings?.Any() == true,
+            Message = errors.Any() ? string.Join("; ", errors) : (warnings?.Any() == true ? string.Join("; ", warnings) : string.Empty),
+            Errors = errors ?? new List<string>(),
+            Warnings = warnings ?? new List<string>()
+        };
+    }
+}


### PR DESCRIPTION
Este PR implementa três helpers reutilizáveis na pasta Services/AutoAvaliacao/Common: NotaHelper, ValidationHelper e AccordionHelper. Eles centralizam lógicas de manipulação de notas, validações de regras de negócio e comportamento de accordions/truncamento de texto, promovendo reutilização e padronização em múltiplos componentes do sistema de avaliação interna. Também adiciona documentação detalhada em markdown na pasta docs, explicando a integração e uso dos helpers, além de um fluxo mermaid de alto nível.