### PR TITLE
Migração do Preenchimento PDI: Web Forms para Blazor com arquitetura desacoplada e documentação

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -46,6 +46,11 @@ public class ApplicationDbContext : DbContext
     public DbSet<AssociadoProjeto> AssociadosProjetos { get; set; }
     public DbSet<TipoProjeto> TiposProjetos { get; set; }
 
+    // DbSets para PDI
+    public DbSet<PDI_RESPOSTAS> PDIRespostas { get; set; }
+    public DbSet<PDI_QUESTOES> PDIQuestoes { get; set; }
+    public DbSet<PERIODOSAVALIACOES> PeriodosAvaliacoes { get; set; }
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -373,6 +378,31 @@ public class ApplicationDbContext : DbContext
             entity.HasKey(e => e.IdTipo);
             entity.ToTable("TIPOS_PROJETOS");
             entity.Property(e => e.Nome).HasColumnName("ProjetoTipo");
+        });
+
+        // Configuração das entidades do PDI
+        modelBuilder.Entity<PDI_RESPOSTAS>(entity =>
+        {
+            entity.HasKey(e => e.idPDIRespostas);
+            entity.ToTable("PDI_RESPOSTAS");
+            entity.HasOne(e => e.PERIODOSAVALIACOES)
+                .WithMany()
+                .HasForeignKey(e => e.idPeriodo)
+                .OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(e => e.PDI_QUESTOES)
+                .WithMany()
+                .HasForeignKey(e => e.idPDIQuestao)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+        modelBuilder.Entity<PDI_QUESTOES>(entity =>
+        {
+            entity.HasKey(e => e.idPDIQuestoes);
+            entity.ToTable("PDI_QUESTOES");
+        });
+        modelBuilder.Entity<PERIODOSAVALIACOES>(entity =>
+        {
+            entity.HasKey(e => e.IdPeriodo);
+            entity.ToTable("PERIODOSAVALIACOES");
         });
     }
 }

--- a/Pages/PDI/AvaliacaoPDI.razor
+++ b/Pages/PDI/AvaliacaoPDI.razor
@@ -1,0 +1,125 @@
+@page "/pdi/avaliacao"
+@rendermode InteractiveAuto
+@inject Peers.Moderno.Services.PDI.IPDIService PDIService
+@inject Peers.Moderno.Services.Common.IUserContextService UserContextService
+@inject Peers.Moderno.Services.Common.IMessageBoxService MessageBoxService
+
+<PageTitle>Preenchimento PDI</PageTitle>
+
+@if (loading)
+{
+    <div class="text-center mt-5"><span>Carregando...</span></div>
+}
+else if (periodos.Count == 0)
+{
+    <div class="alert alert-warning">Nenhum período de PDI encontrado.</div>
+}
+else
+{
+    <div class="page-breadcrumb border-bottom">
+        <div class="row">
+            <div class="col-lg-3 col-md-4 col-xs-12 align-self-center">
+                <h5 class="font-medium text-uppercase mb-0">Preenchimento PDI</h5>
+            </div>
+            <div class="col-lg-9 col-md-8 col-xs-12 align-self-center">
+                <nav aria-label="breadcrumb" class="mt-2 float-md-right float-left">
+                    <ol class="breadcrumb mb-0 justify-content-end p-0">
+                        <li class="breadcrumb-item"><a href="/">Peers</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">PDI</li>
+                    </ol>
+                </nav>
+            </div>
+        </div>
+    </div>
+    <div class="page-content container-fluid">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body">
+                    <h4 class="card-title">Períodos</h4>
+                    <ul class="nav nav-pills mb-3" id="pills-tab2" role="tablist">
+                        @foreach (var pill in pills)
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link btn btn-facebook @(pill.active)" id="@pill.id" data-bs-toggle="pill" href="@pill.href" role="tab"
+                                   aria-controls="@pill.ariacontrols" aria-selected="@pill.ariaselected">@pill.Periodo</a>
+                            </li>
+                        }
+                    </ul>
+                </div>
+                <div class="card-body">
+                    <div class="tab-content" id="pills-tabContent">
+                        @for (int p = 0; p < periodos.Count; p++)
+                        {
+                            var periodo = periodos[p];
+                            <div class="tab-pane fade @(periodo.active)" id="@periodo.id" role="tabpanel" aria-labelledby="@periodo.arialabelled">
+                                <h4>@periodo.Periodo</h4>
+                                <div style="display:flex;flex-direction:row;height:900px;width:100%">
+                                    @foreach (var coluna in periodo.PDIColunas)
+                                    {
+                                        <div style="display:flex;flex-direction:column;flex-grow:1;min-width:16%;max-width:18%">
+                                            @foreach (var resposta in coluna.PDIRespostas)
+                                            {
+                                                <div style="flex-grow:@resposta.FlexGrow;background-color:white;border:solid 0.6em;border-color:#E5F419;@resposta.BorderStyle;display:flex;flex-direction:column;justify-content:space-between;gap:2px">
+                                                    <div style="display:flex;flex-direction:row;align-items:center;justify-content:start;min-height:50px">
+                                                        <img width="40px" height="40px" src="@resposta.Icone" />
+                                                        <label style="color:@resposta.TituloStyle;font-weight:bold"> @resposta.Titulo </label>
+                                                    </div>
+                                                    <textarea class="form-control" style="width:90%;align-self:center;height:100%;border:thin solid #F0F0F0" @bind-value="resposta.Resposta" @bind-value:event="onchange" @onchange="async (e) => await AtualizarResposta(resposta.idPDIResposta, resposta.Resposta)" disabled="@(!resposta.RespostaEnabled)"></textarea>
+                                                    <label @attributes="GetSubtituloAttributes(resposta.SubtituloStyle)"> @resposta.Subtitulo </label>
+                                                </div>
+                                            }
+                                        </div>
+                                    }
+                                </div>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private List<Peers.Moderno.Services.PDI.Common.Models.PDIPeriodoModel> periodos = new();
+    private List<Peers.Moderno.Services.PDI.Common.Models.PDIPillsModel> pills = new();
+    private bool loading = true;
+    private int idAssociado = 0;
+
+    protected override async Task OnInitializedAsync()
+    {
+        loading = true;
+        var usuario = await UserContextService.GetUsuarioLogadoAsync();
+        if (usuario == null)
+        {
+            MessageBoxService.ShowError("Usuário não autenticado.");
+            loading = false;
+            return;
+        }
+        idAssociado = usuario.Id;
+        await CarregarDados();
+        loading = false;
+    }
+
+    private async Task CarregarDados()
+    {
+        periodos = await PDIService.GetPdiPeriodosAsync(idAssociado);
+        pills = await PDIService.GetPdiPillsAsync(idAssociado);
+    }
+
+    private async Task AtualizarResposta(int idPDIResposta, string resposta)
+    {
+        await PDIService.AtualizarRespostaAsync(idPDIResposta, resposta);
+        MessageBoxService.ShowSuccess("Resposta atualizada com sucesso!");
+    }
+
+    private Dictionary<string, object> GetSubtituloAttributes(string subtituloStyle)
+    {
+        var dict = new Dictionary<string, object>();
+        if (!string.IsNullOrEmpty(subtituloStyle))
+        {
+            dict["style"] = subtituloStyle.Replace("style=\"", string.Empty).Replace("\"", string.Empty);
+        }
+        return dict;
+    }
+}

--- a/Pages/PDI/AvaliacaoPDI.razor.cs
+++ b/Pages/PDI/AvaliacaoPDI.razor.cs
@@ -1,0 +1,1 @@
+// Este arquivo foi substituído pelo code block @code no AvaliacaoPDI.razor, mantendo a lógica inline para facilitar a manutenção e clareza. Caso seja necessário separar, a lógica pode ser movida para este arquivo como partial class.

--- a/Services/PDI/Common/Models/PDIPeriodoModel.cs
+++ b/Services/PDI/Common/Models/PDIPeriodoModel.cs
@@ -1,0 +1,40 @@
+namespace Peers.Moderno.Services.PDI.Common.Models;
+
+public class PDIPeriodoModel
+{
+    public string id { get; set; } = string.Empty;
+    public string active { get; set; } = string.Empty;
+    public string arialabelled { get; set; } = string.Empty;
+    public string Periodo { get; set; } = string.Empty;
+    public List<PDIColunasModel> PDIColunas { get; set; } = new();
+}
+
+public class PDIColunasModel
+{
+    public List<PDIRespostasModel> PDIRespostas { get; set; } = new();
+}
+
+public class PDIRespostasModel
+{
+    public string Titulo { get; set; } = string.Empty;
+    public string TituloStyle { get; set; } = string.Empty;
+    public string Subtitulo { get; set; } = string.Empty;
+    public string SubtituloStyle { get; set; } = string.Empty;
+    public string FlexGrow { get; set; } = string.Empty;
+    public string Icone { get; set; } = string.Empty;
+    public string BorderStyle { get; set; } = string.Empty;
+    public string Resposta { get; set; } = string.Empty;
+    public bool RespostaEnabled { get; set; }
+    public int idPDIResposta { get; set; }
+    public string OnInput { get; set; } = string.Empty;
+}
+
+public class PDIPillsModel
+{
+    public string id { get; set; } = string.Empty;
+    public string href { get; set; } = string.Empty;
+    public string ariacontrols { get; set; } = string.Empty;
+    public string ariaselected { get; set; } = string.Empty;
+    public string active { get; set; } = string.Empty;
+    public string Periodo { get; set; } = string.Empty;
+}

--- a/Services/PDI/Common/PDIModelHelper.cs
+++ b/Services/PDI/Common/PDIModelHelper.cs
@@ -1,0 +1,36 @@
+using Peers.Moderno.Services.PDI.Common.Models;
+
+namespace Peers.Moderno.Services.PDI.Common;
+
+public static class PDIModelHelper
+{
+    public static PDIRespostasModel MapToPDIRespostasModel(PDI_QUESTOES questao, PDI_RESPOSTAS? resposta, PERIODOSAVALIACOES periodo, PERIODOSAVALIACOES? periodoUltimo, bool isUltimoPeriodo)
+    {
+        string corAzul = "#021240";
+        var subtituloStyle = "style=\"align-self:center;background-color:#F2F2F2;font-weight:bolder;width:40%;min-width:80px;text-align:center;padding:2px\"";
+        string styleBordas = string.Empty;
+        if (questao.BordaEsquerda == false) styleBordas += "border-left:none;";
+        if (questao.BordaDireita == false) styleBordas += "border-right:none;";
+        if (questao.BordaCima == false) styleBordas += "border-top:none;";
+        if (questao.BordaBaixo == false) styleBordas += "border-bottom:none;";
+        var flexGrow = questao.ColunaTamanho.ToString().Replace(",", ".");
+        if (questao.FixTamanho > -1)
+            flexGrow += $";min-height:{questao.FixTamanho}%;max-height:{questao.FixTamanho}%";
+        var respostaText = resposta?.Resposta ?? "";
+        respostaText = respostaText.Replace("\n", "fsdfsdfs").Replace("\r", "fsdfsdfs");
+        return new PDIRespostasModel
+        {
+            Titulo = !string.IsNullOrEmpty(questao.Titulo) ? questao.Titulo : "TITULO",
+            TituloStyle = string.IsNullOrEmpty(questao.Titulo) ? "white" : corAzul,
+            Subtitulo = questao.Subtitulo,
+            SubtituloStyle = !string.IsNullOrEmpty(questao.Subtitulo) ? subtituloStyle : string.Empty,
+            FlexGrow = flexGrow,
+            Icone = !string.IsNullOrEmpty(questao.Icone) ? questao.Icone : "assets/images/icon/empty.png",
+            BorderStyle = styleBordas,
+            Resposta = respostaText,
+            RespostaEnabled = periodo.IdPeriodo == periodoUltimo?.IdPeriodo,
+            idPDIResposta = resposta?.idPDIRespostas ?? 0,
+            OnInput = isUltimoPeriodo && resposta != null ? $"action_AtualizaResposta('{resposta.idPDIRespostas}', this); return false; this.focus();" : string.Empty
+        };
+    }
+}

--- a/Services/PDI/IPDIService.cs
+++ b/Services/PDI/IPDIService.cs
@@ -1,0 +1,11 @@
+using Peers.Moderno.Services.PDI.Common.Models;
+
+namespace Peers.Moderno.Services.PDI;
+
+public interface IPDIService
+{
+    Task<List<PDIPeriodoModel>> GetPdiPeriodosAsync(int idAssociado);
+    Task<List<PDIPillsModel>> GetPdiPillsAsync(int idAssociado);
+    Task AtualizarRespostaAsync(int idPDIResposta, string resposta);
+    Task ValidaPDIRespostasAsync(int idAssociado, int idPeriodo);
+}

--- a/Services/PDI/PDIService.cs
+++ b/Services/PDI/PDIService.cs
@@ -1,0 +1,128 @@
+using Microsoft.EntityFrameworkCore;
+using Peers.Moderno.Data;
+using Peers.Moderno.Services.PDI.Common;
+using Peers.Moderno.Services.PDI.Common.Models;
+using Peers.Moderno.Services.Common;
+
+namespace Peers.Moderno.Services.PDI;
+
+public class PDIService : IPDIService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly ITelemetryService _telemetry;
+
+    public PDIService(ApplicationDbContext db, ITelemetryService telemetry)
+    {
+        _db = db;
+        _telemetry = telemetry;
+    }
+
+    public async Task<List<PDIPeriodoModel>> GetPdiPeriodosAsync(int idAssociado)
+    {
+        var respostas = await _db.Set<PDI_RESPOSTAS>()
+            .Include(r => r.PERIODOSAVALIACOES)
+            .Include(r => r.PDI_QUESTOES)
+            .Where(r => r.idAssociado == idAssociado)
+            .ToListAsync();
+
+        var periodoUltimo = await _db.Set<PERIODOSAVALIACOES>().OrderByDescending(p => p.IdPeriodo).FirstOrDefaultAsync();
+        var periodos = respostas.Select(x => x.PERIODOSAVALIACOES).Distinct().OrderBy(p => p.IdPeriodo).ToList();
+        var pdiQuestoesAll = await _db.Set<PDI_QUESTOES>().ToListAsync();
+
+        var periodosModel = new List<PDIPeriodoModel>();
+        for (int j = 0; j < periodos.Count; j++)
+        {
+            var periodo = periodos[j];
+            var periodoModel = new PDIPeriodoModel
+            {
+                id = $"tab-{j}",
+                active = j == periodos.Count - 1 ? "active in show" : string.Empty,
+                arialabelled = $"tab-{j}-tab",
+                Periodo = periodo.Periodo,
+                PDIColunas = new List<PDIColunasModel>()
+            };
+
+            var pdiQuestoes = pdiQuestoesAll;
+            var respostasPeriodo = respostas.Where(x => x.idPeriodo == periodo.IdPeriodo).ToList();
+            if (periodo.IdPeriodo != periodoUltimo?.IdPeriodo)
+            {
+                pdiQuestoes = respostasPeriodo.Select(x => x.PDI_QUESTOES).Distinct().ToList();
+            }
+
+            var lastColuna = pdiQuestoes.Select(x => x.ColunaPosicao).DefaultIfEmpty(1).Max();
+            for (int i = 1; i <= lastColuna; i++)
+            {
+                var colQuestoes = pdiQuestoes.Where(x => x.ColunaPosicao == i).ToList();
+                var colunaModel = new PDIColunasModel { PDIRespostas = new List<PDIRespostasModel>() };
+                foreach (var questao in colQuestoes)
+                {
+                    var resposta = respostasPeriodo.FirstOrDefault(x => x.idPDIQuestao == questao.idPDIQuestoes);
+                    var addRespostas = PDIModelHelper.MapToPDIRespostasModel(questao, resposta, periodo, periodoUltimo, j == periodos.Count - 1);
+                    colunaModel.PDIRespostas.Add(addRespostas);
+                }
+                periodoModel.PDIColunas.Add(colunaModel);
+            }
+            periodosModel.Add(periodoModel);
+        }
+        return periodosModel;
+    }
+
+    public async Task<List<PDIPillsModel>> GetPdiPillsAsync(int idAssociado)
+    {
+        var respostas = await _db.Set<PDI_RESPOSTAS>()
+            .Include(r => r.PERIODOSAVALIACOES)
+            .Where(r => r.idAssociado == idAssociado)
+            .ToListAsync();
+        var periodos = respostas.Select(x => x.PERIODOSAVALIACOES).Distinct().OrderBy(p => p.IdPeriodo).ToList();
+        var pills = new List<PDIPillsModel>();
+        for (int i = 0; i < periodos.Count; i++)
+        {
+            var periodo = periodos[i];
+            pills.Add(new PDIPillsModel
+            {
+                id = $"tab-{i}-tab",
+                href = $"#tab-{i}",
+                ariacontrols = $"tab-{i}",
+                ariaselected = i == periodos.Count - 1 ? "true" : "false",
+                active = i == periodos.Count - 1 ? "active" : string.Empty,
+                Periodo = periodo.Periodo
+            });
+        }
+        return pills;
+    }
+
+    public async Task AtualizarRespostaAsync(int idPDIResposta, string resposta)
+    {
+        var pdiResposta = await _db.Set<PDI_RESPOSTAS>().FirstOrDefaultAsync(x => x.idPDIRespostas == idPDIResposta);
+        if (pdiResposta != null)
+        {
+            pdiResposta.Resposta = resposta;
+            _db.Update(pdiResposta);
+            await _db.SaveChangesAsync();
+            _telemetry.TrackEvent("PDIRespostaAtualizada", new Dictionary<string, string> { { "idPDIResposta", idPDIResposta.ToString() } });
+        }
+    }
+
+    public async Task ValidaPDIRespostasAsync(int idAssociado, int idPeriodo)
+    {
+        var pdiQuestoes = await _db.Set<PDI_QUESTOES>().ToListAsync();
+        var pdiRespostas = await _db.Set<PDI_RESPOSTAS>().Where(x => x.idAssociado == idAssociado && x.idPeriodo == idPeriodo).ToListAsync();
+        foreach (var questao in pdiQuestoes)
+        {
+            var existe = pdiRespostas.Any(x => x.idPDIQuestao == questao.idPDIQuestoes);
+            if (!existe)
+            {
+                var novaResposta = new PDI_RESPOSTAS
+                {
+                    idAssociado = idAssociado,
+                    idPeriodo = idPeriodo,
+                    idPDIQuestao = questao.idPDIQuestoes,
+                    Resposta = "Preencha aqui",
+                    DHC = DateTime.UtcNow
+                };
+                _db.Add(novaResposta);
+            }
+        }
+        await _db.SaveChangesAsync();
+    }
+}

--- a/docs/pdi_migration.md
+++ b/docs/pdi_migration.md
@@ -1,0 +1,40 @@
+# Migração do Preenchimento PDI: Web Forms para Blazor (.NET 9)
+
+## Visão Geral
+
+Este documento detalha a arquitetura, integração e fluxo do novo módulo de Preenchimento do PDI migrado do Web Forms para Blazor Web App (.NET 9), seguindo as melhores práticas de desacoplamento, reutilização e centralização de serviços.
+
+## Arquitetura e Integração
+
+- **Serviços de Negócio:** Toda a lógica de carregamento, atualização e validação do PDI foi extraída para o serviço `IPDIService`/`PDIService` (em `Services/PDI`), facilitando a reutilização e testabilidade.
+- **Helpers Comuns:** O helper `PDIModelHelper` (em `Services/PDI/Common`) centraliza o mapeamento de entidades do banco para modelos de exibição (DTOs), promovendo padronização.
+- **Modelos DTO:** Os modelos de dados para períodos, colunas, respostas e pills estão em `Services/PDI/Common/Models`.
+- **DbContext:** O `ApplicationDbContext` foi atualizado para mapear as entidades `PDI_RESPOSTAS`, `PDI_QUESTOES` e `PERIODOSAVALIACOES`.
+- **Componente Blazor:** A interface do usuário foi migrada para o componente `Pages/PDI/AvaliacaoPDI.razor`, utilizando data binding, navegação por pills e integração direta com os serviços via DI.
+- **Serviços Comuns:** Serviços como `IUserContextService`, `IMessageBoxService` e `ITelemetryService` são utilizados para contexto de usuário, mensagens e telemetria.
+
+## Fluxo do Processo
+
+mermaid
+flowchart TD
+    Start([Usuário acessa /pdi/avaliacao])
+    Start --> Auth{Usuário autenticado?}
+    Auth -- Não --> ErrorMsg[Exibe erro de autenticação]
+    Auth -- Sim --> LoadData[Chama PDIService.GetPdiPeriodosAsync/GetPdiPillsAsync]
+    LoadData --> RenderUI[Renderiza UI com Pills e Periodos]
+    RenderUI --> EditResp[Usuário edita resposta]
+    EditResp --> AtualizaResp[PDIService.AtualizarRespostaAsync]
+    AtualizaResp --> SuccessMsg[Exibe mensagem de sucesso]
+    RenderUI --> NavegaPills[Usuário navega entre períodos]
+    NavegaPills --> RenderUI
+
+
+## Sugestões de Melhorias Futuras
+
+- Implementar cache de dados para reduzir queries repetidas ao banco.
+- Adicionar validação de campos no lado do cliente para respostas do PDI.
+- Permitir edição em lote de respostas.
+- Adicionar testes automatizados para o serviço PDIService.
+- Melhorar a experiência de navegação entre períodos (ex: animações, loading incremental).
+- Internacionalização dos textos e labels.
+- Expor endpoints API para integração externa (mobile, BI).


### PR DESCRIPTION
Este PR implementa a migração do módulo de Preenchimento do PDI do Web Forms para Blazor, criando toda a estrutura de serviços de negócio, helpers reutilizáveis, modelos DTO, componente Blazor, atualização do ApplicationDbContext para suportar as entidades do PDI e documentação detalhada. O código foi organizado para máxima reutilização, centralização de lógica comum e aderência às melhores práticas de desenvolvimento .NET 9. A documentação inclui explicação da arquitetura, fluxo de páginas (com diagrama Mermaid) e sugestões de melhorias futuras.