### PR TITLE
Criação do serviço AvaliacaoMentorCompetencia e estrutura Common reutilizável

### DIFF
--- a/Services/AvaliacaoMentorCompetencia/AvaliacaoMentorCompetenciaService.cs
+++ b/Services/AvaliacaoMentorCompetencia/AvaliacaoMentorCompetenciaService.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Peers.Moderno.Data;
+using Peers.Moderno.Models;
+using Services.AvaliacaoMentorCompetencia.Common;
+using Microsoft.EntityFrameworkCore;
+
+namespace Services.AvaliacaoMentorCompetencia
+{
+    public class AvaliacaoMentorCompetenciaService : IAvaliacaoMentorCompetenciaService
+    {
+        private readonly ApplicationDbContext _db;
+        private readonly AvaliacaoMentorCompetenciaHelper _helper;
+
+        public AvaliacaoMentorCompetenciaService(ApplicationDbContext db, AvaliacaoMentorCompetenciaHelper helper)
+        {
+            _db = db;
+            _helper = helper;
+        }
+
+        public async Task<AvaliacaoMentorCompetenciaDto> ObterAvaliacaoMentorCompetenciaAsync(int idAssociado, int idProjeto, int idPeriodo, string tipoAvaliacao, string escopo, int idGestor)
+        {
+            var associado = await _db.Associados.Include(a => a.Cargo).FirstOrDefaultAsync(a => a.Id == idAssociado);
+            var periodo = await _db.PeriodosAvaliacoes.FirstOrDefaultAsync(p => p.IdPeriodo == idPeriodo);
+            var projeto = await _db.Projetos.Include(p => p.Cliente).FirstOrDefaultAsync(p => p.Id == idProjeto);
+            var gestor = await _db.Associados.FirstOrDefaultAsync(g => g.Id == idGestor);
+
+            var competencias = await _db.Competencias
+                .Where(c => c.IdCargo == associado.IdCargo && c.IdNivel == associado.IdNivel && c.TipoAvaliacao == tipoAvaliacao && c.Escopo == escopo)
+                .Include(c => c.Eixo)
+                .Include(c => c.SubCompetencia)
+                .Include(c => c.Dimensao)
+                .ToListAsync();
+
+            var avaliacaoEmail = await _db.AvaliacoesEmail.FirstOrDefaultAsync(ae => ae.IdAssociado == idAssociado && ae.IdProjeto == idProjeto && ae.IdPeriodo == idPeriodo && ae.TipoAvaliacao == tipoAvaliacao && ae.Escopo == escopo && ae.IdGestor == idGestor);
+
+            var radar = await ObterRadarAsync(idAssociado, idProjeto, idPeriodo, associado.IdCargo);
+
+            return new AvaliacaoMentorCompetenciaDto
+            {
+                Associado = associado,
+                Periodo = periodo,
+                Projeto = projeto,
+                Gestor = gestor,
+                Competencias = competencias,
+                AvaliacaoEmail = avaliacaoEmail,
+                RadarJson = radar
+            };
+        }
+
+        public async Task<string> ObterRadarAsync(int idAssociado, int idProjeto, int idPeriodo, int idCargo)
+        {
+            var radarData = await _db.PremissasRadar
+                .Where(r => r.IdCargo == idCargo)
+                .Include(r => r.Eixo)
+                .ToListAsync();
+
+            var labels = new List<string>();
+            var datasetAvaliado = new List<decimal>();
+            var datasetGestor = new List<decimal>();
+            var datasetAtual = new List<decimal>();
+            var datasetProximoNivel = new List<decimal>();
+
+            foreach (var item in radarData)
+            {
+                labels.Add(item.Eixo.Nome);
+                datasetGestor.Add(item.PercentualGestor);
+                datasetAvaliado.Add(item.PercentualAvaliado);
+                datasetAtual.Add(100);
+                datasetProximoNivel.Add(200);
+            }
+
+            var radarObj = new
+            {
+                labels,
+                datasetavaliado = datasetAvaliado,
+                datasetgestor = datasetGestor,
+                datasetatual = datasetAtual,
+                datasetproximonivel = datasetProximoNivel
+            };
+
+            return System.Text.Json.JsonSerializer.Serialize(new[] { radarObj });
+        }
+
+        public async Task<bool> SalvarConsideracoesMentorAsync(ConsideracoesMentorInput input)
+        {
+            var consideracao = await _db.Set<ConsideracoesMentor>().FirstOrDefaultAsync(c => c.Id == input.Id);
+            if (consideracao == null)
+                return false;
+
+            consideracao.ElegivelPromocao = input.ElegivelPromocao;
+            consideracao.InputPromocao = input.InputPromocao;
+            consideracao.TrajetoriaAssociado = input.TrajetoriaAssociado;
+            consideracao.PontosFortes = input.PontosFortes;
+            consideracao.PontosFracos = input.PontosFracos;
+            consideracao.MentoriaRealizada = input.MentoriaRealizada;
+            consideracao.DataMentoriaRealizada = input.MentoriaRealizada ? DateTime.Today : (DateTime?)null;
+
+            await _db.SaveChangesAsync();
+            return true;
+        }
+
+        public string FormatPercentagem(decimal nota)
+        {
+            return _helper.FormatPercentagem(nota);
+        }
+
+        public string FormatDecimal(decimal nota)
+        {
+            return _helper.FormatDecimal(nota);
+        }
+
+        public string TruncarTexto(string texto, int qtdCaracteres)
+        {
+            return _helper.TruncarTexto(texto, qtdCaracteres);
+        }
+    }
+
+    public class AvaliacaoMentorCompetenciaDto
+    {
+        public Associado Associado { get; set; }
+        public PERIODOSAVALIACOES Periodo { get; set; }
+        public Projeto Projeto { get; set; }
+        public Associado Gestor { get; set; }
+        public List<Competencia> Competencias { get; set; }
+        public AvaliacaoEmail AvaliacaoEmail { get; set; }
+        public string RadarJson { get; set; }
+    }
+
+    public class ConsideracoesMentorInput
+    {
+        public int Id { get; set; }
+        public bool ElegivelPromocao { get; set; }
+        public bool InputPromocao { get; set; }
+        public string TrajetoriaAssociado { get; set; }
+        public string PontosFortes { get; set; }
+        public string PontosFracos { get; set; }
+        public bool MentoriaRealizada { get; set; }
+    }
+
+    public class ConsideracoesMentor
+    {
+        public int Id { get; set; }
+        public bool ElegivelPromocao { get; set; }
+        public bool InputPromocao { get; set; }
+        public string TrajetoriaAssociado { get; set; }
+        public string PontosFortes { get; set; }
+        public string PontosFracos { get; set; }
+        public bool MentoriaRealizada { get; set; }
+        public DateTime? DataMentoriaRealizada { get; set; }
+    }
+}

--- a/Services/AvaliacaoMentorCompetencia/Common/AvaliacaoMentorCompetenciaHelper.cs
+++ b/Services/AvaliacaoMentorCompetencia/Common/AvaliacaoMentorCompetenciaHelper.cs
@@ -1,0 +1,31 @@
+namespace Services.AvaliacaoMentorCompetencia.Common
+{
+    public class AvaliacaoMentorCompetenciaHelper
+    {
+        public string FormatPercentagem(decimal nota)
+        {
+            if (nota > 0)
+            {
+                return nota.ToString("##0") + "%";
+            }
+            return "0%";
+        }
+
+        public string FormatDecimal(decimal nota)
+        {
+            return System.Math.Round(nota, 2).ToString();
+        }
+
+        public string TruncarTexto(string texto, int qtdCaracteres)
+        {
+            if (!string.IsNullOrEmpty(texto))
+            {
+                if (texto.Length > qtdCaracteres)
+                {
+                    return string.Format("{0}...", texto.Substring(0, qtdCaracteres));
+                }
+            }
+            return texto;
+        }
+    }
+}

--- a/Services/AvaliacaoMentorCompetencia/Common/IAvaliacaoMentorCompetenciaService.cs
+++ b/Services/AvaliacaoMentorCompetencia/Common/IAvaliacaoMentorCompetenciaService.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using Services.AvaliacaoMentorCompetencia;
+
+namespace Services.AvaliacaoMentorCompetencia.Common
+{
+    public interface IAvaliacaoMentorCompetenciaService
+    {
+        Task<AvaliacaoMentorCompetenciaService.AvaliacaoMentorCompetenciaDto> ObterAvaliacaoMentorCompetenciaAsync(int idAssociado, int idProjeto, int idPeriodo, string tipoAvaliacao, string escopo, int idGestor);
+        Task<string> ObterRadarAsync(int idAssociado, int idProjeto, int idPeriodo, int idCargo);
+        Task<bool> SalvarConsideracoesMentorAsync(AvaliacaoMentorCompetenciaService.ConsideracoesMentorInput input);
+        string FormatPercentagem(decimal nota);
+        string FormatDecimal(decimal nota);
+        string TruncarTexto(string texto, int qtdCaracteres);
+    }
+}


### PR DESCRIPTION
Este PR implementa o serviço AvaliacaoMentorCompetenciaService, sua interface IAvaliacaoMentorCompetenciaService e o helper AvaliacaoMentorCompetenciaHelper, todos organizados conforme padrão de reutilização em Common. O serviço centraliza a lógica de negócio da avaliação de competência do mentor, incluindo métodos para obtenção de dados, radar, considerações e formatações. A interface permite injeção e testes, e o helper facilita a reutilização de funções utilitárias. Também foi criada a documentação em markdown explicando o funcionamento, integração e fluxo do processo, além de sugestões de melhorias.