### PR TITLE
Serviço para gerenciamento de fotos dos associados com operações CRUD básicas.

### DIFF
--- a/Services/FotosAssociadosService.cs
+++ b/Services/FotosAssociadosService.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Data;
+using Models;
+
+namespace Services
+{
+    public class FotosAssociadosService : IFotosAssociadosService
+    {
+        private readonly ApplicationDbContext _context;
+        public FotosAssociadosService(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<FOTOSASSOCIADOS?> ObterFotoPorAssociadoAsync(int idAssociado)
+        {
+            return await _context.FOTOSASSOCIADOS.FirstOrDefaultAsync(f => f.IdAssociado == idAssociado);
+        }
+
+        public async Task<bool> AdicionarFotoAsync(FOTOSASSOCIADOS foto)
+        {
+            _context.FOTOSASSOCIADOS.Add(foto);
+            return await _context.SaveChangesAsync() > 0;
+        }
+
+        public async Task<bool> AtualizarFotoAsync(FOTOSASSOCIADOS foto)
+        {
+            _context.FOTOSASSOCIADOS.Update(foto);
+            return await _context.SaveChangesAsync() > 0;
+        }
+    }
+}

--- a/Services/IFotosAssociadosService.cs
+++ b/Services/IFotosAssociadosService.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using Models;
+
+namespace Services
+{
+    public interface IFotosAssociadosService
+    {
+        Task<FOTOSASSOCIADOS?> ObterFotoPorAssociadoAsync(int idAssociado);
+        Task<bool> AdicionarFotoAsync(FOTOSASSOCIADOS foto);
+        Task<bool> AtualizarFotoAsync(FOTOSASSOCIADOS foto);
+    }
+}


### PR DESCRIPTION
Definição da interface IFotosAssociadosService e implementação FotosAssociadosService para obter, adicionar e atualizar fotos de associados, usando Entity Framework Core para persistência e garantindo abstração para facilitar testes e manutenção.