### PR TITLE
Centralização e padronização de combos reutilizáveis + revisão do serviço de mensagens

### DIFF
--- a/Services/Common/ComboHelper.cs
+++ b/Services/Common/ComboHelper.cs
@@ -1,5 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
+using Peers.Moderno.Models;
+using Peers.Moderno.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace Peers.Moderno.Services.Common;
 
@@ -108,6 +111,55 @@ public static class ComboHelper
     public static string GetStatusText(int status)
     {
         return status == 1 ? "Ativo" : "Inativo";
+    }
+
+    // Métodos para combos dinâmicos de Projetos, Clientes, Períodos e Status
+    public static async Task<List<ComboItem>> GetProjetosComboAsync(ApplicationDbContext db, int? gestorId = null, int? clienteId = null, int? status = null, int? periodoId = null)
+    {
+        var query = db.Projetos.AsQueryable();
+        if (gestorId.HasValue)
+            query = query.Where(p => p.IdAssociadoGestor == gestorId.Value);
+        if (clienteId.HasValue)
+            query = query.Where(p => p.IdCliente == clienteId.Value);
+        if (status.HasValue)
+            query = query.Where(p => p.Status == status.Value);
+        if (periodoId.HasValue)
+            query = query.Where(p => p.AssociadosProjeto.Any(ap => ap.IdPeriodo == periodoId.Value));
+        var projetos = await query.OrderBy(p => p.Nome).ToListAsync();
+        var items = new List<ComboItem> { new ComboItem { Value = "", Text = "[Selecionar]" } };
+        items.AddRange(projetos.Select(p => new ComboItem { Value = p.Id.ToString(), Text = p.Nome }));
+        return items;
+    }
+
+    public static async Task<List<ComboItem>> GetClientesComboAsync(ApplicationDbContext db)
+    {
+        var clientes = await db.Clientes.OrderBy(c => c.Nome).ToListAsync();
+        var items = new List<ComboItem> { new ComboItem { Value = "", Text = "[Selecionar]" } };
+        items.AddRange(clientes.Select(c => new ComboItem { Value = c.IdCliente.ToString(), Text = c.Nome }));
+        return items;
+    }
+
+    public static async Task<List<ComboItem>> GetPeriodosComboAsync(ApplicationDbContext db, int? empresaId = null)
+    {
+        var query = db.PeriodosAvaliacoes.AsQueryable();
+        if (empresaId.HasValue)
+            query = query.Where(p => p.IdEmpresa == empresaId.Value);
+        var periodos = await query.OrderByDescending(p => p.IdPeriodo).ToListAsync();
+        var items = new List<ComboItem> { new ComboItem { Value = "", Text = "[Selecionar]" } };
+        items.AddRange(periodos.Select(p => new ComboItem { Value = p.IdPeriodo.ToString(), Text = p.Nome }));
+        return items;
+    }
+
+    public static async Task<List<ComboItem>> GetStatusComboAsync(ApplicationDbContext db)
+    {
+        // Supondo que status de projetos estejam em uma tabela ou enum
+        var statusList = new List<ComboItem>
+        {
+            new ComboItem { Value = "", Text = "[Selecionar]" },
+            new ComboItem { Value = "1", Text = "Ativo" },
+            new ComboItem { Value = "0", Text = "Inativo" }
+        };
+        return await Task.FromResult(statusList);
     }
 }
 


### PR DESCRIPTION
Este PR centraliza a lógica de geração de combos reutilizáveis (projetos, clientes, períodos, status) no ComboHelper, com métodos assíncronos e parametrizáveis, promovendo reuso em múltiplos fluxos Blazor. Também revisa o MessageBoxService para garantir aderência ao padrão de exibição de mensagens, centralizando a lógica e mantendo retrocompatibilidade. Inclui documentação detalhada em markdown na pasta docs, com explicação, integração e fluxo mermaid das páginas e serviços envolvidos.