### PR TITLE
Criação dos serviços e helpers reutilizáveis para Avaliação Gestor às Cegas

### DIFF
--- a/Services/AvaliacoesGestor/Common/AvaliacoesGestorHelper.cs
+++ b/Services/AvaliacoesGestor/Common/AvaliacoesGestorHelper.cs
@@ -1,51 +1,168 @@
+using Peers.Moderno.Models;
+using Peers.Moderno.Data;
+using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using Services.AvaliacoesGestor.Common;
 
-public static class AvaliacoesGestorHelper
+namespace Services.AvaliacoesGestor.Common;
+
+public class AvaliacoesGestorHelper
 {
-    public static string TruncaTexto(string texto, int qtdCaracter)
+    public bool DeveIncluirAssociadoNoFluxo(AssociadoProjeto ap, int? idPeriodo)
     {
-        if (string.IsNullOrEmpty(texto))
-            return string.Empty;
-        return texto.Length > qtdCaracter ? texto.Substring(0, qtdCaracter) + "..." : texto;
+        if (ap == null || ap.Associado == null)
+            return false;
+        if (!string.Equals(ap.TipoAvaliacao, "desempenho", StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (idPeriodo.HasValue && ap.IdPeriodo != idPeriodo.Value)
+            return false;
+        return true;
     }
 
-    public static List<PerformanceModel> OrganizarAbrangencias(List<PerformanceModel> performances)
+    public async Task<ProjetosAssociadosModel?> MapearProjetosAssociadosModelAsync(AssociadoProjeto ap, int? idPeriodo, ApplicationDbContext db)
     {
-        var abrangenciasContadas = new HashSet<string>();
-        var lista = new List<PerformanceModel>();
-        foreach (var item in performances)
+        if (ap == null)
+            return null;
+        var periodo = idPeriodo.HasValue
+            ? await db.PeriodosAvaliacoes.FirstOrDefaultAsync(p => p.IdPeriodo == idPeriodo.Value)
+            : await db.PeriodosAvaliacoes.FirstOrDefaultAsync(p => p.IdPeriodo == ap.IdPeriodo);
+        if (periodo == null)
+            return null;
+        var associado = await db.Associados.Include(a => a.Cargo).FirstOrDefaultAsync(a => a.Id == ap.IdAssociado);
+        if (associado == null)
+            return null;
+        var gestor = await db.Associados.FirstOrDefaultAsync(a => a.Id == ap.IdGestor);
+        var avaliador = await db.Associados.FirstOrDefaultAsync(a => a.Id == ap.IdAvaliador);
+        var mentor = associado.IdMentor.HasValue ? await db.Associados.FirstOrDefaultAsync(a => a.Id == associado.IdMentor.Value) : null;
+        var foto = associado.FotoNome ?? "assets/images/users/usernophoto.jpg";
+        var etapa = ObterEtapaAvaliacao(ap.PosicaoAtualFluxoAvaliacao);
+        var status = ObterStatusAvaliacao(ap.Status);
+        var rotuloBotao = ObterRotuloBotao(ap, etapa);
+        var exibirBotaoFinalizar = PodeExibirBotaoFinalizar(ap, etapa);
+        return new ProjetosAssociadosModel
         {
-            var clone = new PerformanceModel
-            {
-                IdPerformance = item.IdPerformance,
-                Descricao = item.Descricao,
-                Abaixo = item.Abaixo,
-                Esperado = item.Esperado,
-                Acima = item.Acima,
-                Abrangencia = item.Abrangencia,
-                SeparadorAbrangencia = abrangenciasContadas.Add(item.Abrangencia) ? string.Empty : "hidden",
-                Input = item.Input,
-                DisclaimerInput = item.DisclaimerInput,
-                NotaAvaliado = item.NotaAvaliado,
-                NotaCegas = item.NotaCegas,
-                NotaGestor = item.NotaGestor,
-                ObservacaoAvaliado = item.ObservacaoAvaliado,
-                ObservacaoCegas = item.ObservacaoCegas,
-                ObservacaoGestor = item.ObservacaoGestor,
-                PodeEditar = item.PodeEditar,
-                InputAvaliacaoGestor = item.InputAvaliacaoGestor,
-                NotaPadraoAvaliacaoGestor = item.NotaPadraoAvaliacaoGestor
-            };
-            lista.Add(clone);
-        }
-        return lista;
+            Id = ap.Id,
+            Projeto = ap.Projeto,
+            Associado = associado,
+            DataInicio = ap.DataInicio?.ToString("dd/MM/yyyy") ?? "",
+            DataTermino = ap.DataFim?.ToString("dd/MM/yyyy") ?? "",
+            Periodo = periodo,
+            TipoAvaliacao = ap.TipoAvaliacao,
+            Escopo = ap.Escopo,
+            FotoAssociado = foto,
+            Gestor = gestor,
+            Avaliador = avaliador,
+            ExibirBotaoFinalizar = exibirBotaoFinalizar,
+            RotuloBotao = rotuloBotao,
+            Etapa = etapa,
+            Status = status,
+            ExibirRotuloEtapa = "",
+            AvaliacaoLiberada = ap.AvaliacaoLiberada,
+            IdEmail = ap.IdAvaliacaoEmail?.ToString() ?? ""
+        };
     }
 
-    public static bool ValidarNotasPreenchidas(List<PerformanceModel> performances)
+    public string ObterEtapaAvaliacao(string? posicaoFluxo)
     {
-        return performances.All(p => !string.IsNullOrEmpty(p.NotaGestor) && p.NotaGestor != "0");
+        if (string.IsNullOrEmpty(posicaoFluxo))
+            return "Não Iniciada";
+        switch (posicaoFluxo)
+        {
+            case "AutoAvaliacao":
+                return "Em Auto-avaliação e Av. às Cegas";
+            case "AvaliacaoAsCegas":
+                return "Em Auto-avaliação e Av. as Cegas";
+            case "AvaliacaoGestor":
+                return "Em Av. Gestor";
+            case "Feedback":
+                return "Em Feedback";
+            case "AvaliacaoMentor":
+                return "Em Cons. Mentor";
+            case "Finalizada":
+                return "Finalizada";
+            default:
+                return "Em andamento";
+        }
+    }
+
+    public string ObterStatusAvaliacao(object? status)
+    {
+        if (status == null)
+            return "Não iniciado";
+        var statusStr = status.ToString();
+        if (statusStr == "1" || statusStr?.ToLower() == "ativo")
+            return "Ativo";
+        if (statusStr == "0" || statusStr?.ToLower() == "inativo")
+            return "Inativo";
+        return statusStr ?? "";
+    }
+
+    public string ObterRotuloBotao(AssociadoProjeto ap, string etapa)
+    {
+        if (ap == null)
+            return "Iniciar Avaliação";
+        if (etapa == "Em andamento")
+            return "Continuar Avaliação";
+        if (etapa == "Finalizada")
+            return "Ver Avaliação";
+        return "Iniciar Avaliação";
+    }
+
+    public bool PodeExibirBotaoFinalizar(AssociadoProjeto ap, string etapa)
+    {
+        if (ap == null)
+            return false;
+        return etapa == "Em andamento";
+    }
+
+    public async Task<bool> FinalizarAvaliacaoAsync(int idAvaliacao, int usuarioId, ApplicationDbContext db)
+    {
+        var avaliacaoEmail = await db.AvaliacoesEmail.FirstOrDefaultAsync(a => a.idAvaliacao == idAvaliacao);
+        if (avaliacaoEmail == null)
+            return false;
+        var etapaAtual = "AvaliacaoAsCegas";
+        var avaliacoesCompetencia = await db.AvaliacoesCompetenciasNotas
+            .Where(a => a.IdAssociado == avaliacaoEmail.idAssociado && a.IdProjeto == avaliacaoEmail.idProjeto && a.IdPeriodo == avaliacaoEmail.idPeriodo && a.Etapa == etapaAtual)
+            .ToListAsync();
+        var avaliacoesPerformance = await db.AvaliacoesPerformance
+            .Where(a => a.IdAssociado == avaliacaoEmail.idAssociado && a.IdProjeto == avaliacaoEmail.idProjeto && a.IdPeriodo == avaliacaoEmail.idPeriodo && a.PosicaoAtualFluxoAvaliacao == etapaAtual)
+            .ToListAsync();
+        if (!avaliacoesCompetencia.Any() || !avaliacoesPerformance.Any())
+            return false;
+        foreach (var av in avaliacoesCompetencia)
+        {
+            if (av.IdNotaNivel1AvaliacaoCegas == null || av.IdNotaNivel2AvaliacaoCegas == null || av.IdNotaNivel1AvaliacaoCegas <= 0 || av.IdNotaNivel2AvaliacaoCegas <= 0)
+            {
+                // Ajuste automático se modo == 2
+                if (av.IdModo == 2)
+                {
+                    av.IdNotaNivel1AvaliacaoCegas = av.IdNotaPadraoNivel1 ?? 5;
+                    av.IdNotaNivel2AvaliacaoCegas = av.IdNotaPadraoNivel2 ?? 5;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+        foreach (var av in avaliacoesPerformance)
+        {
+            if (av.IdNotaNivel1Feedback == null || av.IdNotaNivel1Feedback <= 0)
+                return false;
+        }
+        var dataHoraFinalizacao = DateTime.Now;
+        foreach (var av in avaliacoesPerformance)
+        {
+            av.DataHoraFimFeedback = dataHoraFinalizacao;
+            db.AvaliacoesPerformance.Update(av);
+        }
+        foreach (var av in avaliacoesCompetencia)
+        {
+            av.DataHoraFimAvaliacaoCegas = dataHoraFinalizacao;
+            db.AvaliacoesCompetenciasNotas.Update(av);
+        }
+        await db.SaveChangesAsync();
+        return true;
     }
 }

--- a/Services/AvaliacoesGestor/Common/AvaliacoesGestorService.cs
+++ b/Services/AvaliacoesGestor/Common/AvaliacoesGestorService.cs
@@ -1,153 +1,124 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
-using Peers.Moderno.Data;
 using Peers.Moderno.Models;
+using Peers.Moderno.Data;
 using Services.AvaliacoesGestor.Common;
 using Services.Common;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System;
+
+namespace Services.AvaliacoesGestor.Common;
 
 public class AvaliacoesGestorService : IAvaliacoesGestorService
 {
     private readonly ApplicationDbContext _db;
-    private readonly ComboHelper _comboHelper;
+    private readonly IComboHelper _comboHelper;
+    private readonly AvaliacoesGestorHelper _helper;
 
-    public AvaliacoesGestorService(ApplicationDbContext db, ComboHelper comboHelper)
+    public AvaliacoesGestorService(ApplicationDbContext db, IComboHelper comboHelper, AvaliacoesGestorHelper helper)
     {
         _db = db;
         _comboHelper = comboHelper;
+        _helper = helper;
     }
 
-    public async Task<AvaliacaoGestorPerformanceDto> CarregarDadosAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao)
+    public async Task<List<ComboItem>> ObterProjetosComboAsync(int idGestor)
     {
-        var projeto = await _db.Projetos.Include(p => p.Cliente).FirstOrDefaultAsync(p => p.Id == idProjeto);
-        var periodo = await _db.PeriodosAvaliacoes.FirstOrDefaultAsync(p => p.IdPeriodo == idPeriodo);
-        var associado = await _db.Associados.Include(a => a.Cargo).FirstOrDefaultAsync(a => a.Id == idAssociado);
-        var gestor = projeto != null ? await _db.Associados.FirstOrDefaultAsync(a => a.Id == projeto.IdAssociadoGestor) : null;
-        var cliente = projeto?.Cliente?.Nome ?? string.Empty;
-        var tempoPeers = ""; // Implementar lógica de cálculo
-        var tempoCargo = ""; // Implementar lógica de cálculo
-        var tempoRestante = await CalcularTempoRestanteAsync(idAvaliacao);
-        var performances = await CarregarListaPerformancesAsync(idAssociado, idProjeto, idPeriodo);
-        return new AvaliacaoGestorPerformanceDto
-        {
-            Projeto = new ProjetoDto { IdProjeto = projeto?.Id ?? 0, Nome = projeto?.Nome ?? string.Empty },
-            Associado = new AssociadoDto { IdAssociado = associado?.Id ?? 0, Nome = associado?.Nome ?? string.Empty, Cargo = associado?.Cargo?.Nome ?? string.Empty },
-            Periodo = new PeriodoDto { IdPeriodo = periodo?.IdPeriodo ?? 0, Periodo = periodo?.Descricao ?? string.Empty },
-            Gestor = new AssociadoDto { IdAssociado = gestor?.Id ?? 0, Nome = gestor?.Nome ?? string.Empty, Cargo = gestor?.Cargo?.Nome ?? string.Empty },
-            Cliente = cliente,
-            TempoPeers = tempoPeers,
-            TempoCargo = tempoCargo,
-            TempoRestante = tempoRestante,
-            Performances = performances
-        };
+        var projetos = await _db.Projetos
+            .Where(p => p.AssociadoGestor != null && p.AssociadoGestor.Id == idGestor && p.Ativo)
+            .Select(p => new ComboItem { Value = p.Id.ToString(), Text = p.Nome })
+            .ToListAsync();
+        projetos.Insert(0, new ComboItem { Value = "", Text = "[Selecionar]" });
+        return projetos;
     }
 
-    public async Task<List<PerformanceModel>> CarregarListaPerformancesAsync(int idAssociado, int idProjeto, int idPeriodo)
+    public async Task<List<ComboItem>> ObterClientesComboAsync()
     {
-        // Carrega avaliações existentes
-        var avaliacoes = await _db.AvaliacoesPerformance
-            .Where(a => a.IdAssociado == idAssociado && a.IdProjeto == idProjeto && a.IdPeriodo == idPeriodo)
+        var clientes = await _db.Clientes
+            .Where(c => c.Ativo)
+            .Select(c => new ComboItem { Value = c.IdCliente.ToString(), Text = c.Nome })
             .ToListAsync();
-        var performances = await _db.Performances
-            .Where(p => p.IdCargo == _db.Associados.Where(a => a.Id == idAssociado).Select(a => a.IdCargo).FirstOrDefault())
+        clientes.Insert(0, new ComboItem { Value = "", Text = "[Selecionar]" });
+        return clientes;
+    }
+
+    public async Task<List<ComboItem>> ObterPeriodosComboAsync(int idEmpresa)
+    {
+        var periodos = await _db.PeriodosAvaliacoes
+            .Where(p => p.IdEmpresa == idEmpresa)
+            .Select(p => new ComboItem { Value = p.IdPeriodo.ToString(), Text = p.Nome })
             .ToListAsync();
-        var lista = new List<PerformanceModel>();
-        var abrangenciasContadas = new HashSet<string>();
-        foreach (var perf in performances)
+        periodos.Insert(0, new ComboItem { Value = "", Text = "[Selecionar]" });
+        return periodos;
+    }
+
+    public async Task<List<ComboItem>> ObterStatusComboAsync()
+    {
+        var status = await _db.ProjetosComplexidades
+            .Select(s => new ComboItem { Value = s.IdComplexidade.ToString(), Text = s.Nome })
+            .ToListAsync();
+        status.Insert(0, new ComboItem { Value = "", Text = "[Selecionar]" });
+        return status;
+    }
+
+    public async Task<List<ProjetoModel>> BuscarProjetosAvaliacoesAsync(int idGestor, int? idProjeto = null, int? idStatus = null, int? idPeriodo = null, int? idCliente = null)
+    {
+        var query = _db.Projetos
+            .Include(p => p.Cliente)
+            .Include(p => p.AssociadoResponsavel)
+            .Include(p => p.AssociadoGestor)
+            .Include(p => p.AssociadosProjeto)
+            .ThenInclude(ap => ap.Associado)
+            .Where(p => p.AssociadoGestor != null && p.AssociadoGestor.Id == idGestor && p.Ativo)
+            .AsQueryable();
+
+        if (idProjeto.HasValue)
+            query = query.Where(p => p.Id == idProjeto.Value);
+        if (idStatus.HasValue)
+            query = query.Where(p => p.Complexidade != null && p.Complexidade.IdComplexidade == idStatus.Value);
+        if (idCliente.HasValue)
+            query = query.Where(p => p.Cliente != null && p.Cliente.IdCliente == idCliente.Value);
+
+        var projetos = await query.ToListAsync();
+        var lista = new List<ProjetoModel>();
+        foreach (var p in projetos)
         {
-            var avaliacao = avaliacoes.FirstOrDefault(a => a.IdPerformance == perf.IdPerformance);
-            var model = new PerformanceModel
+            var model = new ProjetoModel
             {
-                IdPerformance = perf.IdPerformance,
-                Descricao = perf.Descricao,
-                Abaixo = perf.PerformanceAbaixo,
-                Esperado = perf.PerformanceEsperado,
-                Acima = perf.PerformanceAcima,
-                Abrangencia = perf.Abrangencia,
-                SeparadorAbrangencia = abrangenciasContadas.Add(perf.Abrangencia) ? string.Empty : "hidden",
-                Input = perf.InputAvaliacaoGestor ? string.Empty : "hidden",
-                DisclaimerInput = perf.InputAvaliacaoGestor ? string.Empty : "Esta nota não requer preenchimento do gestor",
-                NotaAvaliado = avaliacao?.IdNotaNivel1AutoAvaliacao?.ToString() ?? string.Empty,
-                NotaCegas = avaliacao?.IdNotaNivel1AvaliacaoCegas?.ToString() ?? string.Empty,
-                NotaGestor = avaliacao?.IdNotaNivel1AvaliacaoGestor?.ToString() ?? string.Empty,
-                ObservacaoAvaliado = avaliacao?.ComentariosAutoAvaliacao ?? string.Empty,
-                ObservacaoCegas = avaliacao?.ComentariosAvaliacaoCegas ?? string.Empty,
-                ObservacaoGestor = avaliacao?.ComentariosAvaliacaoGestor ?? string.Empty,
-                PodeEditar = avaliacao != null && avaliacao.PosicaoAtualFluxoAvaliacao == 3, // 3 = etapaAvaliacaoGestor
-                InputAvaliacaoGestor = perf.InputAvaliacaoGestor,
-                NotaPadraoAvaliacaoGestor = perf.NotaPadraoAvaliacaoGestor
+                Id = p.Id,
+                Nome = p.Nome,
+                DataInicio = p.DataInicio.ToString("dd/MM/yyyy"),
+                DataTermino = p.DataFim?.ToString("dd/MM/yyyy"),
+                Gestor = p.AssociadoGestor,
+                Responsavel = p.AssociadoResponsavel,
+                Cliente = p.Cliente,
+                Status = p.Complexidade,
+                Associados = new List<ProjetosAssociadosModel>()
             };
-            lista.Add(model);
+            var associadosProjeto = p.AssociadosProjeto.ToList();
+            foreach (var ap in associadosProjeto)
+            {
+                if (!_helper.DeveIncluirAssociadoNoFluxo(ap, idPeriodo))
+                    continue;
+                var associadoModel = await _helper.MapearProjetosAssociadosModelAsync(ap, idPeriodo, _db);
+                if (associadoModel != null)
+                    model.Associados.Add(associadoModel);
+            }
+            if (model.Associados.Any())
+                lista.Add(model);
         }
         return lista;
     }
 
-    public async Task<bool> SalvarAvaliacoesAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao, List<PerformanceGestorInputDto> avaliacoes, bool finalizarAvaliacao)
+    public async Task<bool> FinalizarAvaliacaoAsync(int idAvaliacao, int usuarioId)
     {
-        var avaliacoesDb = await _db.AvaliacoesPerformance
-            .Where(a => a.IdAssociado == idAssociado && a.IdProjeto == idProjeto && a.IdPeriodo == idPeriodo)
-            .ToListAsync();
-        foreach (var input in avaliacoes)
-        {
-            var avaliacao = avaliacoesDb.FirstOrDefault(a => a.IdPerformance == input.IdPerformance);
-            if (avaliacao == null)
-                continue;
-            if (avaliacao.PosicaoAtualFluxoAvaliacao != 3) // 3 = etapaAvaliacaoGestor
-                continue;
-            avaliacao.IdNotaNivel1AvaliacaoGestor = input.IdNotaNivel1AvaliacaoGestor;
-            avaliacao.ComentariosAvaliacaoGestor = input.ComentariosAvaliacaoGestor?.Trim() ?? string.Empty;
-            avaliacao.DHCAvaliacaoGestor = DateTime.Now;
-            avaliacao.USRAvaliacaoGestor = 0; // Preencher com usuário logado
-            avaliacao.DataHoraInicioAvaliacaoGestor = DateTime.Now;
-            avaliacao.IdNotaNivel1Feedback = input.IdNotaNivel1AvaliacaoGestor;
-            if (avaliacao.DataHoraInicioAvaliacaoGestor == null || avaliacao.DataHoraInicioAvaliacaoGestor == DateTime.MinValue)
-                avaliacao.DataHoraInicioAvaliacaoGestor = DateTime.Now;
-            if (finalizarAvaliacao)
-                avaliacao.DataHoraFimAvaliacaoGestor = DateTime.Now;
-            // Atualiza para feedback
-            if (finalizarAvaliacao)
-            {
-                avaliacao.PosicaoAtualFluxoAvaliacao = 4; // 4 = etapaFeedback
-                avaliacao.IdNotaNivel1Feedback = input.IdNotaNivel1AvaliacaoGestor;
-                avaliacao.ComentariosFeedback = input.ComentariosAvaliacaoGestor?.Trim() ?? string.Empty;
-                avaliacao.DHCFeedback = DateTime.Now;
-                avaliacao.USRFeedback = 0; // Preencher com usuário logado
-                avaliacao.DataHoraInicioFeedback = DateTime.Now;
-            }
-        }
-        await _db.SaveChangesAsync();
-        return true;
+        return await _helper.FinalizarAvaliacaoAsync(idAvaliacao, usuarioId, _db);
     }
 
-    public async Task<bool> ValidarPreenchimentoAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao)
+    public async Task<ProjetoModel?> ObterProjetoDetalhadoAsync(int idProjeto, int idGestor, int? idPeriodo = null)
     {
-        // Exemplo: validar se todas as performances possuem nota preenchida
-        var avaliacoes = await _db.AvaliacoesPerformance
-            .Where(a => a.IdAssociado == idAssociado && a.IdProjeto == idProjeto && a.IdPeriodo == idPeriodo)
-            .ToListAsync();
-        return avaliacoes.All(a => a.IdNotaNivel1AvaliacaoGestor > 0);
-    }
-
-    public async Task<bool> PodeEditarAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao)
-    {
-        var avaliacoes = await _db.AvaliacoesPerformance
-            .Where(a => a.IdAssociado == idAssociado && a.IdProjeto == idProjeto && a.IdPeriodo == idPeriodo)
-            .ToListAsync();
-        return avaliacoes.Any(a => a.PosicaoAtualFluxoAvaliacao == 3); // 3 = etapaAvaliacaoGestor
-    }
-
-    private async Task<string> CalcularTempoRestanteAsync(int idAvaliacao)
-    {
-        var avaliacaoEmail = await _db.AvaliacoesEmail.FirstOrDefaultAsync(a => a.idAvaliacao == idAvaliacao);
-        if (avaliacaoEmail == null || !avaliacaoEmail.DataLiberacao.HasValue)
-            return string.Empty;
-        var prazo = await _db.Prazos.FirstOrDefaultAsync(p => p.IdPrazo == avaliacaoEmail.IdPrazo);
-        if (prazo == null)
-            return string.Empty;
-        var dataFinal = avaliacaoEmail.DataLiberacao.Value.AddDays(prazo.DuracaoAvaliacaoGestor);
-        return DateTime.Today >= dataFinal ? DateTime.Today.AddDays(prazo.CompensadorAvaliacaoGestor).ToString("dd/MM/yyyy") : dataFinal.ToString("dd/MM/yyyy");
+        var projetos = await BuscarProjetosAvaliacoesAsync(idGestor, idProjeto, null, idPeriodo, null);
+        return projetos.FirstOrDefault();
     }
 }

--- a/Services/AvaliacoesGestor/Common/IAvaliacoesGestorService.cs
+++ b/Services/AvaliacoesGestor/Common/IAvaliacoesGestorService.cs
@@ -1,76 +1,16 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Peers.Moderno.Models;
+using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace Services.AvaliacoesGestor.Common;
 
 public interface IAvaliacoesGestorService
 {
-    Task<AvaliacaoGestorPerformanceDto> CarregarDadosAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao);
-    Task<List<PerformanceModel>> CarregarListaPerformancesAsync(int idAssociado, int idProjeto, int idPeriodo);
-    Task<bool> SalvarAvaliacoesAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao, List<PerformanceGestorInputDto> avaliacoes, bool finalizarAvaliacao);
-    Task<bool> ValidarPreenchimentoAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao);
-    Task<bool> PodeEditarAsync(int idProjeto, int idAssociado, int idPeriodo, int idAvaliacao);
-}
-
-public class AvaliacaoGestorPerformanceDto
-{
-    public ProjetoDto Projeto { get; set; } = new();
-    public AssociadoDto Associado { get; set; } = new();
-    public PeriodoDto Periodo { get; set; } = new();
-    public AssociadoDto Gestor { get; set; } = new();
-    public string Cliente { get; set; } = string.Empty;
-    public string TempoPeers { get; set; } = string.Empty;
-    public string TempoCargo { get; set; } = string.Empty;
-    public string TempoRestante { get; set; } = string.Empty;
-    public List<PerformanceModel> Performances { get; set; } = new();
-}
-
-public class ProjetoDto
-{
-    public int IdProjeto { get; set; }
-    public string Nome { get; set; } = string.Empty;
-}
-
-public class AssociadoDto
-{
-    public int IdAssociado { get; set; }
-    public string Nome { get; set; } = string.Empty;
-    public string Cargo { get; set; } = string.Empty;
-}
-
-public class PeriodoDto
-{
-    public int IdPeriodo { get; set; }
-    public string Periodo { get; set; } = string.Empty;
-}
-
-public class PerformanceGestorInputDto
-{
-    public int IdPerformance { get; set; }
-    public int IdNotaNivel1AvaliacaoGestor { get; set; }
-    public string ComentariosAvaliacaoGestor { get; set; } = string.Empty;
-}
-
-public class PerformanceModel
-{
-    public int IdPerformance { get; set; }
-    public string Descricao { get; set; } = string.Empty;
-    public string Abaixo { get; set; } = string.Empty;
-    public string Esperado { get; set; } = string.Empty;
-    public string Acima { get; set; } = string.Empty;
-    public string Abrangencia { get; set; } = string.Empty;
-    public string SeparadorAbrangencia { get; set; } = string.Empty;
-    public string Input { get; set; } = string.Empty;
-    public string DisclaimerInput { get; set; } = string.Empty;
-    public string NotaAvaliado { get; set; } = string.Empty;
-    public string NotaCegas { get; set; } = string.Empty;
-    public string NotaGestor { get; set; } = string.Empty;
-    public string ObservacaoAvaliado { get; set; } = string.Empty;
-    public string ObservacaoCegas { get; set; } = string.Empty;
-    public string ObservacaoGestor { get; set; } = string.Empty;
-    public bool PodeEditar { get; set; } = false;
-    public bool InputAvaliacaoGestor { get; set; } = false;
-    public int NotaPadraoAvaliacaoGestor { get; set; } = 0;
+    Task<List<ProjetoModel>> BuscarProjetosAvaliacoesAsync(int idGestor, int? idProjeto = null, int? idStatus = null, int? idPeriodo = null, int? idCliente = null);
+    Task<List<ComboItem>> ObterProjetosComboAsync(int idGestor);
+    Task<List<ComboItem>> ObterClientesComboAsync();
+    Task<List<ComboItem>> ObterPeriodosComboAsync(int idEmpresa);
+    Task<List<ComboItem>> ObterStatusComboAsync();
+    Task<bool> FinalizarAvaliacaoAsync(int idAvaliacao, int usuarioId);
+    Task<ProjetoModel?> ObterProjetoDetalhadoAsync(int idProjeto, int idGestor, int? idPeriodo = null);
 }


### PR DESCRIPTION
Este PR implementa os passos 1 e 2 do plano de ação para refatoração do sistema de avaliação interna. Foram criados serviços e helpers na pasta Services/AvaliacoesGestor/Common, centralizando e desacoplando a lógica de negócio do code-behind. O objetivo é garantir reutilização, clareza e facilitar futuras expansões do fluxo de avaliação. Também foi incluída documentação detalhada em docs/avaliacoes-gestor-common.md, explicando a integração dos novos componentes e sugerindo melhorias.