### PR TITLE
Criação do serviço WorkflowComboHelper com interface IWorkflowComboHelper para carregamento padronizado de combos de períodos.

### DIFF
--- a/Services/Workflow/IWorkflowComboHelper.cs
+++ b/Services/Workflow/IWorkflowComboHelper.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Services.Common;
+
+namespace Services.Workflow;
+
+public interface IWorkflowComboHelper
+{
+    Task<List<ComboItem>> GetPeriodosComboAsync(int empresaId);
+}

--- a/Services/Workflow/WorkflowComboHelper.cs
+++ b/Services/Workflow/WorkflowComboHelper.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Peers.Moderno.Data;
+using Services.Common;
+
+namespace Services.Workflow;
+
+public class WorkflowComboHelper : IWorkflowComboHelper
+{
+    private readonly ApplicationDbContext _db;
+
+    public WorkflowComboHelper(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<List<ComboItem>> GetPeriodosComboAsync(int empresaId)
+    {
+        var query = _db.PeriodosAvaliacoes.AsQueryable();
+        query = query.Where(p => p.IdEmpresa == empresaId);
+        var periodos = await query.OrderByDescending(p => p.IdPeriodo).ToListAsync();
+        var items = new List<ComboItem> { new ComboItem { Value = "", Text = "[Selecionar]" } };
+        items.AddRange(periodos.Select(p => new ComboItem { Value = p.IdPeriodo.ToString(), Text = p.Nome }));
+        return items;
+    }
+}


### PR DESCRIPTION
Este PR adiciona a interface IWorkflowComboHelper e sua implementação WorkflowComboHelper, que centralizam a lógica de carregamento dos combos de períodos para uso em múltiplas telas. O serviço utiliza ApplicationDbContext para consultar os períodos filtrados por empresa, ordenados e formatados em uma lista de ComboItem, que é um modelo reutilizável presente na pasta Services/Common. A abordagem promove desacoplamento, reutilização e padronização.