### PR TITLE
Implementação dos serviços de resultado e helper reutilizável para avaliação interna

### DIFF
--- a/Services/Resultados/Common/ResultadoHelper.cs
+++ b/Services/Resultados/Common/ResultadoHelper.cs
@@ -1,0 +1,40 @@
+namespace Services.Resultados.Common;
+
+public class ResultadoHelper
+{
+    public string FormatPercentagem(object nota)
+    {
+        if (nota != null)
+        {
+            if (decimal.TryParse(nota.ToString(), out var notaFormatted))
+            {
+                return notaFormatted.ToString("##0") + "%";
+            }
+        }
+        return "0%";
+    }
+
+    public string FormatDecimal(object nota)
+    {
+        if (nota != null)
+        {
+            if (decimal.TryParse(nota.ToString(), out var notaFormatted))
+            {
+                return Math.Round(notaFormatted, 2).ToString();
+            }
+        }
+        return "0";
+    }
+
+    public string TruncarTexto(string texto, int qtdCaracteres)
+    {
+        if (!string.IsNullOrEmpty(texto))
+        {
+            if (texto.Length > qtdCaracteres)
+            {
+                return string.Format("{0}...", texto.Substring(0, qtdCaracteres));
+            }
+        }
+        return texto;
+    }
+}

--- a/Services/Resultados/IResultadoService.cs
+++ b/Services/Resultados/IResultadoService.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Peers.Moderno.Models;
+
+namespace Services.Resultados;
+
+public interface IResultadoService
+{
+    Task<List<ResultadoProjetosModel>> ObterResultadoAssociadoAsync(int idAssociado, int idPeriodo, int idCargo, string tipoAvaliacao, string escopo);
+    Task<List<ResultadoSomaProjetosModel>> ObterSomaProjetosAsync(List<ResultadoProjetosModel> resultadosProjetos);
+    string FormatPercentagem(object nota);
+    string FormatDecimal(object nota);
+    string TruncarTexto(string texto, int qtdCaracteres);
+}

--- a/Services/Resultados/ResultadoService.cs
+++ b/Services/Resultados/ResultadoService.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Peers.Moderno.Models;
+using Peers.Moderno.Data;
+using Services.Resultados.Common;
+using Microsoft.EntityFrameworkCore;
+
+namespace Services.Resultados;
+
+public class ResultadoService : IResultadoService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly ResultadoHelper _helper;
+
+    public ResultadoService(ApplicationDbContext db, ResultadoHelper helper)
+    {
+        _db = db;
+        _helper = helper;
+    }
+
+    public async Task<List<ResultadoProjetosModel>> ObterResultadoAssociadoAsync(int idAssociado, int idPeriodo, int idCargo, string tipoAvaliacao, string escopo)
+    {
+        var projetos = await _db.ResultadoProjetos
+            .Where(x => x.IdAssociado == idAssociado && x.IdPeriodo == idPeriodo && x.TipoAvaliacao == tipoAvaliacao && x.Escopo == escopo)
+            .ToListAsync();
+        return projetos;
+    }
+
+    public async Task<List<ResultadoSomaProjetosModel>> ObterSomaProjetosAsync(List<ResultadoProjetosModel> resultadosProjetos)
+    {
+        var ids = resultadosProjetos.Select(r => r.Id).ToList();
+        var somaProjetos = await _db.ResultadoSomaProjetos
+            .Where(x => ids.Contains(x.Id))
+            .ToListAsync();
+        return somaProjetos;
+    }
+
+    public string FormatPercentagem(object nota)
+    {
+        return _helper.FormatPercentagem(nota);
+    }
+
+    public string FormatDecimal(object nota)
+    {
+        return _helper.FormatDecimal(nota);
+    }
+
+    public string TruncarTexto(string texto, int qtdCaracteres)
+    {
+        return _helper.TruncarTexto(texto, qtdCaracteres);
+    }
+}

--- a/docs/avalizacao_resultado.md
+++ b/docs/avalizacao_resultado.md
@@ -1,0 +1,41 @@
+# Documentação Técnica: Resultado de Avaliação
+
+## Visão Geral
+
+Esta documentação descreve a arquitetura, funcionamento e integração dos serviços criados para a página de Resultado de Avaliação migrada do Web Forms para Blazor Híbrido. Os serviços e helpers foram centralizados na pasta `Services/Resultados` e `Services/Resultados/Common`, seguindo as premissas de reutilização e desacoplamento.
+
+## Estrutura de Serviços
+
+- **IResultadoService**: Interface que define os métodos de obtenção dos resultados de avaliação, soma de projetos e utilitários de formatação.
+- **ResultadoService**: Implementação da interface, responsável por buscar dados do banco via Entity Framework Core e aplicar lógica de negócio.
+- **ResultadoHelper**: Helper centralizado para formatação de percentuais, decimais e truncamento de texto, utilizado pelo serviço principal.
+
+## Integração
+
+- Os serviços são registrados no container de DI em `Program.cs`.
+- O componente Blazor responsável pela página de resultado injeta `IResultadoService` e utiliza seus métodos para obter dados e formatar informações para exibição.
+- O helper é injetado no serviço principal, promovendo reutilização.
+- O acesso ao banco é feito via `ApplicationDbContext`, mantendo compatibilidade com o legado.
+
+## Fluxo do Processo
+
+mermaid
+flowchart TD
+    A[Usuário acessa página Resultado de Avaliação] --> B[Componente Blazor AvalizacaoResultado]
+    B --> C[Injeta IResultadoService]
+    C --> D[ObterResultadoAssociadoAsync]
+    D --> E[Busca resultados no ApplicationDbContext]
+    B --> F[ObterSomaProjetosAsync]
+    F --> G[Busca soma dos projetos]
+    B --> H[Utiliza métodos FormatPercentagem, FormatDecimal, TruncarTexto]
+    H --> I[Exibe dados formatados na UI]
+
+
+## Sugestões de Melhorias
+
+- Implementar cache de resultados para reduzir queries repetidas.
+- Adicionar testes automatizados para garantir integridade dos métodos de negócio e helpers.
+- Evoluir o helper para suportar internacionalização e formatos regionais.
+- Expandir o serviço para permitir filtros dinâmicos e paginação dos resultados.
+- Integrar logs de telemetria para rastrear uso e performance dos métodos.
+- Modularizar componentes Blazor para facilitar manutenção e reuso em outras páginas.


### PR DESCRIPTION
Este PR contempla a criação dos serviços responsáveis pela obtenção e processamento dos resultados de avaliação interna, centralizados na pasta Services/Resultados. Inclui a interface IResultadoService, sua implementação ResultadoService, e o helper reutilizável ResultadoHelper em Services/Resultados/Common. Também foi adicionada documentação técnica detalhada em docs/avalizacao_resultado.md, conforme premissas do projeto. Todas as mudanças seguem o padrão de centralização, desacoplamento e potencial reutilização para futuras expansões.