### PR TITLE
Criação de helpers reutilizáveis para avaliação e documentação técnica

### DIFF
--- a/Components/AutoAvaliacao/AutoAvaliacaoPerformance.razor
+++ b/Components/AutoAvaliacao/AutoAvaliacaoPerformance.razor
@@ -1,0 +1,341 @@
+@page "/autoavaliacao-performance"
+@rendermode InteractiveAuto
+@using Peers.Moderno.Services.AutoAvaliacao
+@using Peers.Moderno.Services.Common
+@using Peers.Moderno.Models
+@inject IAutoAvaliacaoPerformanceService AutoAvaliacaoService
+@inject IMessageBoxService MessageBoxService
+@inject ITelemetryService TelemetryService
+@inject IUserContextService UserContextService
+@inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
+
+<PageTitle>Auto Avaliação - Performance</PageTitle>
+
+<div class="page-breadcrumb border-bottom">
+    <div class="row">
+        <div class="col-lg-3 col-md-4 col-xs-12 align-self-center">
+            <h5 class="font-medium text-uppercase mb-0">Auto Avaliação</h5>
+        </div>
+        <div class="col-lg-9 col-md-8 col-xs-12 align-self-center">
+            <nav aria-label="breadcrumb" class="mt-2 float-md-right float-left">
+                <ol class="breadcrumb mb-0 justify-content-end p-0">
+                    <li class="breadcrumb-item"><a href="/">Peers</a></li>
+                    <li class="breadcrumb-item"><a href="/">Avaliação / Auto Avaliação</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">Performance</li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+</div>
+
+<div class="page-content container-fluid">
+    @if (isLoading)
+    {
+        <div class="d-flex justify-content-center">
+            <div class="spinner-border" role="status">
+                <span class="sr-only">Carregando...</span>
+            </div>
+        </div>
+    }
+    else if (avaliacaoData != null)
+    {
+        <div class="card">
+            <div class="card-body">
+                <div class="form-body">
+                    <div class="row">
+                        <div class="col-md-5">
+                            <div class="text-left">
+                                <button type="button" class="btn btn-danger" @onclick="IrParaCompetencia">Competencia</button>
+                                <button type="button" class="btn btn-facebook" disabled>Performance</button>
+                                <button type="button" class="btn btn-info" @onclick="IrParaFinalizacao">Ir para Finalização</button>
+                                <p></p>
+                            </div>
+                        </div>
+
+                        <div class="col-sm">
+                            <div class="row">
+                                <div class="col-md-1">
+                                    <label><b>Avaliado</b></label>
+                                </div>
+                                <div class="col-md-3">
+                                    <label>@avaliacaoData.NomeAssociado</label>
+                                </div>
+                                <div class="col-md-1">
+                                    <label><b>Período</b></label>
+                                </div>
+                                <div class="col-md-3">
+                                    <label>@avaliacaoData.Periodo</label>
+                                </div>
+                                <div class="col-md-1">
+                                    <label><b>Gestor</b></label>
+                                </div>
+                                <div class="col-md-3">
+                                    <label>@avaliacaoData.NomeGestor</label>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-2">
+                                    <label><b>Tempo de Cargo:</b></label>
+                                </div>
+                                <div class="col-md-4">
+                                    <label>@avaliacaoData.TempoCargo</label>
+                                </div>
+                                <div class="col-md-2">
+                                    <label><b>Tempo de Peers</b></label>
+                                </div>
+                                <div class="col-md-4">
+                                    <label>@avaliacaoData.TempoPeers</label>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-1">
+                                    <label><b>Projeto</b></label>
+                                </div>
+                                <div class="col-md-3">
+                                    <label>@avaliacaoData.NomeProjeto</label>
+                                </div>
+                                <div class="col-md-1">
+                                    <label><b>Cliente</b></label>
+                                </div>
+                                <div class="col-md-3">
+                                    <label>@avaliacaoData.NomeCliente</label>
+                                </div>
+                                <div class="col-md-2">
+                                    <label><b>Tempo restante</b></label>
+                                </div>
+                                <div class="col-md-2">
+                                    <label>@avaliacaoData.TempoRestante</label>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-body">
+                <div class="form-body">
+                    <div class="row">
+                        <div class="col-md-4 offset-md-8">
+                            <div class="text-right">
+                                <button type="button" class="btn btn-dark" @onclick="SalvarAvaliacao" disabled="@isSaving">Salvar Avaliação</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <br />
+
+                <PerformanceTable Performances="@avaliacaoData.Performances" 
+                                OnNotaChanged="OnNotaChanged" 
+                                OnObservacaoChanged="OnObservacaoChanged" />
+
+                <div class="form-body">
+                    <div class="row">
+                        <div class="col-md-4 offset-md-8">
+                            <div class="text-right">
+                                <button type="button" class="btn btn-dark" @onclick="SalvarAvaliacao" disabled="@isSaving">Salvar Avaliação</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-body">
+                <div class="col-md-5">
+                    <div class="text-left">
+                        <button type="button" class="btn btn-danger" @onclick="IrParaCompetencia">Competencia</button>
+                        <button type="button" class="btn btn-facebook" disabled>Performance</button>
+                        <button type="button" class="btn btn-info" @onclick="IrParaFinalizacao">Ir para Finalização</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+    else if (hasError)
+    {
+        <div class="alert alert-danger" role="alert">
+            <h4 class="alert-heading">Erro!</h4>
+            <p>@errorMessage</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public string? IdProjeto { get; set; }
+    [Parameter] public string? IdAssociado { get; set; }
+    [Parameter] public string? IdPeriodo { get; set; }
+    [Parameter] public string? IdAvaliacao { get; set; }
+
+    private AutoAvaliacaoPerformanceData? avaliacaoData;
+    private bool isLoading = true;
+    private bool isSaving = false;
+    private bool hasError = false;
+    private string errorMessage = string.Empty;
+    private Timer? autoSaveTimer;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            TelemetryService.TrackEvent("AutoAvaliacaoPerformance_PageLoad", new Dictionary<string, string>
+            {
+                { "IdProjeto", IdProjeto ?? "" },
+                { "IdAssociado", IdAssociado ?? "" },
+                { "IdPeriodo", IdPeriodo ?? "" }
+            });
+
+            await CarregarDadosAvaliacao();
+            ConfigurarAutoSave();
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "OnInitializedAsync" },
+                { "Component", "AutoAvaliacaoPerformance" }
+            });
+            
+            hasError = true;
+            errorMessage = "Erro ao carregar dados da avaliação";
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private async Task CarregarDadosAvaliacao()
+    {
+        if (!int.TryParse(IdProjeto, out int idProjeto) ||
+            !int.TryParse(IdAssociado, out int idAssociado) ||
+            !int.TryParse(IdPeriodo, out int idPeriodo))
+        {
+            hasError = true;
+            errorMessage = "Parâmetros inválidos";
+            return;
+        }
+
+        int idAvaliacao = int.TryParse(IdAvaliacao, out int id) ? id : 0;
+        
+        avaliacaoData = await AutoAvaliacaoService.CarregarDadosAvaliacaoAsync(idProjeto, idAssociado, idPeriodo, idAvaliacao);
+        
+        if (avaliacaoData == null)
+        {
+            hasError = true;
+            errorMessage = "Avaliação não encontrada";
+        }
+    }
+
+    private void ConfigurarAutoSave()
+    {
+        autoSaveTimer = new Timer(async _ => await AutoSave(), null, TimeSpan.FromMinutes(15), TimeSpan.FromMinutes(15));
+    }
+
+    private async Task AutoSave()
+    {
+        if (avaliacaoData != null && !isSaving)
+        {
+            try
+            {
+                await AutoAvaliacaoService.SalvarAvaliacaoAsync(avaliacaoData, false);
+                TelemetryService.TrackEvent("AutoAvaliacaoPerformance_AutoSave");
+            }
+            catch (Exception ex)
+            {
+                TelemetryService.TrackException(ex, new Dictionary<string, string>
+                {
+                    { "Method", "AutoSave" },
+                    { "Component", "AutoAvaliacaoPerformance" }
+                });
+            }
+        }
+    }
+
+    private async Task SalvarAvaliacao()
+    {
+        if (avaliacaoData == null || isSaving) return;
+
+        try
+        {
+            isSaving = true;
+            var resultado = await AutoAvaliacaoService.SalvarAvaliacaoAsync(avaliacaoData, false);
+            
+            if (resultado.Sucesso)
+            {
+                MessageBoxService.ShowSuccess("Avaliação Salva com Sucesso.");
+                TelemetryService.TrackEvent("AutoAvaliacaoPerformance_SaveSuccess");
+            }
+            else
+            {
+                MessageBoxService.ShowError(resultado.MensagemErro ?? "Falha ao Incluir Performance da Avaliação.");
+                TelemetryService.TrackEvent("AutoAvaliacaoPerformance_SaveError", new Dictionary<string, string>
+                {
+                    { "Error", resultado.MensagemErro ?? "Unknown" }
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            TelemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "SalvarAvaliacao" },
+                { "Component", "AutoAvaliacaoPerformance" }
+            });
+            MessageBoxService.ShowError("Erro interno ao salvar avaliação");
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+
+    private async Task IrParaCompetencia()
+    {
+        await SalvarAvaliacao();
+        Navigation.NavigateTo("/autoavaliacao-competencia");
+    }
+
+    private async Task IrParaFinalizacao()
+    {
+        await SalvarAvaliacao();
+        Navigation.NavigateTo($"/autoavaliacao?IdProjeto={IdProjeto}&IdAssociado={IdAssociado}&IdPeriodo={IdPeriodo}");
+    }
+
+    private void OnNotaChanged(int idPerformance, int nota)
+    {
+        if (avaliacaoData?.Performances != null)
+        {
+            var performance = avaliacaoData.Performances.FirstOrDefault(p => p.IdPerformance == idPerformance);
+            if (performance != null)
+            {
+                performance.NotaSelecionada = nota;
+                TelemetryService.TrackEvent("AutoAvaliacaoPerformance_NotaChanged", new Dictionary<string, string>
+                {
+                    { "IdPerformance", idPerformance.ToString() },
+                    { "Nota", nota.ToString() }
+                });
+            }
+        }
+    }
+
+    private void OnObservacaoChanged(int idPerformance, string observacao)
+    {
+        if (avaliacaoData?.Performances != null)
+        {
+            var performance = avaliacaoData.Performances.FirstOrDefault(p => p.IdPerformance == idPerformance);
+            if (performance != null)
+            {
+                performance.Observacao = observacao;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        autoSaveTimer?.Dispose();
+    }
+}

--- a/Components/AutoAvaliacao/PerformanceTable.razor
+++ b/Components/AutoAvaliacao/PerformanceTable.razor
@@ -1,0 +1,205 @@
+@using Peers.Moderno.Services.Common
+@using Peers.Moderno.Services.AutoAvaliacao.Common
+@using Peers.Moderno.Models
+@inject IAccordionHelper AccordionHelper
+@inject INotaHelper NotaHelper
+@inject IJSRuntime JSRuntime
+
+<div class="table-responsive">
+    <table class="table table-striped border">
+        <thead>
+            <tr>
+                <th style="width: 200px;">Performance</th>
+                <th>Abaixo</th>
+                <th>Esperado</th>
+                <th>Acima</th>
+                <th>Nota Avaliado</th>
+                <th style="width: 180px;">Considerações Avaliado</th>
+            </tr>
+        </thead>
+        <tbody>
+            @if (Performances != null)
+            {
+                @foreach (var performance in Performances)
+                {
+                    @if (!string.IsNullOrEmpty(performance.Abrangencia) && performance.MostrarSeparadorAbrangencia)
+                    {
+                        <tr>
+                            <td colspan="6" style="text-align:center;font-size:16px">@performance.Abrangencia.ToUpper()</td>
+                        </tr>
+                    }
+                    
+                    @if (performance.MostrarInput)
+                    {
+                        <tr>
+                            <td>
+                                @performance.Descricao
+                                @if (!string.IsNullOrEmpty(performance.DisclaimerInput))
+                                {
+                                    <br />
+                                    <label style="font-size:13px;font-weight:normal;font-style:italic;color:darkred">@performance.DisclaimerInput</label>
+                                }
+                            </td>
+                            <td>
+                                <a href="#" @onclick="() => ToggleAccordion($"abaixo_{performance.IdPerformance}")"
+                                   @onclick:preventDefault="true" class="accordion-toggle">
+                                    @AccordionHelper.TruncarTexto(performance.Abaixo, 45)
+                                    <span style="font-weight:bold">  Ver+</span>
+                                </a>
+                            </td>
+                            <td>
+                                <a href="#" @onclick="() => ToggleAccordion($"esperado_{performance.IdPerformance}")"
+                                   @onclick:preventDefault="true" class="accordion-toggle">
+                                    @AccordionHelper.TruncarTexto(performance.Esperado, 45)
+                                    <span style="font-weight:bold">  Ver+</span>
+                                </a>
+                            </td>
+                            <td>
+                                <a href="#" @onclick="() => ToggleAccordion($"acima_{performance.IdPerformance}")"
+                                   @onclick:preventDefault="true" class="accordion-toggle">
+                                    @AccordionHelper.TruncarTexto(performance.Acima, 45)
+                                    <span style="font-weight:bold">  Ver+</span>
+                                </a>
+                            </td>
+                            <td style="width: 120px;">
+                                <select class="form-control p-0 select2" style="width: 100%" 
+                                        value="@performance.NotaSelecionada" 
+                                        @onchange="(e) => OnNotaChange(performance.IdPerformance, e)"
+                                        disabled="@performance.NotaDesabilitada">
+                                    @foreach (var nota in NotaHelper.ObterNotasPerformance(true))
+                                    {
+                                        <option value="@nota.Value" disabled="@nota.IsDisabled">@nota.Text</option>
+                                    }
+                                </select>
+                            </td>
+                            <td class="text-center">
+                                <button type="button" @onclick="() => ToggleAccordion($"obs_{performance.IdPerformance}")"
+                                        class="accordion-toggle" 
+                                        style="background-color:#003150;padding:8px 15px;border:none">
+                                    <span aria-hidden="true" style="color:white;font-size:15px">Considerações</span>
+                                </button>
+                            </td>
+                        </tr>
+                        
+                        <!-- Accordion Rows -->
+                        <tr class="hiddenRow" id="row_abaixo_@performance.IdPerformance" style="@GetAccordionStyle($"abaixo_{performance.IdPerformance}")">
+                            <td colspan="6" class="hiddenRow">
+                                <div class="accordian-body" id="abaixo_@performance.IdPerformance">
+                                    [Abaixo] @performance.Abaixo
+                                </div>
+                            </td>
+                        </tr>
+                        
+                        <tr class="hiddenRow" id="row_esperado_@performance.IdPerformance" style="@GetAccordionStyle($"esperado_{performance.IdPerformance}")">
+                            <td colspan="6" class="hiddenRow">
+                                <div class="accordian-body" id="esperado_@performance.IdPerformance">
+                                    [Esperado] @performance.Esperado
+                                </div>
+                            </td>
+                        </tr>
+                        
+                        <tr class="hiddenRow" id="row_acima_@performance.IdPerformance" style="@GetAccordionStyle($"acima_{performance.IdPerformance}")">
+                            <td colspan="6" class="hiddenRow">
+                                <div class="accordian-body" id="acima_@performance.IdPerformance">
+                                    [Acima] @performance.Acima
+                                </div>
+                            </td>
+                        </tr>
+                        
+                        <tr class="hiddenRow" id="row_obs_@performance.IdPerformance" style="@GetAccordionStyle($"obs_{performance.IdPerformance}")">
+                            <td colspan="6" class="hiddenRow">
+                                <div class="accordian-body" id="obs_@performance.IdPerformance">
+                                    <strong>Considerações:</strong><br/>
+                                    <textarea rows="5" class="form-control" 
+                                              value="@performance.Observacao"
+                                              @onchange="(e) => OnObservacaoChange(performance.IdPerformance, e)"
+                                              disabled="@performance.ObservacaoDesabilitada"></textarea>
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                }
+            }
+        </tbody>
+    </table>
+</div>
+
+<style>
+    .hiddenRow {
+        padding: 0 !important;
+    }
+    
+    .accordion-toggle {
+        text-decoration: none;
+        color: #007bff;
+    }
+    
+    .accordion-toggle:hover {
+        text-decoration: underline;
+    }
+</style>
+
+@code {
+    [Parameter] public List<PerformanceAvaliacaoModel>? Performances { get; set; }
+    [Parameter] public EventCallback<(int IdPerformance, int Nota)> OnNotaChanged { get; set; }
+    [Parameter] public EventCallback<(int IdPerformance, string Observacao)> OnObservacaoChanged { get; set; }
+
+    private Dictionary<string, bool> accordionStates = new();
+
+    private async Task OnNotaChange(int idPerformance, ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out int nota))
+        {
+            await OnNotaChanged.InvokeAsync((idPerformance, nota));
+        }
+    }
+
+    private async Task OnObservacaoChange(int idPerformance, ChangeEventArgs e)
+    {
+        var observacao = e.Value?.ToString() ?? string.Empty;
+        await OnObservacaoChanged.InvokeAsync((idPerformance, observacao));
+    }
+
+    private async Task ToggleAccordion(string accordionId)
+    {
+        accordionStates[accordionId] = !accordionStates.GetValueOrDefault(accordionId, false);
+        StateHasChanged();
+        
+        // Smooth scroll to accordion if opening
+        if (accordionStates[accordionId])
+        {
+            await JSRuntime.InvokeVoidAsync("scrollToElement", accordionId);
+        }
+    }
+
+    private string GetAccordionStyle(string accordionId)
+    {
+        return accordionStates.GetValueOrDefault(accordionId, false) ? "" : "display: none;";
+    }
+
+    protected override void OnParametersSet()
+    {
+        // Initialize accordion states for new performances
+        if (Performances != null)
+        {
+            foreach (var performance in Performances)
+            {
+                var accordionIds = new[]
+                {
+                    $"abaixo_{performance.IdPerformance}",
+                    $"esperado_{performance.IdPerformance}",
+                    $"acima_{performance.IdPerformance}",
+                    $"obs_{performance.IdPerformance}"
+                };
+
+                foreach (var id in accordionIds)
+                {
+                    if (!accordionStates.ContainsKey(id))
+                    {
+                        accordionStates[id] = false;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Services/AutoAvaliacao/Common/AccordionHelper.cs
+++ b/Services/AutoAvaliacao/Common/AccordionHelper.cs
@@ -1,18 +1,22 @@
 using Peers.Moderno.Services.Common;
+using Microsoft.Extensions.Configuration;
 
 namespace Peers.Moderno.Services.AutoAvaliacao.Common;
 
 public interface IAccordionHelper
 {
-    string TruncarTexto(string texto, int maxLength);
-    string GerarIdAccordion(string prefixo, int id);
-    string GerarLinkAccordion(string texto, string targetId, int maxLength);
+    string TruncarTexto(string? texto, int tamanhoMaximo);
+    string GetTextoExpandido(string? texto, int tamanhoMaximo, string textoVerMais = "Ver+");
+    bool DeveExibirBotaoExpandir(string? texto, int tamanhoMaximo);
+    string GetIdAccordion(string prefixo, int id);
+    string GetClasseAccordion(bool isExpanded = false);
+    string GetAriaExpanded(bool isExpanded = false);
     AccordionConfig GetAccordionConfig();
-    bool ShouldShowExpandButton(string texto, int maxLength);
-    string GetExpandButtonText();
-    string FormatarTextoCompleto(string prefixo, string texto);
-    AccordionItem CriarAccordionItem(string id, string titulo, string conteudo, bool isExpanded = false);
-    List<AccordionItem> CriarAccordionsPerformance(int idPerformance, string abaixo, string esperado, string acima);
+    Dictionary<string, object> GetAccordionAttributes(string targetId, bool isExpanded = false);
+    string FormatarTextoComPrefixo(string? texto, string prefixo);
+    bool IsTextoVazio(string? texto);
+    int GetTamanhoMaximoPadrao();
+    string GetTextoVerMaisPadrao();
 }
 
 public class AccordionHelper : IAccordionHelper
@@ -20,162 +24,207 @@ public class AccordionHelper : IAccordionHelper
     private readonly IConfiguration _configuration;
     private readonly ITelemetryService _telemetryService;
 
-    public AccordionHelper(IConfiguration configuration, ITelemetryService telemetryService)
+    public AccordionHelper(
+        IConfiguration configuration,
+        ITelemetryService telemetryService)
     {
         _configuration = configuration;
         _telemetryService = telemetryService;
     }
 
-    public string TruncarTexto(string texto, int maxLength)
+    public string TruncarTexto(string? texto, int tamanhoMaximo)
     {
-        if (string.IsNullOrEmpty(texto))
-            return string.Empty;
+        try
+        {
+            if (string.IsNullOrWhiteSpace(texto))
+                return string.Empty;
 
-        if (texto.Length <= maxLength)
-            return texto;
+            if (texto.Length <= tamanhoMaximo)
+                return texto;
 
-        return texto.Substring(0, maxLength) + "...";
+            return texto.Substring(0, tamanhoMaximo) + "...";
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "TruncarTexto" },
+                { "Component", "AccordionHelper" },
+                { "TamanhoMaximo", tamanhoMaximo.ToString() }
+            });
+            return texto ?? string.Empty;
+        }
     }
 
-    public string GerarIdAccordion(string prefixo, int id)
+    public string GetTextoExpandido(string? texto, int tamanhoMaximo, string textoVerMais = "Ver+")
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(texto))
+                return string.Empty;
+
+            if (texto.Length <= tamanhoMaximo)
+                return texto;
+
+            var textoTruncado = TruncarTexto(texto, tamanhoMaximo);
+            return $"{textoTruncado} <span style='font-weight:bold'>{textoVerMais}</span>";
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetTextoExpandido" },
+                { "Component", "AccordionHelper" },
+                { "TamanhoMaximo", tamanhoMaximo.ToString() }
+            });
+            return texto ?? string.Empty;
+        }
+    }
+
+    public bool DeveExibirBotaoExpandir(string? texto, int tamanhoMaximo)
+    {
+        return !string.IsNullOrWhiteSpace(texto) && texto.Length > tamanhoMaximo;
+    }
+
+    public string GetIdAccordion(string prefixo, int id)
     {
         return $"{prefixo}_{id}";
     }
 
-    public string GerarLinkAccordion(string texto, string targetId, int maxLength)
+    public string GetClasseAccordion(bool isExpanded = false)
     {
-        var textoTruncado = TruncarTexto(texto, maxLength);
-        var showExpandButton = ShouldShowExpandButton(texto, maxLength);
-        
-        if (showExpandButton)
-        {
-            return $"{textoTruncado} <span style='font-weight:bold'>{GetExpandButtonText()}</span>";
-        }
-        
-        return textoTruncado;
+        return isExpanded ? "accordian-body collapse show" : "accordian-body collapse";
+    }
+
+    public string GetAriaExpanded(bool isExpanded = false)
+    {
+        return isExpanded.ToString().ToLower();
     }
 
     public AccordionConfig GetAccordionConfig()
     {
-        return new AccordionConfig
+        try
         {
-            MaxTextLength = _configuration.GetValue("AutoAvaliacao:MaxCompetenciaLength", 70),
-            ShowExpandButton = _configuration.GetValue("AutoAvaliacao:ShowVerMaisTexto", true),
-            ExpandButtonText = _configuration.GetValue("AutoAvaliacao:VerMaisTexto", "Ver+"),
-            EnableAccordions = _configuration.GetValue("AutoAvaliacao:ComponenteConfig:CompetenciaTable:EnableAccordions", true),
-            EnableStickyHeaders = _configuration.GetValue("AutoAvaliacao:ComponenteConfig:CompetenciaTable:EnableStickyHeaders", true)
+            return new AccordionConfig
+            {
+                TamanhoMaximo = _configuration.GetValue<int>("AutoAvaliacao:MaxCompetenciaLength", 70),
+                TextoVerMais = _configuration.GetValue<string>("AutoAvaliacao:VerMaisTexto", "Ver+") ?? "Ver+",
+                HabilitarAccordions = _configuration.GetValue<bool>("AutoAvaliacao:ComponenteConfig:CompetenciaTable:EnableAccordions", true),
+                ExibirBotaoExpandir = _configuration.GetValue<bool>("AutoAvaliacao:ComponenteConfig:CompetenciaTable:ShowExpandButton", true),
+                HabilitarCabecalhoFixo = _configuration.GetValue<bool>("AutoAvaliacao:ComponenteConfig:CompetenciaTable:EnableStickyHeaders", true)
+            };
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetAccordionConfig" },
+                { "Component", "AccordionHelper" }
+            });
+            
+            return new AccordionConfig
+            {
+                TamanhoMaximo = 70,
+                TextoVerMais = "Ver+",
+                HabilitarAccordions = true,
+                ExibirBotaoExpandir = true,
+                HabilitarCabecalhoFixo = true
+            };
+        }
+    }
+
+    public Dictionary<string, object> GetAccordionAttributes(string targetId, bool isExpanded = false)
+    {
+        return new Dictionary<string, object>
+        {
+            { "data-toggle", "collapse" },
+            { "data-target", $"#{targetId}" },
+            { "aria-expanded", GetAriaExpanded(isExpanded) },
+            { "aria-controls", targetId },
+            { "class", "accordion-toggle" }
         };
     }
 
-    public bool ShouldShowExpandButton(string texto, int maxLength)
+    public string FormatarTextoComPrefixo(string? texto, string prefixo)
     {
-        if (string.IsNullOrEmpty(texto))
-            return false;
-            
-        return texto.Length > maxLength && GetAccordionConfig().ShowExpandButton;
-    }
+        try
+        {
+            if (string.IsNullOrWhiteSpace(texto))
+                return string.Empty;
 
-    public string GetExpandButtonText()
-    {
-        return GetAccordionConfig().ExpandButtonText;
-    }
-
-    public string FormatarTextoCompleto(string prefixo, string texto)
-    {
-        if (string.IsNullOrEmpty(prefixo) || string.IsNullOrEmpty(texto))
+            return $"[{prefixo}] {texto}";
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "FormatarTextoComPrefixo" },
+                { "Component", "AccordionHelper" },
+                { "Prefixo", prefixo }
+            });
             return texto ?? string.Empty;
-            
-        return $"[{prefixo}] {texto}";
+        }
     }
 
-    public AccordionItem CriarAccordionItem(string id, string titulo, string conteudo, bool isExpanded = false)
+    public bool IsTextoVazio(string? texto)
     {
-        var config = GetAccordionConfig();
-        
-        return new AccordionItem
-        {
-            Id = id,
-            Titulo = titulo,
-            TituloTruncado = TruncarTexto(titulo, config.MaxTextLength),
-            Conteudo = conteudo,
-            IsExpanded = isExpanded,
-            ShowExpandButton = ShouldShowExpandButton(titulo, config.MaxTextLength),
-            ExpandButtonText = GetExpandButtonText()
-        };
+        return string.IsNullOrWhiteSpace(texto);
     }
 
-    public List<AccordionItem> CriarAccordionsPerformance(int idPerformance, string abaixo, string esperado, string acima)
+    public int GetTamanhoMaximoPadrao()
     {
-        var items = new List<AccordionItem>();
-        var config = GetAccordionConfig();
+        return _configuration.GetValue<int>("AutoAvaliacao:MaxCompetenciaLength", 70);
+    }
 
-        if (!string.IsNullOrEmpty(abaixo))
-        {
-            items.Add(new AccordionItem
-            {
-                Id = GerarIdAccordion("abaixo", idPerformance),
-                Titulo = TruncarTexto(abaixo, config.MaxTextLength),
-                Conteudo = FormatarTextoCompleto("Abaixo", abaixo),
-                ShowExpandButton = ShouldShowExpandButton(abaixo, config.MaxTextLength),
-                ExpandButtonText = GetExpandButtonText()
-            });
-        }
-
-        if (!string.IsNullOrEmpty(esperado))
-        {
-            items.Add(new AccordionItem
-            {
-                Id = GerarIdAccordion("esperado", idPerformance),
-                Titulo = TruncarTexto(esperado, config.MaxTextLength),
-                Conteudo = FormatarTextoCompleto("Esperado", esperado),
-                ShowExpandButton = ShouldShowExpandButton(esperado, config.MaxTextLength),
-                ExpandButtonText = GetExpandButtonText()
-            });
-        }
-
-        if (!string.IsNullOrEmpty(acima))
-        {
-            items.Add(new AccordionItem
-            {
-                Id = GerarIdAccordion("acima", idPerformance),
-                Titulo = TruncarTexto(acima, config.MaxTextLength),
-                Conteudo = FormatarTextoCompleto("Acima", acima),
-                ShowExpandButton = ShouldShowExpandButton(acima, config.MaxTextLength),
-                ExpandButtonText = GetExpandButtonText()
-            });
-        }
-
-        _telemetryService.TrackEvent("AccordionItemsCreated", new Dictionary<string, string>
-        {
-            { "IdPerformance", idPerformance.ToString() },
-            { "ItemsCount", items.Count.ToString() }
-        });
-
-        return items;
+    public string GetTextoVerMaisPadrao()
+    {
+        return _configuration.GetValue<string>("AutoAvaliacao:VerMaisTexto", "Ver+") ?? "Ver+";
     }
 }
 
 public class AccordionConfig
 {
-    public int MaxTextLength { get; set; } = 70;
-    public bool ShowExpandButton { get; set; } = true;
-    public string ExpandButtonText { get; set; } = "Ver+";
-    public bool EnableAccordions { get; set; } = true;
-    public bool EnableStickyHeaders { get; set; } = true;
+    public int TamanhoMaximo { get; set; } = 70;
+    public string TextoVerMais { get; set; } = "Ver+";
+    public bool HabilitarAccordions { get; set; } = true;
+    public bool ExibirBotaoExpandir { get; set; } = true;
+    public bool HabilitarCabecalhoFixo { get; set; } = true;
 }
 
-public class AccordionItem
+public static class AccordionExtensions
 {
-    public string Id { get; set; } = string.Empty;
-    public string Titulo { get; set; } = string.Empty;
-    public string TituloTruncado { get; set; } = string.Empty;
-    public string Conteudo { get; set; } = string.Empty;
-    public bool IsExpanded { get; set; } = false;
-    public bool ShowExpandButton { get; set; } = false;
-    public string ExpandButtonText { get; set; } = "Ver+";
-    public string CssClass { get; set; } = string.Empty;
-    public string TargetId => $"#{Id}";
-    public string DataTarget => $"#{Id}";
-    public string AriaExpanded => IsExpanded ? "true" : "false";
-    public string CollapseClass => IsExpanded ? "collapse show" : "collapse";
+    public static string ToAccordionId(this string prefixo, int id)
+    {
+        return $"{prefixo}_{id}";
+    }
+
+    public static string ToAccordionTarget(this string id)
+    {
+        return $"#{id}";
+    }
+
+    public static bool ShouldTruncate(this string? texto, int tamanhoMaximo)
+    {
+        return !string.IsNullOrWhiteSpace(texto) && texto.Length > tamanhoMaximo;
+    }
+
+    public static string TruncateWithEllipsis(this string? texto, int tamanhoMaximo)
+    {
+        if (string.IsNullOrWhiteSpace(texto) || texto.Length <= tamanhoMaximo)
+            return texto ?? string.Empty;
+
+        return texto.Substring(0, tamanhoMaximo) + "...";
+    }
+
+    public static Dictionary<string, object> ToBootstrapAccordionAttributes(this string targetId, bool isExpanded = false)
+    {
+        return new Dictionary<string, object>
+        {
+            { "data-toggle", "collapse" },
+            { "data-target", targetId.StartsWith("#") ? targetId : $"#{targetId}" },
+            { "aria-expanded", isExpanded.ToString().ToLower() },
+            { "aria-controls", targetId.TrimStart('#') },
+            { "class", "accordion-toggle" }
+        };
+    }
 }

--- a/Services/AutoAvaliacao/Common/NotaHelper.cs
+++ b/Services/AutoAvaliacao/Common/NotaHelper.cs
@@ -1,5 +1,6 @@
 using Peers.Moderno.Models;
 using Peers.Moderno.Services.Common;
+using Microsoft.Extensions.Configuration;
 
 namespace Peers.Moderno.Services.AutoAvaliacao.Common;
 
@@ -12,75 +13,99 @@ public interface INotaHelper
     bool IsNotaSelecionar(int? nota);
     string GetNotaTexto(int? nota);
     string GetNotaCssClass(int? nota);
-    bool ValidarNotaObrigatoria(int? nota, bool isRequired = true);
     bool ValidarNotasConsistencia(int? notaNivel1, int? notaNivel2);
-    void AjustarNotaNaoSeAplica(ref int? notaNivel1, ref int? notaNivel2);
-    bool HasNotasMensuravelPorPilar(List<int?> notasNivel1, List<int?> notasNivel2);
-    bool ValidarPreenchimentoCompleto(List<int?> notas, bool allowNaoSeAplica = true);
+    bool ValidarNotasObrigatorias(List<int?> notas);
+    bool ValidarPilarPreenchido(List<int?> notas);
     int GetNotaPadraoAutoAvaliacao();
     int GetNotaPadraoAvaliacaoAsCegas();
     int GetNotaPadraoAvaliacaoGestor();
     int GetIdNotaNaoSeAplica();
     int GetIdNotaSelecionar();
+    void RemoverOpcaoSelecionar(List<ComboItem> items);
+    bool ShouldRemoveSelecionar(int? notaAtual);
+    Dictionary<string, object> GetNotaValidationResult(List<int?> notas, string contexto);
 }
 
 public class NotaHelper : INotaHelper
 {
-    private readonly ITelemetryService _telemetryService;
     private readonly IConfiguration _configuration;
-    
-    private const int ID_NOTA_NAO_SE_APLICA = 5;
-    private const int ID_NOTA_SELECIONAR = 0;
-    private const int NOTA_PADRAO_AUTO_AVALIACAO = 1;
-    private const int NOTA_PADRAO_AVALIACAO_AS_CEGAS = 1;
-    private const int NOTA_PADRAO_AVALIACAO_GESTOR = 1;
+    private readonly ITelemetryService _telemetryService;
+    private readonly IMessageBoxService _messageBoxService;
 
-    public NotaHelper(ITelemetryService telemetryService, IConfiguration configuration)
+    public NotaHelper(
+        IConfiguration configuration,
+        ITelemetryService telemetryService,
+        IMessageBoxService messageBoxService)
     {
-        _telemetryService = telemetryService;
         _configuration = configuration;
+        _telemetryService = telemetryService;
+        _messageBoxService = messageBoxService;
     }
 
     public List<ComboItem> GetNotasPerformanceItems(bool includeSelecionar = true)
     {
-        var items = new List<ComboItem>();
-        
-        if (includeSelecionar)
+        try
         {
-            items.Add(new ComboItem { Value = "0", Text = "[Selecionar]", IsDisabled = true });
+            var items = new List<ComboItem>();
+
+            if (includeSelecionar)
+            {
+                items.Add(new ComboItem { Value = "0", Text = "[Selecionar]", IsDisabled = true });
+            }
+
+            items.AddRange(new List<ComboItem>
+            {
+                new ComboItem { Value = "1", Text = "1" },
+                new ComboItem { Value = "2", Text = "2" },
+                new ComboItem { Value = "3", Text = "3" },
+                new ComboItem { Value = "4", Text = "4" },
+                new ComboItem { Value = "5", Text = "Não se aplica" }
+            });
+
+            return items;
         }
-        
-        items.AddRange(new List<ComboItem>
+        catch (Exception ex)
         {
-            new ComboItem { Value = "1", Text = "1" },
-            new ComboItem { Value = "2", Text = "2" },
-            new ComboItem { Value = "3", Text = "3" },
-            new ComboItem { Value = "4", Text = "4" },
-            new ComboItem { Value = "5", Text = "Não se aplica" }
-        });
-        
-        return items;
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetNotasPerformanceItems" },
+                { "Component", "NotaHelper" }
+            });
+            return new List<ComboItem>();
+        }
     }
 
     public List<ComboItem> GetNotasCompetenciaItems(bool includeSelecionar = true)
     {
-        var items = new List<ComboItem>();
-        
-        if (includeSelecionar)
+        try
         {
-            items.Add(new ComboItem { Value = "0", Text = "[Selecionar]", IsDisabled = true });
+            var items = new List<ComboItem>();
+
+            if (includeSelecionar)
+            {
+                items.Add(new ComboItem { Value = "0", Text = "[Selecionar]", IsDisabled = true });
+            }
+
+            items.AddRange(new List<ComboItem>
+            {
+                new ComboItem { Value = "1", Text = "1" },
+                new ComboItem { Value = "2", Text = "2" },
+                new ComboItem { Value = "3", Text = "3" },
+                new ComboItem { Value = "4", Text = "4" },
+                new ComboItem { Value = "5", Text = "Não se aplica" }
+            });
+
+            return items;
         }
-        
-        items.AddRange(new List<ComboItem>
+        catch (Exception ex)
         {
-            new ComboItem { Value = "1", Text = "1" },
-            new ComboItem { Value = "2", Text = "2" },
-            new ComboItem { Value = "3", Text = "3" },
-            new ComboItem { Value = "4", Text = "4" },
-            new ComboItem { Value = "5", Text = "Não se aplica" }
-        });
-        
-        return items;
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetNotasCompetenciaItems" },
+                { "Component", "NotaHelper" }
+            });
+            return new List<ComboItem>();
+        }
     }
 
     public bool IsNotaValida(int? nota)
@@ -90,116 +115,239 @@ public class NotaHelper : INotaHelper
 
     public bool IsNotaNaoSeAplica(int? nota)
     {
-        return nota.HasValue && nota.Value == ID_NOTA_NAO_SE_APLICA;
+        return nota.HasValue && nota.Value == GetIdNotaNaoSeAplica();
     }
 
     public bool IsNotaSelecionar(int? nota)
     {
-        return !nota.HasValue || nota.Value == ID_NOTA_SELECIONAR;
+        return !nota.HasValue || nota.Value == GetIdNotaSelecionar();
     }
 
     public string GetNotaTexto(int? nota)
     {
-        if (!nota.HasValue || nota.Value == ID_NOTA_SELECIONAR)
+        if (!nota.HasValue || nota.Value == 0)
             return "[Selecionar]";
-            
-        return nota.Value == ID_NOTA_NAO_SE_APLICA ? "Não se aplica" : nota.Value.ToString();
+
+        return nota.Value switch
+        {
+            1 => "1",
+            2 => "2",
+            3 => "3",
+            4 => "4",
+            5 => "Não se aplica",
+            _ => "[Selecionar]"
+        };
     }
 
     public string GetNotaCssClass(int? nota)
     {
-        if (!IsNotaValida(nota))
-            return "text-muted";
-            
+        if (!nota.HasValue || nota.Value == 0)
+            return "form-control text-muted";
+
         return nota.Value switch
         {
-            1 => "text-danger",
-            2 => "text-warning",
-            3 => "text-info",
-            4 => "text-success",
-            5 => "text-secondary",
-            _ => "text-muted"
+            1 => "form-control text-danger",
+            2 => "form-control text-warning",
+            3 => "form-control text-info",
+            4 => "form-control text-success",
+            5 => "form-control text-secondary",
+            _ => "form-control"
         };
-    }
-
-    public bool ValidarNotaObrigatoria(int? nota, bool isRequired = true)
-    {
-        if (!isRequired)
-            return true;
-            
-        return IsNotaValida(nota);
     }
 
     public bool ValidarNotasConsistencia(int? notaNivel1, int? notaNivel2)
     {
-        if (!IsNotaValida(notaNivel1) || !IsNotaValida(notaNivel2))
-            return true;
-            
-        if (IsNotaNaoSeAplica(notaNivel1))
-            return IsNotaNaoSeAplica(notaNivel2);
-            
-        return notaNivel2.Value <= notaNivel1.Value;
-    }
-
-    public void AjustarNotaNaoSeAplica(ref int? notaNivel1, ref int? notaNivel2)
-    {
-        if (IsNotaNaoSeAplica(notaNivel1) && !IsNotaNaoSeAplica(notaNivel2))
+        try
         {
-            notaNivel2 = ID_NOTA_NAO_SE_APLICA;
-            
-            _telemetryService.TrackEvent("NotaAjustadaNaoSeAplica", new Dictionary<string, string>
+            if (!notaNivel1.HasValue || !notaNivel2.HasValue)
+                return true;
+
+            if (IsNotaNaoSeAplica(notaNivel1) && !IsNotaNaoSeAplica(notaNivel2))
             {
-                { "NotaNivel1", notaNivel1.ToString() },
-                { "NotaNivel2Original", notaNivel2.ToString() },
-                { "NotaNivel2Ajustada", ID_NOTA_NAO_SE_APLICA.ToString() }
-            });
+                _messageBoxService.ShowWarning(_configuration["AutoAvaliacao:ValidationMessages:NotaNaoSeAplicaInconsistente"] ?? 
+                    "ATENÇÃO ! Avaliação de Competência com inconsistência. (Detalhe: quando a nota de Competência do Nivel Atual for = Não Se Aplica, o Próximo Nivel deve ser Não Se Aplica). O Sistema ajustou sua avaliação. Favor revalidar sua avaliação !!");
+                return false;
+            }
+
+            if (notaNivel2.Value > notaNivel1.Value && !IsNotaNaoSeAplica(notaNivel1) && !IsNotaNaoSeAplica(notaNivel2))
+            {
+                _messageBoxService.ShowError(_configuration["AutoAvaliacao:ValidationMessages:NotasInconsistentes"] ?? 
+                    "Existem Avaliações de Competências inconsistentes. A nota do nível 2 (próximo nível) não pode ser maior que a nota do nível 1 (nível atual).");
+                return false;
+            }
+
+            return true;
         }
-    }
-
-    public bool HasNotasMensuravelPorPilar(List<int?> notasNivel1, List<int?> notasNivel2)
-    {
-        var notasMensuravelNivel1 = notasNivel1.Count(n => IsNotaValida(n) && !IsNotaNaoSeAplica(n));
-        var notasMensuravelNivel2 = notasNivel2.Count(n => IsNotaValida(n) && !IsNotaNaoSeAplica(n));
-        
-        return notasMensuravelNivel1 > 0 && notasMensuravelNivel2 > 0;
-    }
-
-    public bool ValidarPreenchimentoCompleto(List<int?> notas, bool allowNaoSeAplica = true)
-    {
-        foreach (var nota in notas)
+        catch (Exception ex)
         {
-            if (IsNotaSelecionar(nota))
-                return false;
-                
-            if (!allowNaoSeAplica && IsNotaNaoSeAplica(nota))
-                return false;
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarNotasConsistencia" },
+                { "Component", "NotaHelper" },
+                { "NotaNivel1", notaNivel1?.ToString() ?? "null" },
+                { "NotaNivel2", notaNivel2?.ToString() ?? "null" }
+            });
+            return false;
         }
-        
-        return true;
+    }
+
+    public bool ValidarNotasObrigatorias(List<int?> notas)
+    {
+        try
+        {
+            var notasInvalidas = notas.Where(n => IsNotaSelecionar(n)).Count();
+            
+            if (notasInvalidas > 0)
+            {
+                _messageBoxService.ShowError(_configuration["AutoAvaliacao:ValidationMessages:NotasObrigatorias"] ?? 
+                    "É obrigatório selecionar uma nota para cada nível.");
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarNotasObrigatorias" },
+                { "Component", "NotaHelper" },
+                { "TotalNotas", notas.Count.ToString() }
+            });
+            return false;
+        }
+    }
+
+    public bool ValidarPilarPreenchido(List<int?> notas)
+    {
+        try
+        {
+            var notasMensuráveis = notas.Where(n => IsNotaValida(n) && !IsNotaNaoSeAplica(n)).Count();
+            
+            if (notasMensuráveis == 0)
+            {
+                _messageBoxService.ShowError(_configuration["AutoAvaliacao:ValidationMessages:PilarVazio"] ?? 
+                    "Cada pilar precisa receber ao mínimo 1 nota mensurável em cada nível (diferente de não se aplica)");
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarPilarPreenchido" },
+                { "Component", "NotaHelper" },
+                { "TotalNotas", notas.Count.ToString() }
+            });
+            return false;
+        }
     }
 
     public int GetNotaPadraoAutoAvaliacao()
     {
-        return _configuration.GetValue("AutoAvaliacao:NotasPadrao:AutoAvaliacao", NOTA_PADRAO_AUTO_AVALIACAO);
+        return _configuration.GetValue<int>("AutoAvaliacao:NotasPadrao:NotaPadraoAutoAvaliacao", 1);
     }
 
     public int GetNotaPadraoAvaliacaoAsCegas()
     {
-        return _configuration.GetValue("AutoAvaliacao:NotasPadrao:AvaliacaoAsCegas", NOTA_PADRAO_AVALIACAO_AS_CEGAS);
+        return _configuration.GetValue<int>("AutoAvaliacao:NotasPadrao:NotaPadraoAvaliacaoAsCegas", 1);
     }
 
     public int GetNotaPadraoAvaliacaoGestor()
     {
-        return _configuration.GetValue("AutoAvaliacao:NotasPadrao:AvaliacaoGestor", NOTA_PADRAO_AVALIACAO_GESTOR);
+        return _configuration.GetValue<int>("AutoAvaliacao:NotasPadrao:NotaPadraoAvaliacaoGestor", 1);
     }
 
     public int GetIdNotaNaoSeAplica()
     {
-        return _configuration.GetValue("AutoAvaliacao:NotasPadrao:IdNotaNaoSeAplica", ID_NOTA_NAO_SE_APLICA);
+        return _configuration.GetValue<int>("AutoAvaliacao:NotasPadrao:IdNotaNaoSeAplica", 5);
     }
 
     public int GetIdNotaSelecionar()
     {
-        return _configuration.GetValue("AutoAvaliacao:NotasPadrao:IdNotaSelecionar", ID_NOTA_SELECIONAR);
+        return _configuration.GetValue<int>("AutoAvaliacao:NotasPadrao:IdNotaSelecionar", 0);
+    }
+
+    public void RemoverOpcaoSelecionar(List<ComboItem> items)
+    {
+        try
+        {
+            var selecionarItem = items.FirstOrDefault(i => i.Value == "0" && i.Text == "[Selecionar]");
+            if (selecionarItem != null)
+            {
+                items.Remove(selecionarItem);
+            }
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "RemoverOpcaoSelecionar" },
+                { "Component", "NotaHelper" }
+            });
+        }
+    }
+
+    public bool ShouldRemoveSelecionar(int? notaAtual)
+    {
+        return IsNotaValida(notaAtual) && !IsNotaSelecionar(notaAtual);
+    }
+
+    public Dictionary<string, object> GetNotaValidationResult(List<int?> notas, string contexto)
+    {
+        try
+        {
+            var result = new Dictionary<string, object>
+            {
+                { "IsValid", true },
+                { "Errors", new List<string>() },
+                { "Warnings", new List<string>() },
+                { "Context", contexto }
+            };
+
+            var errors = (List<string>)result["Errors"];
+            var warnings = (List<string>)result["Warnings"];
+
+            if (!ValidarNotasObrigatorias(notas))
+            {
+                result["IsValid"] = false;
+                errors.Add("Notas obrigatórias não preenchidas");
+            }
+
+            if (!ValidarPilarPreenchido(notas))
+            {
+                result["IsValid"] = false;
+                errors.Add("Pilar sem notas mensuráveis");
+            }
+
+            _telemetryService.TrackEvent("NotaValidationCompleted", new Dictionary<string, string>
+            {
+                { "Context", contexto },
+                { "IsValid", result["IsValid"].ToString() },
+                { "ErrorCount", errors.Count.ToString() },
+                { "WarningCount", warnings.Count.ToString() }
+            });
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetNotaValidationResult" },
+                { "Component", "NotaHelper" },
+                { "Context", contexto }
+            });
+            
+            return new Dictionary<string, object>
+            {
+                { "IsValid", false },
+                { "Errors", new List<string> { "Erro interno na validação" } },
+                { "Warnings", new List<string>() },
+                { "Context", contexto }
+            };
+        }
     }
 }

--- a/Services/AutoAvaliacao/Common/ValidationHelper.cs
+++ b/Services/AutoAvaliacao/Common/ValidationHelper.cs
@@ -1,246 +1,469 @@
 using Peers.Moderno.Services.Common;
+using Microsoft.Extensions.Configuration;
 
 namespace Peers.Moderno.Services.AutoAvaliacao.Common;
 
 public interface IValidationHelper
 {
-    ValidationResult ValidarParametrosObrigatorios(int? idProjeto, int? idAssociado, int? idPeriodo);
-    ValidationResult ValidarAvaliacaoCompleta(List<int?> notasCompetencia, List<int?> notasPerformance, bool requireAllFilled = true);
-    ValidationResult ValidarConsistenciaNotas(List<(int? nivel1, int? nivel2)> paresNotas);
-    ValidationResult ValidarPilaresPreenchidos(Dictionary<string, List<int?>> notasPorPilar);
-    ValidationResult ValidarPermissaoEdicao(bool isFinalized, bool hasPermission);
-    ValidationResult ValidarTempoRestante(DateTime? dataLimite);
+    ValidationResult ValidarProjetoObrigatorio(int? idProjeto);
+    ValidationResult ValidarAssociadoObrigatorio(int? idAssociado);
+    ValidationResult ValidarPeriodoObrigatorio(int? idPeriodo);
+    ValidationResult ValidarGestorObrigatorio(int? idGestor);
+    ValidationResult ValidarTipoAvaliacaoObrigatorio(string? tipoAvaliacao);
+    ValidationResult ValidarEscopoObrigatorio(string? escopo);
+    ValidationResult ValidarCompetenciasPreenchidas(List<int?> notas);
+    ValidationResult ValidarPerformancesPreenchidas(List<int?> notas);
+    ValidationResult ValidarPermissaoUsuario(int userProfileId, int minProfileRequired);
+    ValidationResult ValidarAvaliacaoFinalizada(bool isFinalizada);
+    ValidationResult ValidarPrazosAvaliacao(DateTime? dataInicio, DateTime? dataFim);
+    ValidationResult ValidarContextoAvaliacao(int? idProjeto, int? idAssociado, int? idPeriodo);
+    List<ValidationResult> ValidarTodosRequisitos(ValidationContext context);
     string GetMensagemValidacao(string chave, params object[] parametros);
-    bool IsValidationEnabled();
 }
 
 public class ValidationHelper : IValidationHelper
 {
     private readonly IConfiguration _configuration;
     private readonly ITelemetryService _telemetryService;
-    private readonly INotaHelper _notaHelper;
+    private readonly IMessageBoxService _messageBoxService;
+    private readonly IUserContextService _userContextService;
 
     public ValidationHelper(
         IConfiguration configuration,
         ITelemetryService telemetryService,
-        INotaHelper notaHelper)
+        IMessageBoxService messageBoxService,
+        IUserContextService userContextService)
     {
         _configuration = configuration;
         _telemetryService = telemetryService;
-        _notaHelper = notaHelper;
+        _messageBoxService = messageBoxService;
+        _userContextService = userContextService;
     }
 
-    public ValidationResult ValidarParametrosObrigatorios(int? idProjeto, int? idAssociado, int? idPeriodo)
+    public ValidationResult ValidarProjetoObrigatorio(int? idProjeto)
     {
-        var errors = new List<string>();
-
-        if (!idProjeto.HasValue || idProjeto.Value <= 0)
+        try
         {
-            errors.Add(GetMensagemValidacao("ProjetoObrigatorio"));
-        }
-
-        if (!idAssociado.HasValue || idAssociado.Value <= 0)
-        {
-            errors.Add(GetMensagemValidacao("AssociadoObrigatorio"));
-        }
-
-        if (!idPeriodo.HasValue || idPeriodo.Value <= 0)
-        {
-            errors.Add(GetMensagemValidacao("PeriodoObrigatorio"));
-        }
-
-        if (errors.Any())
-        {
-            _telemetryService.TrackEvent("ValidationError_ParametrosObrigatorios", new Dictionary<string, string>
+            if (!idProjeto.HasValue || idProjeto.Value <= 0)
             {
-                { "ErrorCount", errors.Count.ToString() },
-                { "IdProjeto", idProjeto?.ToString() ?? "null" },
-                { "IdAssociado", idAssociado?.ToString() ?? "null" },
-                { "IdPeriodo", idPeriodo?.ToString() ?? "null" }
-            });
-
-            return ValidationResult.Error(string.Join("; ", errors));
-        }
-
-        return ValidationResult.Success();
-    }
-
-    public ValidationResult ValidarAvaliacaoCompleta(List<int?> notasCompetencia, List<int?> notasPerformance, bool requireAllFilled = true)
-    {
-        var errors = new List<string>();
-
-        if (requireAllFilled)
-        {
-            if (!_notaHelper.ValidarPreenchimentoCompleto(notasCompetencia, true))
-            {
-                errors.Add(GetMensagemValidacao("CompetenciasNaoPreenchidas"));
+                var mensagem = GetMensagemValidacao("ProjetoObrigatorio");
+                _messageBoxService.ShowInfo(mensagem);
+                return ValidationResult.Error(mensagem);
             }
 
-            if (!_notaHelper.ValidarPreenchimentoCompleto(notasPerformance, true))
-            {
-                errors.Add(GetMensagemValidacao("PerformancesNaoPreenchidas"));
-            }
-        }
-
-        if (!notasCompetencia.Any())
-        {
-            errors.Add(GetMensagemValidacao("CompetenciasNaoParametrizadas"));
-        }
-
-        if (!notasPerformance.Any())
-        {
-            errors.Add(GetMensagemValidacao("PerformancesNaoParametrizadas"));
-        }
-
-        if (errors.Any())
-        {
-            _telemetryService.TrackEvent("ValidationError_AvaliacaoIncompleta", new Dictionary<string, string>
-            {
-                { "ErrorCount", errors.Count.ToString() },
-                { "CompetenciasCount", notasCompetencia.Count.ToString() },
-                { "PerformancesCount", notasPerformance.Count.ToString() }
-            });
-
-            return ValidationResult.Error(string.Join("; ", errors));
-        }
-
-        return ValidationResult.Success();
-    }
-
-    public ValidationResult ValidarConsistenciaNotas(List<(int? nivel1, int? nivel2)> paresNotas)
-    {
-        var inconsistencias = new List<string>();
-        var ajustesNecessarios = new List<string>();
-
-        foreach (var (nivel1, nivel2) in paresNotas)
-        {
-            if (!_notaHelper.ValidarNotasConsistencia(nivel1, nivel2))
-            {
-                inconsistencias.Add($"Nota Nível 1: {_notaHelper.GetNotaTexto(nivel1)}, Nível 2: {_notaHelper.GetNotaTexto(nivel2)}");
-            }
-
-            if (_notaHelper.IsNotaNaoSeAplica(nivel1) && !_notaHelper.IsNotaNaoSeAplica(nivel2))
-            {
-                ajustesNecessarios.Add($"Ajuste necessário: Nível 1 = Não se aplica, Nível 2 deve ser Não se aplica");
-            }
-        }
-
-        if (inconsistencias.Any())
-        {
-            _telemetryService.TrackEvent("ValidationError_NotasInconsistentes", new Dictionary<string, string>
-            {
-                { "InconsistenciasCount", inconsistencias.Count.ToString() },
-                { "AjustesCount", ajustesNecessarios.Count.ToString() }
-            });
-
-            var errorMessage = GetMensagemValidacao("NotasInconsistentes");
-            if (ajustesNecessarios.Any())
-            {
-                errorMessage += " " + GetMensagemValidacao("NotaNaoSeAplicaInconsistente");
-            }
-
-            return ValidationResult.Error(errorMessage);
-        }
-
-        return ValidationResult.Success();
-    }
-
-    public ValidationResult ValidarPilaresPreenchidos(Dictionary<string, List<int?>> notasPorPilar)
-    {
-        var pilaresVazios = new List<string>();
-
-        foreach (var pilar in notasPorPilar)
-        {
-            var notasMensuravelNivel1 = pilar.Value.Count(n => _notaHelper.IsNotaValida(n) && !_notaHelper.IsNotaNaoSeAplica(n));
-            
-            if (notasMensuravelNivel1 == 0)
-            {
-                pilaresVazios.Add(pilar.Key);
-            }
-        }
-
-        if (pilaresVazios.Any())
-        {
-            _telemetryService.TrackEvent("ValidationError_PilaresVazios", new Dictionary<string, string>
-            {
-                { "PilaresVaziosCount", pilaresVazios.Count.ToString() },
-                { "PilaresVazios", string.Join(", ", pilaresVazios) }
-            });
-
-            return ValidationResult.Error(GetMensagemValidacao("PilarVazio"));
-        }
-
-        return ValidationResult.Success();
-    }
-
-    public ValidationResult ValidarPermissaoEdicao(bool isFinalized, bool hasPermission)
-    {
-        if (isFinalized)
-        {
-            return ValidationResult.Error("Avaliação já foi finalizada e não pode ser editada.");
-        }
-
-        if (!hasPermission)
-        {
-            return ValidationResult.Error(GetMensagemValidacao("PermissaoNegada"));
-        }
-
-        return ValidationResult.Success();
-    }
-
-    public ValidationResult ValidarTempoRestante(DateTime? dataLimite)
-    {
-        if (!dataLimite.HasValue)
-        {
             return ValidationResult.Success();
         }
-
-        if (DateTime.Now > dataLimite.Value)
+        catch (Exception ex)
         {
-            return ValidationResult.Warning("Prazo da avaliação expirado. Utilize o período de compensação se disponível.");
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarProjetoObrigatorio" },
+                { "Component", "ValidationHelper" },
+                { "IdProjeto", idProjeto?.ToString() ?? "null" }
+            });
+            return ValidationResult.Error("Erro interno na validação do projeto");
         }
+    }
 
-        var tempoRestante = dataLimite.Value - DateTime.Now;
-        if (tempoRestante.TotalHours < 24)
+    public ValidationResult ValidarAssociadoObrigatorio(int? idAssociado)
+    {
+        try
         {
-            return ValidationResult.Warning($"Atenção: Restam apenas {tempoRestante.TotalHours:F1} horas para finalizar a avaliação.");
-        }
+            if (!idAssociado.HasValue || idAssociado.Value <= 0)
+            {
+                var mensagem = GetMensagemValidacao("AssociadoObrigatorio");
+                _messageBoxService.ShowInfo(mensagem);
+                return ValidationResult.Error(mensagem);
+            }
 
-        return ValidationResult.Success();
+            return ValidationResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarAssociadoObrigatorio" },
+                { "Component", "ValidationHelper" },
+                { "IdAssociado", idAssociado?.ToString() ?? "null" }
+            });
+            return ValidationResult.Error("Erro interno na validação do associado");
+        }
+    }
+
+    public ValidationResult ValidarPeriodoObrigatorio(int? idPeriodo)
+    {
+        try
+        {
+            if (!idPeriodo.HasValue || idPeriodo.Value <= 0)
+            {
+                var mensagem = GetMensagemValidacao("PeriodoObrigatorio");
+                _messageBoxService.ShowInfo(mensagem);
+                return ValidationResult.Error(mensagem);
+            }
+
+            return ValidationResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarPeriodoObrigatorio" },
+                { "Component", "ValidationHelper" },
+                { "IdPeriodo", idPeriodo?.ToString() ?? "null" }
+            });
+            return ValidationResult.Error("Erro interno na validação do período");
+        }
+    }
+
+    public ValidationResult ValidarGestorObrigatorio(int? idGestor)
+    {
+        try
+        {
+            if (!idGestor.HasValue || idGestor.Value <= 0)
+            {
+                var mensagem = GetMensagemValidacao("GestorObrigatorio");
+                _messageBoxService.ShowInfo(mensagem);
+                return ValidationResult.Error(mensagem);
+            }
+
+            return ValidationResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarGestorObrigatorio" },
+                { "Component", "ValidationHelper" },
+                { "IdGestor", idGestor?.ToString() ?? "null" }
+            });
+            return ValidationResult.Error("Erro interno na validação do gestor");
+        }
+    }
+
+    public ValidationResult ValidarTipoAvaliacaoObrigatorio(string? tipoAvaliacao)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(tipoAvaliacao))
+            {
+                var mensagem = GetMensagemValidacao("TipoAvaliacaoObrigatorio");
+                _messageBoxService.ShowInfo(mensagem);
+                return ValidationResult.Error(mensagem);
+            }
+
+            return ValidationResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarTipoAvaliacaoObrigatorio" },
+                { "Component", "ValidationHelper" },
+                { "TipoAvaliacao", tipoAvaliacao ?? "null" }
+            });
+            return ValidationResult.Error("Erro interno na validação do tipo de avaliação");
+        }
+    }
+
+    public ValidationResult ValidarEscopoObrigatorio(string? escopo)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(escopo))
+            {
+                var mensagem = GetMensagemValidacao("EscopoObrigatorio");
+                _messageBoxService.ShowInfo(mensagem);
+                return ValidationResult.Error(mensagem);
+            }
+
+            return ValidationResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarEscopoObrigatorio" },
+                { "Component", "ValidationHelper" },
+                { "Escopo", escopo ?? "null" }
+            });
+            return ValidationResult.Error("Erro interno na validação do escopo");
+        }
+    }
+
+    public ValidationResult ValidarCompetenciasPreenchidas(List<int?> notas)
+    {
+        try
+        {
+            var notasVazias = notas.Where(n => !n.HasValue || n.Value == 0).Count();
+            
+            if (notasVazias > 0)
+            {
+                var mensagem = GetMensagemValidacao("CompetenciasNaoPreenchidas");
+                _messageBoxService.ShowError(mensagem);
+                return ValidationResult.Error(mensagem);
+            }
+
+            return ValidationResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarCompetenciasPreenchidas" },
+                { "Component", "ValidationHelper" },
+                { "TotalNotas", notas.Count.ToString() }
+            });
+            return ValidationResult.Error("Erro interno na validação das competências");
+        }
+    }
+
+    public ValidationResult ValidarPerformancesPreenchidas(List<int?> notas)
+    {
+        try
+        {
+            var notasVazias = notas.Where(n => !n.HasValue || n.Value == 0).Count();
+            
+            if (notasVazias > 0)
+            {
+                var mensagem = GetMensagemValidacao("PerformancesNaoPreenchidas");
+                _messageBoxService.ShowError(mensagem);
+                return ValidationResult.Error(mensagem);
+            }
+
+            return ValidationResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarPerformancesPreenchidas" },
+                { "Component", "ValidationHelper" },
+                { "TotalNotas", notas.Count.ToString() }
+            });
+            return ValidationResult.Error("Erro interno na validação das performances");
+        }
+    }
+
+    public ValidationResult ValidarPermissaoUsuario(int userProfileId, int minProfileRequired)
+    {
+        try
+        {
+            if (userProfileId < minProfileRequired)
+            {
+                var mensagem = GetMensagemValidacao("PermissaoNegada");
+                _messageBoxService.ShowError(mensagem);
+                return ValidationResult.Error(mensagem);
+            }
+
+            return ValidationResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarPermissaoUsuario" },
+                { "Component", "ValidationHelper" },
+                { "UserProfileId", userProfileId.ToString() },
+                { "MinProfileRequired", minProfileRequired.ToString() }
+            });
+            return ValidationResult.Error("Erro interno na validação de permissão");
+        }
+    }
+
+    public ValidationResult ValidarAvaliacaoFinalizada(bool isFinalizada)
+    {
+        try
+        {
+            if (isFinalizada)
+            {
+                var mensagem = "Avaliação já foi finalizada e não pode ser alterada";
+                _messageBoxService.ShowWarning(mensagem);
+                return ValidationResult.Error(mensagem);
+            }
+
+            return ValidationResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarAvaliacaoFinalizada" },
+                { "Component", "ValidationHelper" },
+                { "IsFinalizada", isFinalizada.ToString() }
+            });
+            return ValidationResult.Error("Erro interno na validação do status da avaliação");
+        }
+    }
+
+    public ValidationResult ValidarPrazosAvaliacao(DateTime? dataInicio, DateTime? dataFim)
+    {
+        try
+        {
+            var agora = DateTime.Now;
+
+            if (dataInicio.HasValue && agora < dataInicio.Value)
+            {
+                var mensagem = "Avaliação ainda não foi liberada";
+                _messageBoxService.ShowWarning(mensagem);
+                return ValidationResult.Error(mensagem);
+            }
+
+            if (dataFim.HasValue && agora > dataFim.Value)
+            {
+                var mensagem = "Prazo para avaliação expirado";
+                _messageBoxService.ShowWarning(mensagem);
+                return ValidationResult.Error(mensagem);
+            }
+
+            return ValidationResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarPrazosAvaliacao" },
+                { "Component", "ValidationHelper" },
+                { "DataInicio", dataInicio?.ToString() ?? "null" },
+                { "DataFim", dataFim?.ToString() ?? "null" }
+            });
+            return ValidationResult.Error("Erro interno na validação dos prazos");
+        }
+    }
+
+    public ValidationResult ValidarContextoAvaliacao(int? idProjeto, int? idAssociado, int? idPeriodo)
+    {
+        try
+        {
+            var resultados = new List<ValidationResult>
+            {
+                ValidarProjetoObrigatorio(idProjeto),
+                ValidarAssociadoObrigatorio(idAssociado),
+                ValidarPeriodoObrigatorio(idPeriodo)
+            };
+
+            var erros = resultados.Where(r => !r.IsValid).ToList();
+            
+            if (erros.Any())
+            {
+                var mensagensErro = string.Join("; ", erros.Select(e => e.ErrorMessage));
+                return ValidationResult.Error(mensagensErro);
+            }
+
+            return ValidationResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarContextoAvaliacao" },
+                { "Component", "ValidationHelper" }
+            });
+            return ValidationResult.Error("Erro interno na validação do contexto");
+        }
+    }
+
+    public List<ValidationResult> ValidarTodosRequisitos(ValidationContext context)
+    {
+        try
+        {
+            var resultados = new List<ValidationResult>();
+
+            resultados.Add(ValidarContextoAvaliacao(context.IdProjeto, context.IdAssociado, context.IdPeriodo));
+            
+            if (context.ValidarCompetencias && context.NotasCompetencias != null)
+            {
+                resultados.Add(ValidarCompetenciasPreenchidas(context.NotasCompetencias));
+            }
+            
+            if (context.ValidarPerformances && context.NotasPerformances != null)
+            {
+                resultados.Add(ValidarPerformancesPreenchidas(context.NotasPerformances));
+            }
+            
+            if (context.ValidarPermissoes)
+            {
+                resultados.Add(ValidarPermissaoUsuario(context.UserProfileId, context.MinProfileRequired));
+            }
+            
+            if (context.ValidarPrazos)
+            {
+                resultados.Add(ValidarPrazosAvaliacao(context.DataInicio, context.DataFim));
+            }
+
+            _telemetryService.TrackEvent("ValidationCompleted", new Dictionary<string, string>
+            {
+                { "TotalValidations", resultados.Count.ToString() },
+                { "FailedValidations", resultados.Count(r => !r.IsValid).ToString() },
+                { "Context", context.ToString() }
+            });
+
+            return resultados;
+        }
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "ValidarTodosRequisitos" },
+                { "Component", "ValidationHelper" }
+            });
+            return new List<ValidationResult> { ValidationResult.Error("Erro interno na validação geral") };
+        }
     }
 
     public string GetMensagemValidacao(string chave, params object[] parametros)
     {
-        var mensagem = _configuration[$"AutoAvaliacao:ValidationMessages:{chave}"] ?? chave;
-        
-        if (parametros.Any())
+        try
         {
-            try
+            var mensagem = _configuration[$"AutoAvaliacao:ValidationMessages:{chave}"];
+            
+            if (string.IsNullOrEmpty(mensagem))
+            {
+                return GetMensagemPadrao(chave);
+            }
+
+            if (parametros.Length > 0)
             {
                 return string.Format(mensagem, parametros);
             }
-            catch
-            {
-                return mensagem;
-            }
+
+            return mensagem;
         }
-        
-        return mensagem;
+        catch (Exception ex)
+        {
+            _telemetryService.TrackException(ex, new Dictionary<string, string>
+            {
+                { "Method", "GetMensagemValidacao" },
+                { "Component", "ValidationHelper" },
+                { "Chave", chave }
+            });
+            return GetMensagemPadrao(chave);
+        }
     }
 
-    public bool IsValidationEnabled()
+    private string GetMensagemPadrao(string chave)
     {
-        return _configuration.GetValue("AutoAvaliacao:EnableValidation", true);
+        return chave switch
+        {
+            "ProjetoObrigatorio" => "É obrigatório a seleção de um Projeto.",
+            "AssociadoObrigatorio" => "É obrigatório a seleção de um Associado.",
+            "PeriodoObrigatorio" => "É obrigatório a seleção de um Período.",
+            "GestorObrigatorio" => "É obrigatório a seleção de um Gestor.",
+            "TipoAvaliacaoObrigatorio" => "É obrigatório a seleção de um tipo de avaliação.",
+            "EscopoObrigatorio" => "É obrigatório a seleção de um escopo.",
+            "CompetenciasNaoPreenchidas" => "É obrigatório digitar todas as notas da Avaliação Competência antes de finalizar a Avaliação",
+            "PerformancesNaoPreenchidas" => "É obrigatório digitar todas as notas da Avaliação Performance antes de finalizar a Avaliação",
+            "PermissaoNegada" => "Você não tem permissão para esta operação",
+            _ => "Erro de validação"
+        };
     }
 }
 
 public class ValidationResult
 {
     public bool IsValid { get; private set; }
-    public bool IsWarning { get; private set; }
-    public string Message { get; private set; } = string.Empty;
-    public List<string> Errors { get; private set; } = new List<string>();
-    public List<string> Warnings { get; private set; } = new List<string>();
+    public string ErrorMessage { get; private set; } = string.Empty;
+    public string WarningMessage { get; private set; } = string.Empty;
+    public Dictionary<string, object> AdditionalData { get; private set; } = new();
 
     private ValidationResult() { }
 
@@ -249,36 +472,52 @@ public class ValidationResult
         return new ValidationResult { IsValid = true };
     }
 
-    public static ValidationResult Error(string message)
+    public static ValidationResult Error(string errorMessage)
     {
         return new ValidationResult
         {
             IsValid = false,
-            Message = message,
-            Errors = new List<string> { message }
+            ErrorMessage = errorMessage
         };
     }
 
-    public static ValidationResult Warning(string message)
+    public static ValidationResult Warning(string warningMessage)
     {
         return new ValidationResult
         {
             IsValid = true,
-            IsWarning = true,
-            Message = message,
-            Warnings = new List<string> { message }
+            WarningMessage = warningMessage
         };
     }
 
-    public static ValidationResult Multiple(List<string> errors, List<string> warnings = null)
+    public ValidationResult WithData(string key, object value)
     {
-        return new ValidationResult
-        {
-            IsValid = !errors.Any(),
-            IsWarning = warnings?.Any() == true,
-            Message = errors.Any() ? string.Join("; ", errors) : (warnings?.Any() == true ? string.Join("; ", warnings) : string.Empty),
-            Errors = errors ?? new List<string>(),
-            Warnings = warnings ?? new List<string>()
-        };
+        AdditionalData[key] = value;
+        return this;
+    }
+}
+
+public class ValidationContext
+{
+    public int? IdProjeto { get; set; }
+    public int? IdAssociado { get; set; }
+    public int? IdPeriodo { get; set; }
+    public int? IdGestor { get; set; }
+    public string? TipoAvaliacao { get; set; }
+    public string? Escopo { get; set; }
+    public List<int?>? NotasCompetencias { get; set; }
+    public List<int?>? NotasPerformances { get; set; }
+    public int UserProfileId { get; set; }
+    public int MinProfileRequired { get; set; } = 1;
+    public DateTime? DataInicio { get; set; }
+    public DateTime? DataFim { get; set; }
+    public bool ValidarCompetencias { get; set; } = false;
+    public bool ValidarPerformances { get; set; } = false;
+    public bool ValidarPermissoes { get; set; } = false;
+    public bool ValidarPrazos { get; set; } = false;
+
+    public override string ToString()
+    {
+        return $"ValidationContext[Projeto:{IdProjeto}, Associado:{IdAssociado}, Periodo:{IdPeriodo}]";
     }
 }

--- a/Services/Common/ComboHelper.cs
+++ b/Services/Common/ComboHelper.cs
@@ -299,6 +299,108 @@ public static class ComboHelper
             new ComboItem { Value = "backoffice", Text = "Backoffice" }
         };
     }
+
+    // Novos métodos específicos para Performance
+    public static List<ComboItem> GetNotasPerformanceItems(bool includeSelecionar = true)
+    {
+        var items = new List<ComboItem>();
+        
+        if (includeSelecionar)
+        {
+            items.Add(new ComboItem { Value = "0", Text = "[Selecionar]", IsDisabled = true });
+        }
+        
+        items.AddRange(new List<ComboItem>
+        {
+            new ComboItem { Value = "1", Text = "1" },
+            new ComboItem { Value = "2", Text = "2" },
+            new ComboItem { Value = "3", Text = "3" },
+            new ComboItem { Value = "4", Text = "4" },
+            new ComboItem { Value = "5", Text = "N/A" }
+        });
+        
+        return items;
+    }
+
+    public static string GetNotaPerformanceText(int? nota)
+    {
+        return nota switch
+        {
+            1 => "1",
+            2 => "2",
+            3 => "3",
+            4 => "4",
+            5 => "N/A",
+            _ => "[Selecionar]"
+        };
+    }
+
+    public static bool IsNotaValida(int? nota)
+    {
+        return nota.HasValue && nota.Value > 0 && nota.Value <= 5;
+    }
+
+    public static List<ComboItem> GetAbrangenciaPerformanceItems()
+    {
+        return new List<ComboItem>
+        {
+            new ComboItem { Value = "Individual", Text = "Individual" },
+            new ComboItem { Value = "Coletivo", Text = "Coletivo" }
+        };
+    }
+
+    public static string GetAbrangenciaPerformanceText(string? abrangencia)
+    {
+        return abrangencia switch
+        {
+            "Individual" => "Individual",
+            "Coletivo" => "Coletivo",
+            _ => "Individual"
+        };
+    }
+
+    public static List<ComboItem> GetInputAutoavaliacaoItems()
+    {
+        return new List<ComboItem>
+        {
+            new ComboItem { Value = "true", Text = "Sim" },
+            new ComboItem { Value = "false", Text = "Não" }
+        };
+    }
+
+    public static string GetInputAutoavaliacaoText(bool inputAutoavaliacao)
+    {
+        return inputAutoavaliacao ? "Sim" : "Não";
+    }
+
+    public static bool ShouldDisableNota(bool inputAutoavaliacao, bool avaliacaoFinalizada)
+    {
+        return !inputAutoavaliacao || avaliacaoFinalizada;
+    }
+
+    public static string GetDisclaimerInputText(bool inputAutoavaliacao)
+    {
+        return inputAutoavaliacao ? "" : "Esta nota não requer preenchimento do avaliado";
+    }
+
+    public static List<ComboItem> GetStatusPerformanceItems()
+    {
+        return new List<ComboItem>
+        {
+            new ComboItem { Value = "1", Text = "Ativo" },
+            new ComboItem { Value = "0", Text = "Inativo" }
+        };
+    }
+
+    public static string GetStatusPerformanceText(bool ativo)
+    {
+        return ativo ? "Ativo" : "Inativo";
+    }
+
+    public static string GetStatusPerformanceBadgeClass(bool ativo)
+    {
+        return ativo ? "badge-success" : "badge-secondary";
+    }
 }
 
 public class ComboItem


### PR DESCRIPTION
Este PR implementa três helpers reutilizáveis na pasta Services/AutoAvaliacao/Common: NotaHelper (lógica de notas e validação), AccordionHelper (lógica de accordions e truncamento de texto) e ValidationHelper (validações centralizadas). Todos seguem a arquitetura modular, integram serviços comuns e estão prontos para uso em múltiplos componentes do sistema de avaliação interna. Além disso, cria a pasta docs com um arquivo markdown explicando a integração, uso e fluxo de alto nível dessas classes, conforme diretrizes de documentação e arquitetura.