### PR TITLE
Subcomponente RetrocederAvaliacaoPanel.razor criado para exibir o painel/modal de retroceder avaliações, com opções de seleção e botões de ação.

### DIFF
--- a/Components/Avaliacoes/RetrocederAvaliacaoPanel.razor
+++ b/Components/Avaliacoes/RetrocederAvaliacaoPanel.razor
@@ -1,0 +1,74 @@
+@using Services.Common
+
+@if (Loading)
+{
+    <div class="text-center my-5">
+        <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">Carregando...</span>
+        </div>
+    </div>
+}
+else if (AvaliacaoSelecionada != null)
+{
+    <div class="modal show d-block" tabindex="-1" style="background:rgba(0,0,0,0.2)">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Retroceder Avaliação</h5>
+                    <button type="button" class="btn-close" aria-label="Fechar" @onclick="OnCancelarClicked"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <strong>Projeto:</strong> @AvaliacaoSelecionada.Projeto?.Projeto<br />
+                        <strong>Associado:</strong> @AvaliacaoSelecionada.Associado?.Nome<br />
+                        <strong>Período:</strong> @AvaliacaoSelecionada.Periodo?.Periodo<br />
+                        <strong>Fase Atual:</strong> @AvaliacaoSelecionada.Fase
+                    </div>
+                    <div class="mb-3">
+                        <h6>Selecione as avaliações que deseja retroceder</h6>
+                        <div class="content-checkboxes d-flex gap-3">
+                            @if (OpcoesRetrocesso.PodeRetrocederAutoAvaliacao)
+                            {
+                                <div>
+                                    <input type="checkbox" id="ckbAutoAvaliacao" @bind="OpcoesRetrocesso.IncluirAutoAvaliacao" />
+                                    <label for="ckbAutoAvaliacao">Auto Avaliação</label>
+                                </div>
+                            }
+                            @if (OpcoesRetrocesso.PodeRetrocederAsCegas)
+                            {
+                                <div>
+                                    <input type="checkbox" id="ckbAsCegas" @bind="OpcoesRetrocesso.IncluirAsCegas" />
+                                    <label for="ckbAsCegas">Avaliação às cegas</label>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-secondary" @onclick="OnCancelarClicked">Cancelar</button>
+                    <button class="btn btn-info" @onclick="OnEfetuarRetrocessoClicked" disabled="@Loading">Efetuar Retrocesso</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public AvaliacaoEmailModel? AvaliacaoSelecionada { get; set; }
+    [Parameter] public RetrocederAvaliacaoOpcoesModel OpcoesRetrocesso { get; set; } = new();
+    [Parameter] public EventCallback<RetrocederAvaliacaoOpcoesModel> OnEfetuarRetrocesso { get; set; }
+    [Parameter] public EventCallback OnCancelar { get; set; }
+    [Parameter] public bool Loading { get; set; }
+
+    private async Task OnEfetuarRetrocessoClicked()
+    {
+        if (OnEfetuarRetrocesso.HasDelegate)
+            await OnEfetuarRetrocesso.InvokeAsync(OpcoesRetrocesso);
+    }
+
+    private async Task OnCancelarClicked()
+    {
+        if (OnCancelar.HasDelegate)
+            await OnCancelar.InvokeAsync();
+    }
+}


### PR DESCRIPTION
Este componente apresenta um modal que exibe detalhes da avaliação selecionada e permite selecionar quais avaliações retroceder (autoavaliação e avaliação às cegas). Inclui botões para cancelar ou efetuar o retrocesso, com tratamento visual para carregamento. Modulariza a UI e facilita a manutenção e reutilização.