### PR TITLE
Componente ComboHelper.razor para dropdowns reutilizáveis.

### DIFF
--- a/Pages/Components/ComboHelper.razor
+++ b/Pages/Components/ComboHelper.razor
@@ -1,0 +1,34 @@
+@using Services.Common
+@typeparam TItem
+@inject ComboHelper ComboHelperService
+
+<select @bind="SelectedValue" class="form-control" @onchange="OnChanged">
+    @if (ShowDefaultOption)
+    {
+        <option value="">[Selecionar]</option>
+    }
+    @foreach (var item in Items)
+    {
+        <option value="@item.Value" disabled="@(item.IsDisabled ? "disabled" : null)" selected="@(item.IsSelected ? "selected" : null)">@item.Text</option>
+    }
+</select>
+
+@code {
+    [Parameter]
+    public List<ComboItem> Items { get; set; } = new();
+
+    [Parameter]
+    public string? SelectedValue { get; set; }
+
+    [Parameter]
+    public EventCallback<string?> SelectedValueChanged { get; set; }
+
+    [Parameter]
+    public bool ShowDefaultOption { get; set; } = true;
+
+    private async Task OnChanged(ChangeEventArgs e)
+    {
+        SelectedValue = e.Value?.ToString();
+        await SelectedValueChanged.InvokeAsync(SelectedValue);
+    }
+}


### PR DESCRIPTION
Componente Blazor que implementa um dropdown genérico reutilizável, consumindo o serviço ComboHelper centralizado em Services/Common para padronização e reutilização.