### PR TITLE
Criação do helper ResultadoHelper para centralizar funções reutilizáveis relacionadas a cálculos e manipulação de dados de avaliação.

### DIFF
--- a/Services/Resultados/Common/ResultadoHelper.cs
+++ b/Services/Resultados/Common/ResultadoHelper.cs
@@ -1,40 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Peers.Moderno.Models;
+
 namespace Services.Resultados.Common;
 
-public class ResultadoHelper
+public static class ResultadoHelper
 {
-    public string FormatPercentagem(object nota)
+    public static decimal CalcularMediaPercentual(IEnumerable<decimal?> valores)
     {
-        if (nota != null)
+        var lista = valores.Where(v => v.HasValue).Select(v => v.Value).ToList();
+        if (!lista.Any()) return 0;
+        return Math.Round(lista.Average(), 2);
+    }
+
+    public static decimal CalcularSoma(IEnumerable<decimal?> valores)
+    {
+        return valores.Where(v => v.HasValue).Sum(v => v.Value);
+    }
+
+    public static string ObterRatingPerformance(decimal? valor)
+    {
+        if (!valor.HasValue) return "-";
+        if (valor >= 90) return "Excelente";
+        if (valor >= 75) return "Muito Bom";
+        if (valor >= 60) return "Bom";
+        if (valor >= 40) return "Regular";
+        return "Insuficiente";
+    }
+
+    public static IEnumerable<ResultadoProjetosModel> FiltrarProjetosPorAssociadoPeriodo(IEnumerable<ResultadoProjetosModel> projetos, int idAssociado, int idPeriodo)
+    {
+        return projetos.Where(p => p.IdAssociado == idAssociado && p.IdPeriodo == idPeriodo);
+    }
+
+    public static IEnumerable<ResultadoProjetosModel> OrdenarProjetosPorData(IEnumerable<ResultadoProjetosModel> projetos)
+    {
+        return projetos.OrderBy(p => p.DataInicioAlocado);
+    }
+
+    public static string TruncarTexto(string texto, int qtdCaracteres)
+    {
+        if (!string.IsNullOrEmpty(texto) && texto.Length > qtdCaracteres)
         {
-            if (decimal.TryParse(nota.ToString(), out var notaFormatted))
-            {
-                return notaFormatted.ToString("##0") + "%";
-            }
+            return string.Format("{0}...", texto.Substring(0, qtdCaracteres));
+        }
+        return texto;
+    }
+
+    public static List<string> ObterEixosDasCompetencias(IEnumerable<Competencia> competencias)
+    {
+        return competencias.Select(c => c.Eixo?.Nome ?? "").Distinct().Where(x => !string.IsNullOrEmpty(x)).ToList();
+    }
+
+    public static decimal? ObterNotaCompetenciaPorEixo(IEnumerable<ResultadoProjetosModel> projetos, string eixo)
+    {
+        var notas = projetos.SelectMany(p => p.ListCompetenciasNivel1)
+            .Where(c => c.Eixo == eixo)
+            .Select(c => c.PercentualNotaFinalNivel1)
+            .Where(v => v.HasValue)
+            .Select(v => v.Value);
+        if (!notas.Any()) return null;
+        return Math.Round(notas.Average(), 2);
+    }
+
+    public static decimal? ObterNotaPerformancePorProjeto(ResultadoProjetosModel projeto)
+    {
+        return projeto.SomaPerfomance;
+    }
+
+    public static string FormatPercentagem(decimal? nota)
+    {
+        if (nota.HasValue)
+        {
+            return nota.Value.ToString("##0") + "%";
         }
         return "0%";
     }
 
-    public string FormatDecimal(object nota)
+    public static string FormatDecimal(decimal? nota)
     {
-        if (nota != null)
+        if (nota.HasValue)
         {
-            if (decimal.TryParse(nota.ToString(), out var notaFormatted))
-            {
-                return Math.Round(notaFormatted, 2).ToString();
-            }
+            return Math.Round(nota.Value, 2).ToString();
         }
         return "0";
-    }
-
-    public string TruncarTexto(string texto, int qtdCaracteres)
-    {
-        if (!string.IsNullOrEmpty(texto))
-        {
-            if (texto.Length > qtdCaracteres)
-            {
-                return string.Format("{0}...", texto.Substring(0, qtdCaracteres));
-            }
-        }
-        return texto;
     }
 }


### PR DESCRIPTION
Implementado um helper estático em Services/Resultados/Common/ResultadoHelper.cs que oferece métodos para cálculo de médias, somas, formatação, filtragem e ordenação de dados de avaliação. Este helper segue a arquitetura de centralização de serviços reutilizáveis, facilitando a manutenção e evitando duplicação de código em múltiplos componentes.