### PR TITLE
Centralização da lógica de avaliação de performance do gestor em serviços e helpers reutilizáveis

### DIFF
--- a/Services/AvaliacoesGestor/Common/AvaliacoesGestorHelper.cs
+++ b/Services/AvaliacoesGestor/Common/AvaliacoesGestorHelper.cs
@@ -1,76 +1,51 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
-using Peers.Moderno.Data;
-using Peers.Moderno.Models;
+using Services.AvaliacoesGestor.Common;
 
-namespace Services.AvaliacoesGestor.Common
+public static class AvaliacoesGestorHelper
 {
-    public class AvaliacoesGestorHelper
+    public static string TruncaTexto(string texto, int qtdCaracter)
     {
-        private readonly ApplicationDbContext _db;
-        public AvaliacoesGestorHelper(ApplicationDbContext db)
-        {
-            _db = db;
-        }
+        if (string.IsNullOrEmpty(texto))
+            return string.Empty;
+        return texto.Length > qtdCaracter ? texto.Substring(0, qtdCaracter) + "..." : texto;
+    }
 
-        public async Task<List<Competencia>> ObterCompetenciasParaAvaliacaoAsync(Associado associado, Projeto projeto, PERIODOSAVALIACOES periodo, string tipoAvaliacao, string escopo, AvaliacaoEmail avaliacaoEmail)
+    public static List<PerformanceModel> OrganizarAbrangencias(List<PerformanceModel> performances)
+    {
+        var abrangenciasContadas = new HashSet<string>();
+        var lista = new List<PerformanceModel>();
+        foreach (var item in performances)
         {
-            var competencias = await _db.Competencias
-                .Where(c => c.IdCargo == associado.IdCargo && c.IdNivel == associado.IdNivel)
-                .Include(c => c.SubCompetencia)
-                .ToListAsync();
-            return competencias;
-        }
-
-        public async Task<List<CompetenciaGestorDto>> MapearCompetenciasParaDtoAsync(List<Competencia> competencias, Associado associado, Projeto projeto, PERIODOSAVALIACOES periodo, string tipoAvaliacao, string escopo, AvaliacaoEmail avaliacaoEmail)
-        {
-            var result = new List<CompetenciaGestorDto>();
-            foreach (var comp in competencias)
+            var clone = new PerformanceModel
             {
-                var avaliacaoComp = await _db.AvaliacoesCompetenciasNotas.FirstOrDefaultAsync(a => a.IdCompetencia == comp.IdCompetencia && a.IdAssociado == associado.Id && a.IdProjeto == projeto.Id && a.IdPeriodo == periodo.IdPeriodo && a.TipoAvaliacao == tipoAvaliacao && a.Escopo == escopo && a.IdAvaliacao == avaliacaoEmail.idAvaliacao);
-                result.Add(new CompetenciaGestorDto
-                {
-                    IdAvaliacaoCompetencia = avaliacaoComp?.IdNota ?? 0,
-                    IdCompetencia = comp.IdCompetencia,
-                    NomeCompetencia = comp.Nome,
-                    SubCompetencia = comp.SubCompetencia?.Nome ?? string.Empty,
-                    PalavrasChave = comp.PalavrasChave ?? string.Empty,
-                    DetalheNivelAtual = comp.CompetenciaJRDetalhe ?? string.Empty,
-                    DetalheProximoNivel = comp.CompetenciaPLDetalhe ?? string.Empty,
-                    NotaNivel1Gestor = avaliacaoComp?.IdNotaNivel1AvaliacaoGestor,
-                    NotaNivel2Gestor = avaliacaoComp?.IdNotaNivel2AvaliacaoGestor,
-                    ConsideracoesGestor = avaliacaoComp?.ComentariosAvaliacaoGestor ?? string.Empty,
-                    IdModo = comp.IdModo,
-                    InputNivel1 = comp.InputNivel1,
-                    InputNivel2 = comp.InputNivel2,
-                    VisivelNivel1 = comp.VisivelNivel1,
-                    VisivelNivel2 = comp.VisivelNivel2,
-                    TextoNotaNivel1 = "",
-                    TextoNotaNivel2 = "",
-                    ObservacaoAvaliado = avaliacaoComp?.ComentariosAutoAvaliacao ?? string.Empty,
-                    ObservacaoCegas = avaliacaoComp?.ComentariosAvaliacaoCegas ?? string.Empty
-                });
-            }
-            return result;
+                IdPerformance = item.IdPerformance,
+                Descricao = item.Descricao,
+                Abaixo = item.Abaixo,
+                Esperado = item.Esperado,
+                Acima = item.Acima,
+                Abrangencia = item.Abrangencia,
+                SeparadorAbrangencia = abrangenciasContadas.Add(item.Abrangencia) ? string.Empty : "hidden",
+                Input = item.Input,
+                DisclaimerInput = item.DisclaimerInput,
+                NotaAvaliado = item.NotaAvaliado,
+                NotaCegas = item.NotaCegas,
+                NotaGestor = item.NotaGestor,
+                ObservacaoAvaliado = item.ObservacaoAvaliado,
+                ObservacaoCegas = item.ObservacaoCegas,
+                ObservacaoGestor = item.ObservacaoGestor,
+                PodeEditar = item.PodeEditar,
+                InputAvaliacaoGestor = item.InputAvaliacaoGestor,
+                NotaPadraoAvaliacaoGestor = item.NotaPadraoAvaliacaoGestor
+            };
+            lista.Add(clone);
         }
+        return lista;
+    }
 
-        public bool ValidarCompetencias(List<CompetenciaGestorDto> competencias)
-        {
-            foreach (var comp in competencias)
-            {
-                if (comp.InputNivel1 && (!comp.NotaNivel1Gestor.HasValue || comp.NotaNivel1Gestor == 0))
-                    return false;
-                if (comp.InputNivel2 && (!comp.NotaNivel2Gestor.HasValue || comp.NotaNivel2Gestor == 0))
-                    return false;
-                if (comp.NotaNivel1Gestor == 5 && comp.NotaNivel2Gestor != 5)
-                    return false;
-                if (comp.NotaNivel1Gestor > 0 && comp.NotaNivel2Gestor > 0 && comp.NotaNivel2Gestor > comp.NotaNivel1Gestor)
-                    return false;
-            }
-            return true;
-        }
+    public static bool ValidarNotasPreenchidas(List<PerformanceModel> performances)
+    {
+        return performances.All(p => !string.IsNullOrEmpty(p.NotaGestor) && p.NotaGestor != "0");
     }
 }

--- a/Services/AvaliacoesGestor/Common/AvaliacoesGestorService.cs
+++ b/Services/AvaliacoesGestor/Common/AvaliacoesGestorService.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Peers.Moderno.Data;
+using Peers.Moderno.Models;
+using Services.AvaliacoesGestor.Common;
+using Services.Common;
+
+public class AvaliacoesGestorService : IAvaliacoesGestorService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly ComboHelper _comboHelper;
+
+    public AvaliacoesGestorService(ApplicationDbContext db, ComboHelper comboHelper)
+    {
+        _db = db;
+        _comboHelper = comboHelper;
+    }
+
+    public async Task<AvaliacaoGestorPerformanceDto> CarregarDadosAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao)
+    {
+        var projeto = await _db.Projetos.Include(p => p.Cliente).FirstOrDefaultAsync(p => p.Id == idProjeto);
+        var periodo = await _db.PeriodosAvaliacoes.FirstOrDefaultAsync(p => p.IdPeriodo == idPeriodo);
+        var associado = await _db.Associados.Include(a => a.Cargo).FirstOrDefaultAsync(a => a.Id == idAssociado);
+        var gestor = projeto != null ? await _db.Associados.FirstOrDefaultAsync(a => a.Id == projeto.IdAssociadoGestor) : null;
+        var cliente = projeto?.Cliente?.Nome ?? string.Empty;
+        var tempoPeers = ""; // Implementar lógica de cálculo
+        var tempoCargo = ""; // Implementar lógica de cálculo
+        var tempoRestante = await CalcularTempoRestanteAsync(idAvaliacao);
+        var performances = await CarregarListaPerformancesAsync(idAssociado, idProjeto, idPeriodo);
+        return new AvaliacaoGestorPerformanceDto
+        {
+            Projeto = new ProjetoDto { IdProjeto = projeto?.Id ?? 0, Nome = projeto?.Nome ?? string.Empty },
+            Associado = new AssociadoDto { IdAssociado = associado?.Id ?? 0, Nome = associado?.Nome ?? string.Empty, Cargo = associado?.Cargo?.Nome ?? string.Empty },
+            Periodo = new PeriodoDto { IdPeriodo = periodo?.IdPeriodo ?? 0, Periodo = periodo?.Descricao ?? string.Empty },
+            Gestor = new AssociadoDto { IdAssociado = gestor?.Id ?? 0, Nome = gestor?.Nome ?? string.Empty, Cargo = gestor?.Cargo?.Nome ?? string.Empty },
+            Cliente = cliente,
+            TempoPeers = tempoPeers,
+            TempoCargo = tempoCargo,
+            TempoRestante = tempoRestante,
+            Performances = performances
+        };
+    }
+
+    public async Task<List<PerformanceModel>> CarregarListaPerformancesAsync(int idAssociado, int idProjeto, int idPeriodo)
+    {
+        // Carrega avaliações existentes
+        var avaliacoes = await _db.AvaliacoesPerformance
+            .Where(a => a.IdAssociado == idAssociado && a.IdProjeto == idProjeto && a.IdPeriodo == idPeriodo)
+            .ToListAsync();
+        var performances = await _db.Performances
+            .Where(p => p.IdCargo == _db.Associados.Where(a => a.Id == idAssociado).Select(a => a.IdCargo).FirstOrDefault())
+            .ToListAsync();
+        var lista = new List<PerformanceModel>();
+        var abrangenciasContadas = new HashSet<string>();
+        foreach (var perf in performances)
+        {
+            var avaliacao = avaliacoes.FirstOrDefault(a => a.IdPerformance == perf.IdPerformance);
+            var model = new PerformanceModel
+            {
+                IdPerformance = perf.IdPerformance,
+                Descricao = perf.Descricao,
+                Abaixo = perf.PerformanceAbaixo,
+                Esperado = perf.PerformanceEsperado,
+                Acima = perf.PerformanceAcima,
+                Abrangencia = perf.Abrangencia,
+                SeparadorAbrangencia = abrangenciasContadas.Add(perf.Abrangencia) ? string.Empty : "hidden",
+                Input = perf.InputAvaliacaoGestor ? string.Empty : "hidden",
+                DisclaimerInput = perf.InputAvaliacaoGestor ? string.Empty : "Esta nota não requer preenchimento do gestor",
+                NotaAvaliado = avaliacao?.IdNotaNivel1AutoAvaliacao?.ToString() ?? string.Empty,
+                NotaCegas = avaliacao?.IdNotaNivel1AvaliacaoCegas?.ToString() ?? string.Empty,
+                NotaGestor = avaliacao?.IdNotaNivel1AvaliacaoGestor?.ToString() ?? string.Empty,
+                ObservacaoAvaliado = avaliacao?.ComentariosAutoAvaliacao ?? string.Empty,
+                ObservacaoCegas = avaliacao?.ComentariosAvaliacaoCegas ?? string.Empty,
+                ObservacaoGestor = avaliacao?.ComentariosAvaliacaoGestor ?? string.Empty,
+                PodeEditar = avaliacao != null && avaliacao.PosicaoAtualFluxoAvaliacao == 3, // 3 = etapaAvaliacaoGestor
+                InputAvaliacaoGestor = perf.InputAvaliacaoGestor,
+                NotaPadraoAvaliacaoGestor = perf.NotaPadraoAvaliacaoGestor
+            };
+            lista.Add(model);
+        }
+        return lista;
+    }
+
+    public async Task<bool> SalvarAvaliacoesAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao, List<PerformanceGestorInputDto> avaliacoes, bool finalizarAvaliacao)
+    {
+        var avaliacoesDb = await _db.AvaliacoesPerformance
+            .Where(a => a.IdAssociado == idAssociado && a.IdProjeto == idProjeto && a.IdPeriodo == idPeriodo)
+            .ToListAsync();
+        foreach (var input in avaliacoes)
+        {
+            var avaliacao = avaliacoesDb.FirstOrDefault(a => a.IdPerformance == input.IdPerformance);
+            if (avaliacao == null)
+                continue;
+            if (avaliacao.PosicaoAtualFluxoAvaliacao != 3) // 3 = etapaAvaliacaoGestor
+                continue;
+            avaliacao.IdNotaNivel1AvaliacaoGestor = input.IdNotaNivel1AvaliacaoGestor;
+            avaliacao.ComentariosAvaliacaoGestor = input.ComentariosAvaliacaoGestor?.Trim() ?? string.Empty;
+            avaliacao.DHCAvaliacaoGestor = DateTime.Now;
+            avaliacao.USRAvaliacaoGestor = 0; // Preencher com usuário logado
+            avaliacao.DataHoraInicioAvaliacaoGestor = DateTime.Now;
+            avaliacao.IdNotaNivel1Feedback = input.IdNotaNivel1AvaliacaoGestor;
+            if (avaliacao.DataHoraInicioAvaliacaoGestor == null || avaliacao.DataHoraInicioAvaliacaoGestor == DateTime.MinValue)
+                avaliacao.DataHoraInicioAvaliacaoGestor = DateTime.Now;
+            if (finalizarAvaliacao)
+                avaliacao.DataHoraFimAvaliacaoGestor = DateTime.Now;
+            // Atualiza para feedback
+            if (finalizarAvaliacao)
+            {
+                avaliacao.PosicaoAtualFluxoAvaliacao = 4; // 4 = etapaFeedback
+                avaliacao.IdNotaNivel1Feedback = input.IdNotaNivel1AvaliacaoGestor;
+                avaliacao.ComentariosFeedback = input.ComentariosAvaliacaoGestor?.Trim() ?? string.Empty;
+                avaliacao.DHCFeedback = DateTime.Now;
+                avaliacao.USRFeedback = 0; // Preencher com usuário logado
+                avaliacao.DataHoraInicioFeedback = DateTime.Now;
+            }
+        }
+        await _db.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<bool> ValidarPreenchimentoAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao)
+    {
+        // Exemplo: validar se todas as performances possuem nota preenchida
+        var avaliacoes = await _db.AvaliacoesPerformance
+            .Where(a => a.IdAssociado == idAssociado && a.IdProjeto == idProjeto && a.IdPeriodo == idPeriodo)
+            .ToListAsync();
+        return avaliacoes.All(a => a.IdNotaNivel1AvaliacaoGestor > 0);
+    }
+
+    public async Task<bool> PodeEditarAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao)
+    {
+        var avaliacoes = await _db.AvaliacoesPerformance
+            .Where(a => a.IdAssociado == idAssociado && a.IdProjeto == idProjeto && a.IdPeriodo == idPeriodo)
+            .ToListAsync();
+        return avaliacoes.Any(a => a.PosicaoAtualFluxoAvaliacao == 3); // 3 = etapaAvaliacaoGestor
+    }
+
+    private async Task<string> CalcularTempoRestanteAsync(int idAvaliacao)
+    {
+        var avaliacaoEmail = await _db.AvaliacoesEmail.FirstOrDefaultAsync(a => a.idAvaliacao == idAvaliacao);
+        if (avaliacaoEmail == null || !avaliacaoEmail.DataLiberacao.HasValue)
+            return string.Empty;
+        var prazo = await _db.Prazos.FirstOrDefaultAsync(p => p.IdPrazo == avaliacaoEmail.IdPrazo);
+        if (prazo == null)
+            return string.Empty;
+        var dataFinal = avaliacaoEmail.DataLiberacao.Value.AddDays(prazo.DuracaoAvaliacaoGestor);
+        return DateTime.Today >= dataFinal ? DateTime.Today.AddDays(prazo.CompensadorAvaliacaoGestor).ToString("dd/MM/yyyy") : dataFinal.ToString("dd/MM/yyyy");
+    }
+}

--- a/Services/AvaliacoesGestor/Common/IAvaliacoesGestorService.cs
+++ b/Services/AvaliacoesGestor/Common/IAvaliacoesGestorService.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Peers.Moderno.Models;
+
+namespace Services.AvaliacoesGestor.Common;
+
+public interface IAvaliacoesGestorService
+{
+    Task<AvaliacaoGestorPerformanceDto> CarregarDadosAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao);
+    Task<List<PerformanceModel>> CarregarListaPerformancesAsync(int idAssociado, int idProjeto, int idPeriodo);
+    Task<bool> SalvarAvaliacoesAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao, List<PerformanceGestorInputDto> avaliacoes, bool finalizarAvaliacao);
+    Task<bool> ValidarPreenchimentoAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao);
+    Task<bool> PodeEditarAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao);
+}
+
+public class AvaliacaoGestorPerformanceDto
+{
+    public ProjetoDto Projeto { get; set; } = new();
+    public AssociadoDto Associado { get; set; } = new();
+    public PeriodoDto Periodo { get; set; } = new();
+    public AssociadoDto Gestor { get; set; } = new();
+    public string Cliente { get; set; } = string.Empty;
+    public string TempoPeers { get; set; } = string.Empty;
+    public string TempoCargo { get; set; } = string.Empty;
+    public string TempoRestante { get; set; } = string.Empty;
+    public List<PerformanceModel> Performances { get; set; } = new();
+}
+
+public class ProjetoDto
+{
+    public int IdProjeto { get; set; }
+    public string Nome { get; set; } = string.Empty;
+}
+
+public class AssociadoDto
+{
+    public int IdAssociado { get; set; }
+    public string Nome { get; set; } = string.Empty;
+    public string Cargo { get; set; } = string.Empty;
+}
+
+public class PeriodoDto
+{
+    public int IdPeriodo { get; set; }
+    public string Periodo { get; set; } = string.Empty;
+}
+
+public class PerformanceGestorInputDto
+{
+    public int IdPerformance { get; set; }
+    public int IdNotaNivel1AvaliacaoGestor { get; set; }
+    public string ComentariosAvaliacaoGestor { get; set; } = string.Empty;
+}
+
+public class PerformanceModel
+{
+    public int IdPerformance { get; set; }
+    public string Descricao { get; set; } = string.Empty;
+    public string Abaixo { get; set; } = string.Empty;
+    public string Esperado { get; set; } = string.Empty;
+    public string Acima { get; set; } = string.Empty;
+    public string Abrangencia { get; set; } = string.Empty;
+    public string SeparadorAbrangencia { get; set; } = string.Empty;
+    public string Input { get; set; } = string.Empty;
+    public string DisclaimerInput { get; set; } = string.Empty;
+    public string NotaAvaliado { get; set; } = string.Empty;
+    public string NotaCegas { get; set; } = string.Empty;
+    public string NotaGestor { get; set; } = string.Empty;
+    public string ObservacaoAvaliado { get; set; } = string.Empty;
+    public string ObservacaoCegas { get; set; } = string.Empty;
+    public string ObservacaoGestor { get; set; } = string.Empty;
+    public bool PodeEditar { get; set; } = false;
+    public bool InputAvaliacaoGestor { get; set; } = false;
+    public int NotaPadraoAvaliacaoGestor { get; set; } = 0;
+}

--- a/docs/avalicoes-gestor-performance.md
+++ b/docs/avalicoes-gestor-performance.md
@@ -1,0 +1,41 @@
+# Avaliação Gestor Performance – Arquitetura, Integração e Fluxo
+
+## Visão Geral
+
+Esta documentação descreve a arquitetura, funcionamento e integração dos serviços e helpers criados para a funcionalidade de avaliação de performance do gestor, migrada do Web Forms para Blazor Híbrido .NET 9. Toda a lógica de negócio foi extraída do code-behind e centralizada em serviços e helpers reutilizáveis, promovendo desacoplamento, testabilidade e facilidade de manutenção.
+
+## Estrutura dos Serviços e Helpers
+
+- **IAvaliacoesGestorService**: Interface que define contratos para carregamento, validação, salvamento e finalização das avaliações de performance do gestor.
+- **AvaliacoesGestorService**: Implementação concreta da interface, responsável por toda a lógica de negócio, integração com o banco de dados (via ApplicationDbContext) e regras de fluxo.
+- **AvaliacoesGestorHelper**: Helper estático com funções auxiliares reutilizáveis, como truncamento de texto, organização de abrangências e validação de preenchimento.
+- **ComboHelper**: Reutilizado para combos de notas, abrangências e status.
+- **MessageBoxService**: Reutilizado para exibição de mensagens de feedback ao usuário.
+
+## Integração com o Blazor
+
+O componente Blazor (`Pages/AvaliacoesGestorPerformance.razor`) injeta IAvaliacoesGestorService e utiliza seus métodos para carregar dados, salvar avaliações e validar preenchimento. Helpers são utilizados para lógica de UI e validação local. O fluxo de mensagens e feedback é feito via MessageBoxService.
+
+## Fluxo do Processo (Mermaid)
+
+mermaid
+flowchart TD
+    Start([Início]) --> CarregarDados["Carregar Dados da Avaliação (IAvaliacoesGestorService.CarregarDadosAsync)"]
+    CarregarDados --> RenderizarUI["Renderizar UI Blazor (AvaliacoesGestorPerformance.razor)"]
+    RenderizarUI --> UsuarioPreenche["Usuário preenche notas e observações"]
+    UsuarioPreenche --> SalvarOuFinalizar["Salvar/Finalizar Avaliação (IAvaliacoesGestorService.SalvarAvaliacoesAsync)"]
+    SalvarOuFinalizar --> Validar["Validar Preenchimento (IAvaliacoesGestorService.ValidarPreenchimentoAsync)"]
+    Validar -->|Validação OK| FeedbackSucesso["Exibir mensagem de sucesso (MessageBoxService)"]
+    Validar -->|Erro| FeedbackErro["Exibir mensagem de erro (MessageBoxService)"]
+    FeedbackSucesso --> Fim([Fim])
+    FeedbackErro --> UsuarioPreenche
+
+
+## Sugestões de Melhorias Futuras
+
+- **Integração com IA**: Implementar sugestões automáticas de feedback e observações usando Azure OpenAI.
+- **Testes Automatizados**: Adicionar testes unitários e de integração para os serviços e helpers.
+- **Otimização AOT**: Avaliar ganhos de performance com Ahead-of-Time Compilation.
+- **Validação em Tempo Real**: Melhorar experiência do usuário com validações instantâneas no frontend.
+- **Auditoria e Logs**: Centralizar logs de alterações e ações do gestor para compliance.
+- **Internacionalização**: Preparar textos e mensagens para múltiplos idiomas.


### PR DESCRIPTION
Este PR extraiu toda a lógica de negócio do code-behind da avaliação de performance do gestor e centralizou em serviços e helpers reutilizáveis na pasta Services/AvaliacoesGestor/Common. Foram criadas as interfaces, implementações e helpers necessários para carregamento, validação, salvamento e finalização das avaliações, mantendo toda a funcionalidade existente e preparando para uso em componentes Blazor. Também foi criada documentação detalhada em docs/avalicoes-gestor-performance.md, explicando a arquitetura, integração, fluxo de processo (mermaid) e sugestões de melhorias. Todas as mudanças seguem o padrão de reutilização e separação de responsabilidades, facilitando manutenção e expansão futura.