### PR TITLE
Implementação dos serviços e helpers de Avaliação de Mentoria com reutilização em Common e documentação

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -44,6 +44,8 @@ using Peers.Moderno.Services.AutoAvaliacao.Common;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.AI;
+using Peers.Moderno.Services.Mentoria;
+using Peers.Moderno.Services.Mentoria.Common;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -274,6 +276,10 @@ builder.Services.AddScoped<ITiposProjetosService, TiposProjetosService>();
 // Avaliacoes Services - Registro dos novos serviços do fluxo de avaliação
 builder.Services.AddScoped<Services.Avaliacoes.IAvaliacaoService, Services.Avaliacoes.AvaliacaoService>();
 builder.Services.AddScoped<Services.Avaliacoes.Common.IAvaliacaoUtils, Services.Avaliacoes.Common.AvaliacaoUtils>();
+
+// Mentoria Services - Registro dos novos serviços e helpers
+builder.Services.AddScoped<IMentoriaService, MentoriaService>();
+builder.Services.AddScoped<IMentoriaHelper, MentoriaHelper>();
 
 var app = builder.Build();
 

--- a/Services/Mentoria/Common/IMentoriaHelper.cs
+++ b/Services/Mentoria/Common/IMentoriaHelper.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using Peers.Moderno.Models;
+
+namespace Peers.Moderno.Services.Mentoria.Common;
+
+public interface IMentoriaHelper
+{
+    List<PDIPillsModel> MontarPillsModel(List<PERIODOSAVALIACOES> periodos, PERIODOSAVALIACOES ultimoPeriodo, int idMentorado, int idMentor, List<MENTORADORESPOSTAS> respostasMentorado);
+    List<MentoradoRespostaPill> MontarRespostaPills(List<MENTORADORESPOSTAS> respostasTodas, List<PERIODOSAVALIACOES> periodos, PERIODOSAVALIACOES ultimoPeriodo, Associado mentor, string fotoMentor, List<MentorPergunta> perguntas, List<MentorNota> notas, bool periodoEnabled);
+}

--- a/Services/Mentoria/Common/IMentoriaService.cs
+++ b/Services/Mentoria/Common/IMentoriaService.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Peers.Moderno.Models;
+
+namespace Peers.Moderno.Services.Mentoria.Common;
+
+public interface IMentoriaService
+{
+    Task<List<PERIODOSAVALIACOES>> ListarPeriodosAsync(int tipo);
+    Task<PERIODOSAVALIACOES?> ObterUltimoPeriodoAsync();
+    Task<List<MENTORADORESPOSTAS>> ObterMentoradoRespostasAsync(int idMentorado, int? idPeriodo = null, int? idMentor = null, int? idPergunta = null);
+    Task<List<MentorPergunta>> ObterMentorPerguntasAsync();
+    Task<List<MentorNota>> ObterMentorNotasAsync();
+    Task GerirMentoradoRespostasAsync(MENTORADORESPOSTAS resposta);
+    Task<MENTORADORESPOSTAS?> ObterMentoradoRespostaPorIdAsync(int idResposta);
+}

--- a/Services/Mentoria/MentoriaHelper.cs
+++ b/Services/Mentoria/MentoriaHelper.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Linq;
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Mentoria.Common;
+
+namespace Peers.Moderno.Services.Mentoria;
+
+public class MentoriaHelper : IMentoriaHelper
+{
+    public List<PDIPillsModel> MontarPillsModel(List<PERIODOSAVALIACOES> periodos, PERIODOSAVALIACOES ultimoPeriodo, int idMentorado, int idMentor, List<MENTORADORESPOSTAS> respostasMentorado)
+    {
+        var pdiPillsModel = new List<PDIPillsModel>();
+        foreach (var periodo in periodos)
+        {
+            var hasRespostas = respostasMentorado.Any(r => r.idPeriodo == periodo.IdPeriodo);
+            if (hasRespostas)
+            {
+                var addPill = new PDIPillsModel
+                {
+                    id = $"tab-{periodo.IdPeriodo}-tab",
+                    href = $"#tab-{periodo.IdPeriodo}",
+                    ariacontrols = $"tab-{periodo.IdPeriodo}",
+                    ariaselected = periodo.IdPeriodo == ultimoPeriodo.IdPeriodo ? "true" : "false",
+                    active = periodo.IdPeriodo == ultimoPeriodo.IdPeriodo ? "active" : string.Empty,
+                    classe = periodo.IdPeriodo == ultimoPeriodo.IdPeriodo ? "btn btn-danger" : "btn btn-facebook",
+                    Periodo = periodo.Periodo
+                };
+                pdiPillsModel.Add(addPill);
+            }
+        }
+        return pdiPillsModel;
+    }
+
+    public List<MentoradoRespostaPill> MontarRespostaPills(List<MENTORADORESPOSTAS> respostasTodas, List<PERIODOSAVALIACOES> periodos, PERIODOSAVALIACOES ultimoPeriodo, Associado mentor, string fotoMentor, List<MentorPergunta> perguntas, List<MentorNota> notas, bool periodoEnabled)
+    {
+        var pillModel = new List<MentoradoRespostaPill>();
+        var periodosTodos = respostasTodas.Select(x => x.idPeriodo).Distinct().OrderBy(x => x).ToList();
+        foreach (var periodo in periodosTodos)
+        {
+            var addPeriodo = new MentoradoRespostaPill
+            {
+                idPeriodo = periodo,
+                Periodo = periodos.FirstOrDefault(p => p.IdPeriodo == periodo)?.Periodo ?? string.Empty,
+                id = $"tab-{periodo}",
+                active = periodo == ultimoPeriodo.IdPeriodo ? "active in show" : string.Empty,
+                arialabelled = $"tab-{periodo}-tab",
+                respostas = new List<MentoradoRespostasModel>(),
+                MentorNome = mentor.Nome,
+                MentorFoto = fotoMentor
+            };
+            var isPeriodoEnabled = periodo == ultimoPeriodo.IdPeriodo;
+            var unselectColor = isPeriodoEnabled ? "#FFFFFF" : "#C0C4CF";
+            foreach (var pergunta in perguntas)
+            {
+                var item = respostasTodas.FirstOrDefault(x => x.idPeriodo == periodo && x.idPergunta == pergunta.idMentorPergunta);
+                var addResposta = new MentoradoRespostasModel
+                {
+                    idPergunta = pergunta.idMentorPergunta,
+                    Pergunta = pergunta.Descricao,
+                    idModo = pergunta.idModo,
+                    idResposta = item?.idResposta ?? 0,
+                    Comentarios = item?.Comentario ?? string.Empty,
+                    ComentarioColor = unselectColor,
+                    Enabled = isPeriodoEnabled,
+                    notas = new List<MentoradoRespostasNotasModel>()
+                };
+                foreach (var nota in notas)
+                {
+                    var addNota = new MentoradoRespostasNotasModel
+                    {
+                        BackgroundColor = unselectColor,
+                        idNota = nota.idNota,
+                        Escala = -1,
+                        NotaTexto = nota.Descricao,
+                        Icone = nota.Icone,
+                        HideIcone = "hidden",
+                        Enabled = isPeriodoEnabled,
+                        idResposta = item?.idResposta ?? 0
+                    };
+                    if (item != null && item.idNota == nota.idNota)
+                    {
+                        addNota.BackgroundColor = "#E5F419";
+                    }
+                    addResposta.notas.Add(addNota);
+                }
+                addPeriodo.respostas.Add(addResposta);
+            }
+            pillModel.Add(addPeriodo);
+        }
+        return pillModel;
+    }
+}

--- a/Services/Mentoria/MentoriaService.cs
+++ b/Services/Mentoria/MentoriaService.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Peers.Moderno.Data;
+using Peers.Moderno.Models;
+using Peers.Moderno.Services.Mentoria.Common;
+
+namespace Peers.Moderno.Services.Mentoria;
+
+public class MentoriaService : IMentoriaService
+{
+    private readonly ApplicationDbContext _context;
+
+    public MentoriaService(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<PERIODOSAVALIACOES>> ListarPeriodosAsync(int tipo)
+    {
+        return await _context.PeriodosAvaliacoes
+            .Where(p => p.Tipo == tipo)
+            .OrderByDescending(p => p.IdPeriodo)
+            .ToListAsync();
+    }
+
+    public async Task<PERIODOSAVALIACOES?> ObterUltimoPeriodoAsync()
+    {
+        return await _context.PeriodosAvaliacoes
+            .OrderByDescending(p => p.IdPeriodo)
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task<List<MENTORADORESPOSTAS>> ObterMentoradoRespostasAsync(int idMentorado, int? idPeriodo = null, int? idMentor = null, int? idPergunta = null)
+    {
+        var query = _context.Set<MENTORADORESPOSTAS>().AsQueryable();
+        query = query.Where(x => x.idMentorado == idMentorado);
+        if (idPeriodo.HasValue)
+            query = query.Where(x => x.idPeriodo == idPeriodo.Value);
+        if (idMentor.HasValue)
+            query = query.Where(x => x.idMentor == idMentor.Value);
+        if (idPergunta.HasValue)
+            query = query.Where(x => x.idPergunta == idPergunta.Value);
+        return await query.ToListAsync();
+    }
+
+    public async Task<List<MentorPergunta>> ObterMentorPerguntasAsync()
+    {
+        // Supondo que MentorPergunta é uma entidade mapeada
+        return await _context.Set<MentorPergunta>().OrderBy(x => x.Ordem).ToListAsync();
+    }
+
+    public async Task<List<MentorNota>> ObterMentorNotasAsync()
+    {
+        // Supondo que MentorNota é uma entidade mapeada
+        return await _context.Set<MentorNota>().OrderBy(x => x.Ordem).ToListAsync();
+    }
+
+    public async Task GerirMentoradoRespostasAsync(MENTORADORESPOSTAS resposta)
+    {
+        var existente = await _context.Set<MENTORADORESPOSTAS>().FirstOrDefaultAsync(x => x.idResposta == resposta.idResposta);
+        if (existente != null)
+        {
+            _context.Entry(existente).CurrentValues.SetValues(resposta);
+        }
+        else
+        {
+            await _context.Set<MENTORADORESPOSTAS>().AddAsync(resposta);
+        }
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<MENTORADORESPOSTAS?> ObterMentoradoRespostaPorIdAsync(int idResposta)
+    {
+        return await _context.Set<MENTORADORESPOSTAS>().FirstOrDefaultAsync(x => x.idResposta == idResposta);
+    }
+}

--- a/docs/avaliacao_mentoria.md
+++ b/docs/avaliacao_mentoria.md
@@ -1,0 +1,56 @@
+# Documentação: Avaliação de Mentoria
+
+## Visão Geral
+
+Esta documentação descreve a arquitetura, funcionamento e integração dos serviços de Avaliação de Mentoria migrados do Web Forms para o novo padrão Blazor .NET 9. O fluxo foi modularizado para máxima reutilização e desacoplamento, utilizando as pastas `Services/Mentoria` e `Services/Mentoria/Common`.
+
+## Estrutura dos Serviços
+
+- **IMentoriaService**: Interface centralizadora das operações de negócio de mentoria (listar períodos, obter respostas, atualizar notas/comentários).
+- **MentoriaService**: Implementação concreta, utiliza o ApplicationDbContext para persistência e consultas.
+- **IMentoriaHelper**: Interface para helpers de montagem de modelos de UI e transformação de dados.
+- **MentoriaHelper**: Implementação dos helpers, responsável por montar as estruturas de dados para a camada de apresentação.
+
+## Integração e Uso
+
+Os serviços são registrados no DI container em `Program.cs` e podem ser injetados em qualquer componente Blazor ou serviço adicional:
+
+csharp
+@inject IMentoriaService MentoriaService
+@inject IMentoriaHelper MentoriaHelper
+
+
+Exemplo de uso em componente:
+
+csharp
+var periodos = await MentoriaService.ListarPeriodosAsync(1);
+var ultimoPeriodo = await MentoriaService.ObterUltimoPeriodoAsync();
+var respostas = await MentoriaService.ObterMentoradoRespostasAsync(idMentorado);
+var pills = MentoriaHelper.MontarPillsModel(periodos, ultimoPeriodo, idMentorado, idMentor, respostas);
+
+
+## Fluxo do Processo
+
+mermaid
+flowchart TD
+    A[Usuário acessa Avaliação de Mentoria] --> B[Blazor Component: AvaliacaoMentoria.razor]
+    B --> C[IMentoriaService: ListarPeriodosAsync / ObterUltimoPeriodoAsync]
+    B --> D[IMentoriaService: ObterMentoradoRespostasAsync]
+    B --> E[IMentoriaHelper: MontarPillsModel / MontarRespostaPills]
+    C --> F[ApplicationDbContext]
+    D --> F
+    B --> G[Renderização da UI com dados montados]
+    G --> H[Usuário interage: atualiza nota/comentário]
+    H --> I[IMentoriaService: GerirMentoradoRespostasAsync]
+    I --> F
+    H --> B
+
+
+## Sugestões de Melhorias Futuras
+
+- Implementar cache para consultas de perguntas/notas de mentoria para reduzir queries repetidas.
+- Adicionar testes automatizados para os serviços e helpers.
+- Expandir os helpers para suportar customização de UI por perfil de usuário.
+- Adicionar logs detalhados de auditoria para alterações de notas e comentários.
+- Evoluir o fluxo para suportar avaliações em lote e exportação direta para Excel.
+- Internacionalização dos textos dos modelos e helpers.


### PR DESCRIPTION
Este PR implementa a funcionalidade de Avaliação de Mentoria, incluindo:
- Criação das interfaces IMentoriaService e IMentoriaHelper em Services/Mentoria/Common para centralização e reutilização.
- Implementação dos serviços MentoriaService e MentoriaHelper seguindo o padrão de injeção de dependência e separação de responsabilidades.
- Registro dos serviços no Program.cs para uso em componentes Blazor.
- Criação de documentação detalhada em docs/avaliacao_mentoria.md, incluindo explicação, fluxo mermaid e sugestões de melhorias futuras.
Todas as mudanças seguem a premissa de reutilização de código e organização em pastas Common, conforme instruções do projeto.