### PR TITLE
Criação do serviço WorkflowService com interface IWorkflowService para operações CRUD de workflow, utilizando ApplicationDbContext e mantendo regras de negócio.

### DIFF
--- a/Services/Workflow/IWorkflowService.cs
+++ b/Services/Workflow/IWorkflowService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Peers.Moderno.Models;
+
+namespace Services.Workflow;
+
+public interface IWorkflowService
+{
+    Task<List<WORKFLOW>> ObterListaAsync();
+    Task<WORKFLOW?> ObterByPeriodoAsync(int idPeriodo);
+    Task<WORKFLOW?> ObterAsync(int idWorkflow);
+    Task<bool> InserirAsync(WORKFLOW workflow);
+    Task<bool> AlterarAsync(int idWorkflow, WORKFLOW workflow);
+    Task<bool> DeletarAsync(int idWorkflow);
+}

--- a/Services/Workflow/WorkflowService.cs
+++ b/Services/Workflow/WorkflowService.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Peers.Moderno.Data;
+using Peers.Moderno.Models;
+
+namespace Services.Workflow;
+
+public class WorkflowService : IWorkflowService
+{
+    private readonly ApplicationDbContext _db;
+
+    public WorkflowService(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<List<WORKFLOW>> ObterListaAsync()
+    {
+        return await _db.Set<WORKFLOW>()
+            .Include(w => w.PERIODOSAVALIACOES)
+            .OrderByDescending(w => w.IdWorkflow)
+            .ToListAsync();
+    }
+
+    public async Task<WORKFLOW?> ObterByPeriodoAsync(int idPeriodo)
+    {
+        return await _db.Set<WORKFLOW>()
+            .FirstOrDefaultAsync(w => w.IdPeriodo == idPeriodo);
+    }
+
+    public async Task<WORKFLOW?> ObterAsync(int idWorkflow)
+    {
+        return await _db.Set<WORKFLOW>()
+            .FirstOrDefaultAsync(w => w.IdWorkflow == idWorkflow);
+    }
+
+    public async Task<bool> InserirAsync(WORKFLOW workflow)
+    {
+        _db.Set<WORKFLOW>().Add(workflow);
+        return await _db.SaveChangesAsync() > 0;
+    }
+
+    public async Task<bool> AlterarAsync(int idWorkflow, WORKFLOW workflow)
+    {
+        var entity = await _db.Set<WORKFLOW>().FirstOrDefaultAsync(w => w.IdWorkflow == idWorkflow);
+        if (entity == null)
+            return false;
+        entity.DataInicio = workflow.DataInicio;
+        entity.DiasAutoAvaliacao = workflow.DiasAutoAvaliacao;
+        entity.DiasAvaliacaoCegas = workflow.DiasAvaliacaoCegas;
+        entity.DiasAvaliacaoGestor = workflow.DiasAvaliacaoGestor;
+        entity.DiasFeedback = workflow.DiasFeedback;
+        entity.DiasAlertaSemAlteracao = workflow.DiasAlertaSemAlteracao;
+        entity.IdPeriodo = workflow.IdPeriodo;
+        return await _db.SaveChangesAsync() > 0;
+    }
+
+    public async Task<bool> DeletarAsync(int idWorkflow)
+    {
+        var entity = await _db.Set<WORKFLOW>().FirstOrDefaultAsync(w => w.IdWorkflow == idWorkflow);
+        if (entity == null)
+            return false;
+        _db.Set<WORKFLOW>().Remove(entity);
+        return await _db.SaveChangesAsync() > 0;
+    }
+}


### PR DESCRIPTION
Este PR adiciona a interface IWorkflowService e sua implementação WorkflowService, que encapsulam toda a lógica de acesso e manipulação dos dados de workflow. O serviço é assíncrono, reutilizável e desacoplado da camada de apresentação, facilitando manutenção e testes. A implementação mantém as funcionalidades atuais, incluindo carregamento de relacionamentos e ordenação, além de seguir o padrão de injeção de dependência.