### PR TITLE
Criação do componente DataTableComponent genérico para exibição de tabelas de dados com ações.

### DIFF
--- a/Components/Shared/DataTableComponent.razor
+++ b/Components/Shared/DataTableComponent.razor
@@ -1,0 +1,57 @@
+@typeparam TItem
+@using Microsoft.AspNetCore.Components
+
+<div class="table-responsive">
+    <table class="table table-striped border">
+        <thead>
+            <tr>
+                @foreach (var col in Columns)
+                {
+                    <th>@col.Header</th>
+                }
+                @if (OnEdit.HasDelegate || OnDelete.HasDelegate)
+                {
+                    <th>Ações</th>
+                }
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var item in Items)
+            {
+                <tr>
+                    @foreach (var col in Columns)
+                    {
+                        <td>@col.CellTemplate(item)</td>
+                    }
+                    @if (OnEdit.HasDelegate || OnDelete.HasDelegate)
+                    {
+                        <td>
+                            @if (OnEdit.HasDelegate)
+                            {
+                                <button class="btn btn-info btn-sm mr-1" @onclick="() => OnEdit.InvokeAsync(item)">Alterar</button>
+                            }
+                            @if (OnDelete.HasDelegate)
+                            {
+                                <button class="btn btn-dark btn-sm" @onclick="() => OnDelete.InvokeAsync(item)">Inativar</button>
+                            }
+                        </td>
+                    }
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>
+
+@code {
+    [Parameter] public List<TItem> Items { get; set; }
+    [Parameter] public List<ColumnDefinition<TItem>> Columns { get; set; }
+    [Parameter] public EventCallback<TItem> OnEdit { get; set; }
+    [Parameter] public EventCallback<TItem> OnDelete { get; set; }
+
+    public class ColumnDefinition<T>
+    {
+        public string Header { get; set; }
+        public Func<T, object> ValueSelector { get; set; }
+        public RenderFragment<T> CellTemplate { get; set; }
+    }
+}


### PR DESCRIPTION
Implementado componente Blazor genérico que exibe listas de dados com colunas configuráveis e suporte a ações de editar e inativar, permitindo reutilização em diversas páginas com diferentes tipos de dados.