### PR TITLE
Padronização do namespace da implementação da classe EvolucaoAssociadoService e ajuste dos registros de DI no Program.cs para eliminar erro de ambiguidade e inexistência de tipo.

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -53,7 +53,6 @@ using Services.FeedbackPerformance.Common;
 using Services.AvaliacoesGestor;
 using Services.AvaliacoesGestor.Common;
 using Services.Avaliacoes;
-using Services.Avaliacoes.Common;
 using Services.AvaliacoesGestorasCegas;
 using Services.AvaliacaoMentorCompetencia;
 using Services.AvaliacaoMentorCompetencia.Common;
@@ -66,10 +65,6 @@ using Services.ResultadoLideranca.Common;
 using Services.Common;
 using Services.Comentarios;
 using Services.Comentarios.Common;
-using Services.Common;
-using Services.Avaliacoes;
-using Services.Avaliacoes.Common;
-using Services.Avaliacoes.EvolucaoAssociadoService;
 using Services.Common.EmailService;
 using Services.AvaliacoesExportacao;
 using Services.AvaliacoesExportacao.Common;
@@ -78,13 +73,10 @@ using Services.Periodos;
 using Services.Periodos.Common;
 using Services.Radar;
 using Services.Radar.Common;
-using Services.Common;
 using Services.Common.ChartHelper;
 using Services.Competencias;
 using Services.Competencias.Common;
 using Services.Workflow;
-using Peers.Moderno.Services.Avaliacoes.Common;
-using Services.Avaliacoes;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -204,12 +196,8 @@ builder.Services.AddScoped<IChartJsonUtil, ChartJsonUtil>();
 builder.Services.AddScoped<IPeriodoUtil, PeriodoUtil>();
 builder.Services.AddScoped<IDisparoMassivoRHService, DisparoMassivoRHService>();
 builder.Services.AddScoped<IEnvioAvaliacoesService, EnvioAvaliacoesService>();
-builder.Services.AddScoped<IEvolucaoAssociadoService, EvolucaoAssociadoService>();
 builder.Services.AddScoped<IEvolucaoAssociadoViewService, EvolucaoAssociadoViewService>();
 builder.Services.AddScoped<IEvolucaoAssociadoPerformanceService, EvolucaoAssociadoPerformanceService>();
-builder.Services.AddScoped<IEvolucaoAssociadoViewService, EvolucaoAssociadoViewService>();
-builder.Services.AddScoped<IEvolucaoAssociadoPerformanceService, EvolucaoAssociadoPerformanceService>();
-builder.Services.AddScoped<IEvolucaoAssociadoService, EvolucaoAssociadoService>();
 builder.Services.AddScoped<IExportarAvaliacoesService, ExportarAvaliacoesService>();
 builder.Services.AddScoped<IExportarAvaliacoesHelper, ExportarAvaliacoesHelper>();
 builder.Services.AddScoped<IExportarAvaliacoesExcelService, ExportarAvaliacoesExcelService>();
@@ -223,8 +211,8 @@ builder.Services.AddScoped<Services.Competencias.ICompetenciasService, Services.
 builder.Services.AddScoped<IWorkflowService, WorkflowService>();
 builder.Services.AddScoped<IWorkflowComboHelper, WorkflowComboHelper>();
 
-// Registro único e correto do serviço de EvoluçãoAssociadoService
-builder.Services.AddScoped<Peers.Moderno.Services.Avaliacoes.Common.IEvolucaoAssociadoService, Services.Avaliacoes.EvolucaoAssociadoService>();
+// Registro único e correto do serviço de EvolucaoAssociadoService
+builder.Services.AddScoped<IEvolucaoAssociadoService, EvolucaoAssociadoService>();
 
 var app = builder.Build();
 

--- a/Services/Avaliacoes/EvolucaoAssociadoService.cs
+++ b/Services/Avaliacoes/EvolucaoAssociadoService.cs
@@ -5,12 +5,12 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Peers.Moderno.Data;
 using Peers.Moderno.Models;
-using Services.Common;
+using Peers.Moderno.Services.Common;
 using Peers.Moderno.Services.Avaliacoes.Common;
 
-namespace Services.Avaliacoes;
+namespace Peers.Moderno.Services.Avaliacoes;
 
-public class EvolucaoAssociadoService : Peers.Moderno.Services.Avaliacoes.Common.IEvolucaoAssociadoService
+public class EvolucaoAssociadoService : IEvolucaoAssociadoService
 {
     private readonly ApplicationDbContext _db;
 
@@ -19,7 +19,6 @@ public class EvolucaoAssociadoService : Peers.Moderno.Services.Avaliacoes.Common
         _db = db;
     }
 
-    // Método auxiliar interno, renomeado para evitar conflito com interface
     private async Task<List<EvolucaoAssociadoDto>> ListAssociadosParaEvolucaoInternoAsync(int? idAssociado, int idPeriodo, int idVertical)
     {
         var query = _db.Associados


### PR DESCRIPTION
Foi corrigido o namespace da classe EvolucaoAssociadoService para 'Peers.Moderno.Services.Avaliacoes', alinhando-o com a interface IEvolucaoAssociadoService. No arquivo Program.cs foram removidos usings duplicados e conflitantes, além de manter apenas o registro correto do serviço de EvolucaoAssociadoService para IEvolucaoAssociadoService, eliminando o erro de tipo inexistente e ambiguidade.